### PR TITLE
Handle missing metadata fields in ranking engine

### DIFF
--- a/app/ranking/engine.py
+++ b/app/ranking/engine.py
@@ -18,9 +18,12 @@ def rank_instruments(
     objective: str,
 ) -> pd.DataFrame:
     """Rank instruments based on objective and summary metrics."""
-    start_date = pd.to_datetime(meta["start_date"])
-    end_date = pd.to_datetime(meta["end_date"])
-    years = dataset_years(start_date, end_date)
+    start_date = meta.get("start_date")
+    end_date = meta.get("end_date")
+    if start_date and end_date:
+        years = dataset_years(pd.to_datetime(start_date), pd.to_datetime(end_date))
+    else:
+        years = float(meta.get("dataset_years", 1.0))
 
     weights = get_objective_weights(objective)
     emphasis = get_window_emphasis(objective)
@@ -45,9 +48,12 @@ def rank_instruments(
                     reasons.append("Guardrail: shifted to 10D due to high turnover.")
 
         tier = assign_tier(float(best["score_window"]))
+        volume_available = bool(
+            meta.get("volume_confirmation_enabled", meta.get("volume_available", False))
+        )
         tier, warning = apply_liquidity_cap(
             tier,
-            bool(meta.get("volume_available", False)),
+            volume_available,
             str(meta.get("liquidity_ceiling", "B")),
         )
         warnings = [warning] if warning else []

--- a/tests/test_ranking_engine.py
+++ b/tests/test_ranking_engine.py
@@ -6,6 +6,7 @@ import pandas as pd
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
+from app.data.metadata import build_metadata
 from app.ranking.engine import rank_instruments
 from app.ranking.objectives import get_objective_weights
 
@@ -129,3 +130,16 @@ def test_guardrail_shifts_to_10d_on_high_turnover():
 
     ranked = rank_instruments(df_summary, meta, "income_stability")
     assert ranked.iloc[0]["best_window"] == 10
+
+
+def test_rank_with_metadata_missing_dates():
+    df_summary = _base_summary()
+    meta = build_metadata(
+        pd.DataFrame({"volume": [1000, 1500]}),
+        source="demo",
+        dataset_id="test",
+    )
+
+    ranked = rank_instruments(df_summary, meta, "active_growth")
+    assert not ranked.empty
+    assert ranked["warnings"].apply(len).sum() == 0


### PR DESCRIPTION
### Motivation
- The ranking engine assumed `meta["start_date"]`/`meta["end_date"]` and `meta["volume_available"]` which can be absent when using the ingestion helper `build_metadata`, causing runtime errors or incorrect liquidity capping.
- Add safe fallbacks so ranking works with ingestion-produced metadata and avoids spurious tier downgrades when volume flags are represented differently.

### Description
- Use `meta.get("start_date")`/`meta.get("end_date")` and only compute years via `dataset_years` when both are present, otherwise fall back to `float(meta.get("dataset_years", 1.0))`.
- Respect ingestion metadata by checking `meta.get("volume_confirmation_enabled", meta.get("volume_available", False))` when calling `apply_liquidity_cap` so volume presence is detected correctly.
- Added `test_rank_with_metadata_missing_dates` to `tests/test_ranking_engine.py` which uses `build_metadata` to confirm ranking runs when start/end dates are omitted and that no spurious warnings are emitted.

### Testing
- Ran the test suite with `pytest -q` and all tests passed (`12 passed`).
- The new regression test `test_rank_with_metadata_missing_dates` passed and confirms behavior with ingestion-style metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ad8d58388322ad84e1f43c6d3a2c)