### PR TITLE
Handle ranking metadata defaults for dates and volume flags

### DIFF
--- a/tests/test_ranking_engine.py
+++ b/tests/test_ranking_engine.py
@@ -129,3 +129,14 @@ def test_guardrail_shifts_to_10d_on_high_turnover():
 
     ranked = rank_instruments(df_summary, meta, "income_stability")
     assert ranked.iloc[0]["best_window"] == 10
+
+
+def test_rank_handles_missing_dates_and_volume_flag():
+    df_summary = _base_summary()
+    meta = {
+        "volume_confirmation_enabled": True,
+        "liquidity_ceiling": "A",
+    }
+
+    ranked = rank_instruments(df_summary, meta, "active_growth")
+    assert ranked["warnings"].apply(len).sum() == 0


### PR DESCRIPTION
### Motivation
- Prevent a `KeyError` when callers pass ingestion metadata that omits `start_date`/`end_date` by providing a safe default for dataset years. 
- Align ranking behavior with ingestion metadata by honoring `volume_confirmation_enabled` (with a fallback to the legacy `volume_available`) so `apply_liquidity_cap` is not incorrectly applied when volume data exists.

### Description
- Use `meta.get("start_date")`/`meta.get("end_date")` and default `years = 1.0` when dates are missing instead of indexing into `meta` directly. 
- Compute `volume_available` from `meta.get("volume_confirmation_enabled", meta.get("volume_available", False))` and pass that to `apply_liquidity_cap`. 
- Add `test_rank_handles_missing_dates_and_volume_flag` to `tests/test_ranking_engine.py` to validate ranking works when metadata lacks date range and provides the ingestion volume flag.

### Testing
- Added a unit test `test_rank_handles_missing_dates_and_volume_flag` covering missing date metadata and the ingestion volume flag. 
- No automated test run was performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b059f8c88322b039bcd21f868a51)