### PR TITLE
Fix earnings phase labels and defaults

### DIFF
--- a/tests/test_earnings_tags.py
+++ b/tests/test_earnings_tags.py
@@ -8,6 +8,7 @@ sys.path.append(str(ROOT))
 
 from app.events.earnings import (
     PHASE_EVENT,
+    PHASE_NON,
     PHASE_POST,
     PHASE_PRE,
     tag_earnings_phase,
@@ -60,7 +61,7 @@ def test_earnings_phase_bounds():
 
     outside_day = dates[65]
     outside_row = tagged[tagged["date"] == outside_day].iloc[0]
-    assert pd.isna(outside_row["earnings_phase"])
+    assert outside_row["earnings_phase"] == PHASE_NON
 
 
 def test_earnings_phase_snaps_weekend_to_next_trading_day():

--- a/tests/test_phase_metrics.py
+++ b/tests/test_phase_metrics.py
@@ -13,7 +13,7 @@ def test_phase_metrics_threshold_and_stats():
     df = pd.DataFrame(
         {
             "instrument": ["AAA"] * 12 + ["BBB"] * 5,
-            "earnings_phase": ["earnings"] * 12 + ["post_earnings"] * 5,
+            "earnings_phase": ["reaction"] * 12 + ["post"] * 5,
             "net_return": [0.02] * 6 + [-0.01] * 6 + [0.03] * 5,
         }
     )


### PR DESCRIPTION
### Motivation
- Tests were failing due to a missing `PHASE_NON` constant and inconsistent phase labels used across code and tests.
- Rows were ending up with null/None phases because NaN offsets were not consistently mapped to a default phase.
- The project expects phase labels exactly as `{"pre","reaction","post","non"}` so code and tests must align.

### Description
- Introduced `PHASE_NON = "non"` and renamed existing phase constants to `PHASE_PRE = "pre"`, `PHASE_EVENT = "reaction"`, and `PHASE_POST = "post"` in `app/events/earnings.py`.
- Updated `_phase_from_offsets` to return `PHASE_NON` for NaN or out-of-range offsets and changed the return type to `list[str]`.
- Ensured the main tagging loop assigns `PHASE_NON` for NaN offsets and applied `.fillna(PHASE_NON)` to the `earnings_phase` column so no phases are `None`.
- Aligned tests by updating `tests/test_earnings_tags.py` and `tests/test_phase_metrics.py` to use the new phase labels.

### Testing
- Ran the test suite with `pytest -q` and all automated tests passed: `19 passed in 0.85s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973db1ec3808322bb7c6ae7f97a38e7)