### PR TITLE
Handle missing ranking metadata and volume flags

### DIFF
--- a/app/ranking/engine.py
+++ b/app/ranking/engine.py
@@ -18,9 +18,12 @@ def rank_instruments(
     objective: str,
 ) -> pd.DataFrame:
     """Rank instruments based on objective and summary metrics."""
-    start_date = pd.to_datetime(meta["start_date"])
-    end_date = pd.to_datetime(meta["end_date"])
-    years = dataset_years(start_date, end_date)
+    start_date = meta.get("start_date")
+    end_date = meta.get("end_date")
+    if start_date and end_date:
+        years = dataset_years(pd.to_datetime(start_date), pd.to_datetime(end_date))
+    else:
+        years = 1.0
 
     weights = get_objective_weights(objective)
     emphasis = get_window_emphasis(objective)
@@ -45,9 +48,13 @@ def rank_instruments(
                     reasons.append("Guardrail: shifted to 10D due to high turnover.")
 
         tier = assign_tier(float(best["score_window"]))
+        if "volume_confirmation_enabled" in meta:
+            volume_available = bool(meta.get("volume_confirmation_enabled"))
+        else:
+            volume_available = bool(meta.get("volume_available", False))
         tier, warning = apply_liquidity_cap(
             tier,
-            bool(meta.get("volume_available", False)),
+            volume_available,
             str(meta.get("liquidity_ceiling", "B")),
         )
         warnings = [warning] if warning else []

--- a/tests/test_ranking_engine.py
+++ b/tests/test_ranking_engine.py
@@ -83,6 +83,17 @@ def test_objective_changes_weights_not_summary():
     assert not ranked_income["score_total"].equals(ranked_growth["score_total"])
 
 
+def test_metadata_without_dates_uses_volume_confirmation():
+    df_summary = _base_summary()
+    meta = {
+        "volume_confirmation_enabled": True,
+        "liquidity_ceiling": "A",
+    }
+
+    ranked = rank_instruments(df_summary, meta, "active_growth")
+    assert ranked["warnings"].apply(len).sum() == 0
+
+
 def test_guardrail_shifts_to_10d_on_high_turnover():
     df_summary = pd.DataFrame(
         [


### PR DESCRIPTION
### Motivation
- Prevent runtime `KeyError` when `rank_instruments` is called with ingestion metadata that omits `start_date`/`end_date` produced by `build_metadata`.
- Align ranking logic with ingestion metadata by honoring the `volume_confirmation_enabled` flag so liquidity capping reflects the real volume availability signal.

### Description
- Use `meta.get("start_date")`/`meta.get("end_date")` and fall back to a default `years = 1.0` when dates are absent to avoid crashing; this keeps `dataset_years` usage safe for ingestion metadata.
- Prefer `meta["volume_confirmation_enabled"]` when present and otherwise fall back to the legacy `volume_available` key before calling `apply_liquidity_cap` so volume detection matches `build_metadata` output.
- Add a regression test `test_metadata_without_dates_uses_volume_confirmation` to `tests/test_ranking_engine.py` to cover metadata that omits dates but supplies `volume_confirmation_enabled` and `liquidity_ceiling`.

### Testing
- No automated test suite was executed for this patch after the changes were made.
- Added a regression test (`tests/test_ranking_engine.py::test_metadata_without_dates_uses_volume_confirmation`) to validate the new metadata handling logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b0462d94832296b882fb6be7670d)