### PR TITLE
Add confidence-aware tie-breaking to earnings phase tagging

### DIFF
--- a/app/events/__init__.py
+++ b/app/events/__init__.py
@@ -1,0 +1,1 @@
+"""Event tagging utilities."""

--- a/app/events/earnings.py
+++ b/app/events/earnings.py
@@ -1,0 +1,142 @@
+"""Earnings event tagging."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+PHASE_PRE = "pre_earnings"
+PHASE_EVENT = "earnings"
+PHASE_POST = "post_earnings"
+
+PRE_WINDOW = (-30, -1)
+EVENT_WINDOW = (0, 3)
+POST_WINDOW = (4, 30)
+
+
+def tag_earnings_phase(
+    df: pd.DataFrame,
+    events_df: pd.DataFrame,
+    date_col: str,
+    inst_col: str,
+) -> pd.DataFrame:
+    """Tag rows with earnings phases using trading-day offsets."""
+    tagged = df.copy()
+    tagged[date_col] = pd.to_datetime(tagged[date_col])
+
+    events = events_df.copy()
+    if "earnings_date" not in events.columns:
+        raise KeyError("events_df must include an earnings_date column")
+    events["earnings_date"] = pd.to_datetime(events["earnings_date"])
+    if "confidence" not in events.columns:
+        events["confidence"] = "estimated"
+
+    phase_values: Dict[Tuple[str, pd.Timestamp], str] = {}
+    offset_values: Dict[Tuple[str, pd.Timestamp], int] = {}
+
+    for instrument, group in tagged.groupby(inst_col, sort=False):
+        dates = pd.Index(group[date_col].sort_values().unique())
+        if dates.empty:
+            continue
+
+        event_rows = events[events[inst_col] == instrument]
+        if event_rows.empty:
+            continue
+
+        event_indices = _event_indices(
+            dates,
+            event_rows["earnings_date"],
+            event_rows["confidence"],
+        )
+        if not event_indices:
+            continue
+
+        offsets = _closest_offsets(len(dates), event_indices)
+        phase_map = _phase_from_offsets(offsets)
+        for idx, date in enumerate(dates):
+            offset = offsets[idx]
+            phase = phase_map[idx]
+            if phase is None or offset is None:
+                continue
+            phase_values[(instrument, date)] = phase
+            offset_values[(instrument, date)] = int(offset)
+
+    tagged["earnings_phase"] = tagged.apply(
+        lambda row: phase_values.get((row[inst_col], row[date_col])), axis=1
+    )
+    tagged["earnings_day_offset"] = tagged.apply(
+        lambda row: offset_values.get((row[inst_col], row[date_col])), axis=1
+    )
+
+    return tagged
+
+
+def _event_indices(
+    dates: pd.Index,
+    event_dates: Iterable[pd.Timestamp],
+    confidences: Iterable[str],
+) -> list[tuple[int, int]]:
+    indices: list[tuple[int, int]] = []
+    for event_date, confidence in zip(
+        pd.to_datetime(list(event_dates)),
+        list(confidences),
+    ):
+        position = dates.get_indexer([event_date])[0]
+        if position >= 0:
+            indices.append((int(position), _confidence_score(str(confidence))))
+    return indices
+
+
+def _closest_offsets(length: int, event_indices: Iterable[tuple[int, int]]) -> np.ndarray:
+    index_values = np.arange(length)
+    best_offsets = np.full(length, np.nan)
+    best_abs = np.full(length, np.inf)
+    best_confidence = np.full(length, -1)
+
+    for event_index, confidence_score in event_indices:
+        offsets = index_values - event_index
+        within = (offsets >= PRE_WINDOW[0]) & (offsets <= POST_WINDOW[1])
+        abs_offsets = np.abs(offsets)
+        update = within & (
+            (abs_offsets < best_abs)
+            | ((abs_offsets == best_abs) & (confidence_score > best_confidence))
+            | (
+                (abs_offsets == best_abs)
+                & (confidence_score == best_confidence)
+                & (offsets < best_offsets)
+            )
+        )
+        best_abs[update] = abs_offsets[update]
+        best_confidence[update] = confidence_score
+        best_offsets[update] = offsets[update]
+
+    return best_offsets
+
+
+def _phase_from_offsets(offsets: np.ndarray) -> list[str | None]:
+    phases: list[str | None] = []
+    for offset in offsets:
+        if np.isnan(offset):
+            phases.append(None)
+            continue
+        offset_int = int(offset)
+        if PRE_WINDOW[0] <= offset_int <= PRE_WINDOW[1]:
+            phases.append(PHASE_PRE)
+        elif EVENT_WINDOW[0] <= offset_int <= EVENT_WINDOW[1]:
+            phases.append(PHASE_EVENT)
+        elif POST_WINDOW[0] <= offset_int <= POST_WINDOW[1]:
+            phases.append(PHASE_POST)
+        else:
+            phases.append(None)
+    return phases
+
+
+def _confidence_score(confidence: str) -> int:
+    if confidence.lower() == "confirmed":
+        return 2
+    if confidence.lower() == "estimated":
+        return 1
+    return 0

--- a/app/metrics/__init__.py
+++ b/app/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Metrics utilities."""

--- a/app/metrics/phase_metrics.py
+++ b/app/metrics/phase_metrics.py
@@ -1,0 +1,25 @@
+"""Earnings phase metrics."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def compute_phase_metrics(
+    df: pd.DataFrame,
+    group_cols: list[str],
+    return_col: str,
+) -> pd.DataFrame:
+    """Compute grouped phase metrics and flag insufficient history."""
+    grouped = df.groupby(group_cols)[return_col]
+    metrics = grouped.agg(
+        n="size",
+        win_rate=lambda x: (x > 0).mean(),
+        median_return="median",
+        p25=lambda x: x.quantile(0.25),
+        p75=lambda x: x.quantile(0.75),
+        vol="std",
+    )
+    metrics = metrics.reset_index()
+    metrics["insufficient_history"] = metrics["n"] < 12
+    return metrics

--- a/data/demo/earnings_events.csv
+++ b/data/demo/earnings_events.csv
@@ -1,0 +1,4 @@
+instrument,earnings_date,confidence,source
+AAA,2024-02-15,confirmed,manual_v1
+BBB,2024-02-20,estimated,manual_v1
+CCC,2024-02-28,confirmed,manual_v1

--- a/tests/test_earnings_tags.py
+++ b/tests/test_earnings_tags.py
@@ -1,0 +1,82 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.events.earnings import (
+    PHASE_EVENT,
+    PHASE_POST,
+    PHASE_PRE,
+    tag_earnings_phase,
+)
+
+
+def test_earnings_phase_tags_use_trading_days():
+    dates = pd.bdate_range("2024-01-02", periods=40)
+    df = pd.DataFrame({"instrument": "AAA", "date": dates, "return": 0.0})
+    event_date = dates[10]
+    events_df = pd.DataFrame(
+        {
+            "instrument": ["AAA"],
+            "earnings_date": [event_date],
+            "confidence": ["confirmed"],
+        }
+    )
+
+    tagged = tag_earnings_phase(df, events_df, "date", "instrument")
+
+    friday_before = dates[9]
+    friday_row = tagged[tagged["date"] == friday_before].iloc[0]
+    assert friday_row["earnings_day_offset"] == -1
+
+    event_row = tagged[tagged["date"] == event_date].iloc[0]
+    assert event_row["earnings_phase"] == PHASE_EVENT
+
+
+def test_earnings_phase_bounds():
+    dates = pd.bdate_range("2024-03-01", periods=70)
+    df = pd.DataFrame({"instrument": "BBB", "date": dates, "return": 0.0})
+    event_date = dates[30]
+    events_df = pd.DataFrame(
+        {
+            "instrument": ["BBB"],
+            "earnings_date": [event_date],
+            "confidence": ["estimated"],
+        }
+    )
+
+    tagged = tag_earnings_phase(df, events_df, "date", "instrument")
+
+    pre_day = dates[0]
+    pre_row = tagged[tagged["date"] == pre_day].iloc[0]
+    assert pre_row["earnings_phase"] == PHASE_PRE
+
+    post_day = dates[34]
+    post_row = tagged[tagged["date"] == post_day].iloc[0]
+    assert post_row["earnings_phase"] == PHASE_POST
+
+    outside_day = dates[65]
+    outside_row = tagged[tagged["date"] == outside_day].iloc[0]
+    assert pd.isna(outside_row["earnings_phase"])
+
+
+def test_earnings_phase_tie_breaks_on_confidence():
+    dates = pd.bdate_range("2024-04-01", periods=25)
+    df = pd.DataFrame({"instrument": "CCC", "date": dates, "return": 0.0})
+    event_estimated = dates[5]
+    event_confirmed = dates[9]
+    anchor_date = dates[7]
+    events_df = pd.DataFrame(
+        {
+            "instrument": ["CCC", "CCC"],
+            "earnings_date": [event_estimated, event_confirmed],
+            "confidence": ["estimated", "confirmed"],
+        }
+    )
+
+    tagged = tag_earnings_phase(df, events_df, "date", "instrument")
+    anchor_row = tagged[tagged["date"] == anchor_date].iloc[0]
+    assert anchor_row["earnings_day_offset"] == -2

--- a/tests/test_phase_metrics.py
+++ b/tests/test_phase_metrics.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.metrics.phase_metrics import compute_phase_metrics
+
+
+def test_phase_metrics_threshold_and_stats():
+    df = pd.DataFrame(
+        {
+            "instrument": ["AAA"] * 12 + ["BBB"] * 5,
+            "earnings_phase": ["earnings"] * 12 + ["post_earnings"] * 5,
+            "net_return": [0.02] * 6 + [-0.01] * 6 + [0.03] * 5,
+        }
+    )
+
+    metrics = compute_phase_metrics(
+        df, ["instrument", "earnings_phase"], "net_return"
+    )
+
+    aaa = metrics[metrics["instrument"] == "AAA"].iloc[0]
+    assert aaa["n"] == 12
+    assert bool(aaa["insufficient_history"]) is False
+    assert aaa["win_rate"] == 0.5
+    assert aaa["median_return"] == 0.005
+
+    bbb = metrics[metrics["instrument"] == "BBB"].iloc[0]
+    assert bbb["n"] == 5
+    assert bool(bbb["insufficient_history"]) is True


### PR DESCRIPTION
### Motivation
- Ensure deterministic selection of an earnings event when multiple events fall within the ±30 trading-day window by preferring the closest event and using confidence to break ties. 
- Provide a default confidence handling for legacy or missing data and keep the tagging anchored on the entry date (`date_col`) so phase context reflects decision-time risk.

### Description
- Update `tag_earnings_phase` to read a `confidence` column (defaults to `"estimated"` when missing) and propagate per-event confidence into matching logic in `app/events/earnings.py`.
- Change `_event_indices` to return `(position, confidence_score)` tuples and add `_confidence_score` to map textual confidence to numeric ranks (`confirmed` > `estimated`).
- Revise `_closest_offsets` to choose the nearest event by absolute trading-day distance, prefer higher-confidence events on ties, and use a deterministic tie-breaker when confidence is equal.
- Add a `confidence` column to `data/demo/earnings_events.csv` and extend `tests/test_earnings_tags.py` to validate confidence-aware tie-breaking while keeping `tests/test_phase_metrics.py` intact.

### Testing
- Ran `pytest -q` and the test suite passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bea511008322a39bc45315f30d65)