### PR TITLE
Add data ingestion module and tests

### DIFF
--- a/app/data/ingest.py
+++ b/app/data/ingest.py
@@ -1,0 +1,33 @@
+"""Main ingestion entrypoint."""
+
+from __future__ import annotations
+
+from typing import IO, Optional, Tuple
+
+import pandas as pd
+
+from .loader import load_demo, load_upload
+from .metadata import build_metadata, generate_dataset_id
+from .normalize import normalize_data
+from .validate import validate_canonical
+
+
+def ingest_dataset(
+    mode: str, uploaded_file: Optional[IO] = None
+) -> Tuple[pd.DataFrame, dict, dict]:
+    """Ingest a dataset and return canonical data, metadata, and issues."""
+    if mode not in {"demo", "upload"}:
+        raise ValueError("mode must be 'demo' or 'upload'.")
+
+    if mode == "demo":
+        raw = load_demo()
+        source = "demo"
+    else:
+        raw = load_upload(uploaded_file)
+        source = "upload"
+
+    dataset_id = generate_dataset_id()
+    canonical, _ = normalize_data(raw, source=source, dataset_id=dataset_id)
+    issues = validate_canonical(canonical)
+    meta = build_metadata(canonical, source=source, dataset_id=dataset_id)
+    return canonical, meta, issues

--- a/app/data/loader.py
+++ b/app/data/loader.py
@@ -1,0 +1,22 @@
+"""Load raw data for ingestion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import IO, Optional
+
+import pandas as pd
+
+DEMO_PATH = Path(__file__).resolve().parents[2] / "data" / "demo" / "demo_prices.csv"
+
+
+def load_demo() -> pd.DataFrame:
+    """Load demo data from the packaged CSV."""
+    return pd.read_csv(DEMO_PATH)
+
+
+def load_upload(uploaded_file: Optional[IO]) -> pd.DataFrame:
+    """Load uploaded CSV data."""
+    if uploaded_file is None:
+        raise ValueError("uploaded_file is required for upload mode.")
+    return pd.read_csv(uploaded_file)

--- a/app/data/metadata.py
+++ b/app/data/metadata.py
@@ -1,0 +1,34 @@
+"""Metadata helpers for ingestion."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Dict
+
+import pandas as pd
+
+
+def generate_dataset_id() -> str:
+    """Generate a unique dataset identifier."""
+    return uuid.uuid4().hex
+
+
+def build_metadata(df: pd.DataFrame, source: str, dataset_id: str) -> Dict[str, object]:
+    """Build metadata for a canonical dataset."""
+    volume_present = df["volume"].notna().any()
+    if volume_present:
+        liquidity_ceiling = "A"
+        volume_confirmation_enabled = True
+        extended_windows_allowed = True
+    else:
+        liquidity_ceiling = "B"
+        volume_confirmation_enabled = False
+        extended_windows_allowed = False
+
+    return {
+        "source": source,
+        "dataset_id": dataset_id,
+        "liquidity_ceiling": liquidity_ceiling,
+        "volume_confirmation_enabled": volume_confirmation_enabled,
+        "extended_windows_allowed": extended_windows_allowed,
+    }

--- a/app/data/normalize.py
+++ b/app/data/normalize.py
@@ -1,0 +1,84 @@
+"""Normalize raw input data into canonical format."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+
+from .schema import CANONICAL_COLUMNS, FORMAT_LONG, FORMAT_WIDE, LONG_REQUIRED_COLUMNS
+
+
+def detect_format(df: pd.DataFrame) -> str:
+    """Detect input format (long vs wide)."""
+    lower_columns = {col.lower() for col in df.columns}
+    if LONG_REQUIRED_COLUMNS.issubset(lower_columns):
+        return FORMAT_LONG
+    if "date" in lower_columns:
+        return FORMAT_WIDE
+    raise ValueError("Unable to detect input format.")
+
+
+def _normalize_long(df: pd.DataFrame, source: str, dataset_id: str) -> pd.DataFrame:
+    """Normalize long-format input into canonical schema."""
+    cols = {col.lower(): col for col in df.columns}
+    price_col = None
+    if "close" in cols:
+        price_col = cols["close"]
+    elif "adj_close" in cols:
+        price_col = cols["adj_close"]
+    else:
+        raise ValueError("Missing close or adj_close column.")
+
+    data = pd.DataFrame()
+    data["date"] = pd.to_datetime(df[cols["date"]], errors="coerce")
+    data["instrument"] = (
+        df[cols["instrument"]].astype(str).str.strip().str.upper()
+    )
+    data["close"] = pd.to_numeric(df[price_col], errors="coerce")
+
+    if "volume" in cols:
+        data["volume"] = pd.to_numeric(df[cols["volume"]], errors="coerce")
+    else:
+        data["volume"] = np.nan
+
+    for col_name in ("market", "currency"):
+        if col_name in cols:
+            data[col_name] = (
+                df[cols[col_name]].astype(str).str.strip().replace({"nan": None})
+            )
+        else:
+            data[col_name] = None
+
+    data["source"] = source
+    data["dataset_id"] = dataset_id
+    return data[CANONICAL_COLUMNS]
+
+
+def _normalize_wide(df: pd.DataFrame, source: str, dataset_id: str) -> pd.DataFrame:
+    """Normalize wide-format input into canonical schema."""
+    df = df.copy()
+    df.columns = [col.strip() for col in df.columns]
+    date_col = df.columns[0]
+    prices = df.melt(id_vars=[date_col], var_name="instrument", value_name="close")
+    data = pd.DataFrame()
+    data["date"] = pd.to_datetime(prices[date_col], errors="coerce")
+    data["instrument"] = prices["instrument"].astype(str).str.strip().str.upper()
+    data["close"] = pd.to_numeric(prices["close"], errors="coerce")
+    data["volume"] = np.nan
+    data["market"] = None
+    data["currency"] = None
+    data["source"] = source
+    data["dataset_id"] = dataset_id
+    return data[CANONICAL_COLUMNS]
+
+
+def normalize_data(
+    df: pd.DataFrame, source: str, dataset_id: str
+) -> Tuple[pd.DataFrame, str]:
+    """Normalize data and return canonical dataframe with detected format."""
+    fmt = detect_format(df)
+    if fmt == FORMAT_LONG:
+        return _normalize_long(df, source, dataset_id), fmt
+    return _normalize_wide(df, source, dataset_id), fmt

--- a/app/data/schema.py
+++ b/app/data/schema.py
@@ -1,0 +1,19 @@
+"""Schema definitions for ingestion."""
+
+CANONICAL_COLUMNS = [
+    "date",
+    "instrument",
+    "close",
+    "volume",
+    "market",
+    "currency",
+    "source",
+    "dataset_id",
+]
+
+LONG_REQUIRED_COLUMNS = {"date", "instrument"}
+LONG_PRICE_COLUMNS = {"close", "adj_close"}
+LONG_OPTIONAL_COLUMNS = {"volume", "market", "currency"}
+
+FORMAT_LONG = "long"
+FORMAT_WIDE = "wide"

--- a/app/data/uploader.py
+++ b/app/data/uploader.py
@@ -1,0 +1,12 @@
+"""Upload helpers for ingestion."""
+
+from __future__ import annotations
+
+from typing import IO
+
+import pandas as pd
+
+
+def read_upload(file_obj: IO) -> pd.DataFrame:
+    """Read a CSV file-like object into a DataFrame."""
+    return pd.read_csv(file_obj)

--- a/app/data/validate.py
+++ b/app/data/validate.py
@@ -1,0 +1,36 @@
+"""Validation for canonical datasets."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pandas as pd
+
+
+def validate_canonical(df: pd.DataFrame) -> Dict[str, List[str]]:
+    """Validate canonical dataset and return issues dict."""
+    issues: Dict[str, List[str]] = {"errors": [], "warnings": []}
+
+    if df["date"].isna().any():
+        issues["errors"].append("Unparseable dates detected.")
+    if df["close"].isna().any():
+        issues["errors"].append("Non-numeric close values detected.")
+
+    duplicates = df.duplicated(subset=["date", "instrument"]).any()
+    if duplicates:
+        issues["errors"].append("Duplicate (date, instrument) rows detected.")
+
+    trading_days = df["date"].dropna().dt.normalize().nunique()
+    if trading_days < 60:
+        issues["errors"].append("Fewer than 60 unique trading days.")
+
+    obs_counts = df.dropna(subset=["date"]).groupby("instrument")["date"].nunique()
+    sparse = obs_counts[obs_counts < 40].index.tolist()
+    if sparse:
+        issues["warnings"].append(
+            "Some instruments have fewer than 40 observations: "
+            + ", ".join(sorted(sparse))
+            + "."
+        )
+
+    return issues

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,73 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.data.metadata import build_metadata
+from app.data.normalize import detect_format, normalize_data
+from app.data.validate import validate_canonical
+
+
+def test_detect_format_long_vs_wide():
+    long_df = pd.DataFrame(
+        {"date": ["2024-01-01"], "instrument": ["ABC"], "close": [1.0]}
+    )
+    wide_df = pd.DataFrame({"date": ["2024-01-01"], "ABC": [1.0]})
+
+    assert detect_format(long_df) == "long"
+    assert detect_format(wide_df) == "wide"
+
+
+def test_min_trading_days_hard_fail():
+    dates = pd.date_range("2024-01-01", periods=10, freq="D")
+    df = pd.DataFrame(
+        {
+            "date": dates,
+            "instrument": ["AAA"] * len(dates),
+            "close": [1.0] * len(dates),
+            "volume": [np.nan] * len(dates),
+            "market": [None] * len(dates),
+            "currency": [None] * len(dates),
+            "source": ["demo"] * len(dates),
+            "dataset_id": ["test"] * len(dates),
+        }
+    )
+
+    issues = validate_canonical(df)
+    assert any("Fewer than 60" in err for err in issues["errors"])
+
+
+def test_volume_missing_sets_liquidity_ceiling_b():
+    df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-01"]),
+            "instrument": ["AAA"],
+            "close": [1.0],
+            "volume": [np.nan],
+            "market": [None],
+            "currency": [None],
+            "source": ["demo"],
+            "dataset_id": ["test"],
+        }
+    )
+
+    meta = build_metadata(df, source="demo", dataset_id="test")
+    assert meta["liquidity_ceiling"] == "B"
+
+
+def test_adj_close_accepted_when_close_missing():
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02"],
+            "instrument": ["AAA", "AAA"],
+            "adj_close": [1.0, 2.0],
+        }
+    )
+
+    normalized, fmt = normalize_data(df, source="demo", dataset_id="test")
+    assert fmt == "long"
+    assert normalized["close"].tolist() == [1.0, 2.0]


### PR DESCRIPTION
### Motivation

- Provide a small, self-contained data ingestion pipeline to read demo/upload CSVs and produce a canonical price dataset.  
- Support both LONG and WIDE CSV formats and enforce data quality/metadata gating for downstream processing.  

### Description

- Add `app/data/schema.py` with canonical column definitions and format constants.  
- Add `app/data/loader.py` and `app/data/uploader.py` to load demo CSV (`data/demo/demo_prices.csv`) and uploaded CSV file-like objects.  
- Implement normalization in `app/data/normalize.py` with `detect_format`, `_normalize_long`, `_normalize_wide`, and `normalize_data`, mapping `adj_close` -> `close` when `close` is absent and normalizing `instrument` to upper/trim.  
- Implement validation in `app/data/validate.py` enforcing parseable dates, numeric closes, duplicate `(date, instrument)` detection, minimum unique trading days (hard fail < 60), and per-instrument observation warnings (< 40).  
- Implement metadata rules in `app/data/metadata.py` to set `liquidity_ceiling` and volume-related feature flags based on presence of `volume`.  
- Add main entrypoint `app/data/ingest.py` exposing `ingest_dataset(mode: str, uploaded_file: Optional[IO]=None)` which returns `(df_canonical, meta, issues)`.  
- Add `tests/test_ingestion.py` with lightweight tests for format detection, minimum trading days validation, missing volume metadata behavior, and `adj_close` handling.  

### Testing

- Ran `pytest -q` and the test suite completed successfully with all tests passing.  
- The added tests verify `detect_format` long vs wide, `validate_canonical` min trading days error, `build_metadata` volume-missing behavior, and `normalize_data` handling of `adj_close` when `close` is missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697276019e9c8322b6c3ee48b3dd5b89)