### PR TITLE
Wire planner earnings warnings into trade-card UI rendering

### DIFF
--- a/app/planner/ui.py
+++ b/app/planner/ui.py
@@ -1,0 +1,81 @@
+"""Streamlit UI helpers for Weekly Trade Planner rendering."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Optional
+
+SEVERITY_LEVELS = {"info", "caution", "high"}
+
+
+def _normalize_warning_severity(raw_severity: Optional[str]) -> str:
+    """Normalize warning severity for planner UI rendering."""
+    severity = (raw_severity or "").strip().lower()
+    if severity not in SEVERITY_LEVELS:
+        return "info"
+    return severity
+
+
+def render_earnings_warning_block(
+    trade_row: Mapping[str, Any],
+    *,
+    st_module=None,
+    use_expander: bool = True,
+) -> bool:
+    """Render earnings warning directly under the trade header.
+
+    Returns True when a warning was rendered.
+    """
+    if not bool(trade_row.get("earnings_overlaps_window")):
+        return False
+
+    if st_module is None:
+        import streamlit as st_module
+
+    severity = _normalize_warning_severity(trade_row.get("earnings_warning_severity"))
+    title = trade_row.get("earnings_warning_title") or "Earnings window warning"
+    body = trade_row.get("earnings_warning_body") or ""
+    summary = f"**{title}** · `{severity}`"
+
+    if severity == "high":
+        st_module.error(summary)
+    elif severity == "caution":
+        st_module.warning(summary)
+    else:
+        st_module.info(summary)
+
+    if body:
+        if use_expander:
+            with st_module.expander("Details", expanded=False):
+                st_module.write(body)
+        else:
+            st_module.write(body)
+    return True
+
+
+def render_trade_card(
+    trade_row: Mapping[str, Any],
+    render_trade_math: Callable[[Mapping[str, Any]], None],
+    *,
+    st_module=None,
+    use_expander: bool = True,
+) -> None:
+    """Render one planner trade card in scan-first order.
+
+    Order: header -> earnings warning block -> trade math details.
+    """
+    if st_module is None:
+        import streamlit as st_module
+
+    instrument = trade_row.get("instrument", "Unknown")
+    entry_date = trade_row.get("entry_date", "")
+    holding_window = trade_row.get("holding_window", "")
+    st_module.markdown(
+        f"### {instrument} | Entry: {entry_date} | Window: {holding_window}D"
+    )
+
+    render_earnings_warning_block(
+        trade_row,
+        st_module=st_module,
+        use_expander=use_expander,
+    )
+    render_trade_math(trade_row)

--- a/tests/test_planner_ui_warnings.py
+++ b/tests/test_planner_ui_warnings.py
@@ -1,0 +1,104 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.planner.ui import (
+    _normalize_warning_severity,
+    render_earnings_warning_block,
+    render_trade_card,
+)
+
+
+class _DummyExpander:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyStreamlit:
+    def __init__(self):
+        self.calls = []
+
+    def markdown(self, text):
+        self.calls.append(("markdown", text))
+
+    def info(self, text):
+        self.calls.append(("info", text))
+
+    def warning(self, text):
+        self.calls.append(("warning", text))
+
+    def error(self, text):
+        self.calls.append(("error", text))
+
+    def write(self, text):
+        self.calls.append(("write", text))
+
+    def expander(self, label, expanded=False):
+        self.calls.append(("expander", label, expanded))
+        return _DummyExpander()
+
+
+def test_normalize_warning_severity_defaults_to_info():
+    assert _normalize_warning_severity(None) == "info"
+    assert _normalize_warning_severity("unknown") == "info"
+
+
+def test_warning_block_renders_caution_with_details():
+    st = DummyStreamlit()
+    rendered = render_earnings_warning_block(
+        {
+            "earnings_overlaps_window": True,
+            "earnings_warning_severity": "caution",
+            "earnings_warning_title": "⚠️ Earnings upcoming",
+            "earnings_warning_body": "Trade overlaps earnings.",
+        },
+        st_module=st,
+    )
+
+    assert rendered is True
+    assert ("warning", "**⚠️ Earnings upcoming** · `caution`") in st.calls
+    assert ("write", "Trade overlaps earnings.") in st.calls
+
+
+def test_warning_block_skips_non_overlapping_rows():
+    st = DummyStreamlit()
+    rendered = render_earnings_warning_block(
+        {
+            "earnings_overlaps_window": False,
+            "earnings_warning_severity": "high",
+        },
+        st_module=st,
+    )
+
+    assert rendered is False
+    assert st.calls == []
+
+
+def test_trade_card_order_is_header_then_warning_then_math():
+    st = DummyStreamlit()
+
+    def render_math(_row):
+        st.calls.append(("math", "rendered"))
+
+    render_trade_card(
+        {
+            "instrument": "AAA",
+            "entry_date": "2024-01-02",
+            "holding_window": 10,
+            "earnings_overlaps_window": True,
+            "earnings_warning_severity": "high",
+            "earnings_warning_title": "High risk earnings window",
+            "earnings_warning_body": "Body",
+        },
+        render_math,
+        st_module=st,
+    )
+
+    event_order = [event[0] for event in st.calls]
+    assert event_order.index("markdown") < event_order.index("error")
+    assert event_order.index("error") < event_order.index("math")


### PR DESCRIPTION
### Motivation
- Surface existing earnings warning fields in the Weekly Trade Planner UI by rendering a compact, scannable warning block directly under each trade header when `earnings_overlaps_window` is true.
- Keep the change UI-only, lightweight, and Streamlit-native without altering engine/warning generation or earnings-tagging logic.
- Provide a simple severity mapping (`info`, `caution`, `high`) with a safe default to maintain consistent visual treatment.

### Description
- Added a new Streamlit helper module at `app/planner/ui.py` containing `render_earnings_warning_block(...)` and `render_trade_card(...)` to centralize planner row rendering and place the warning between the header and trade math.
- Implemented `_normalize_warning_severity(...)` to accept `info`, `caution`, and `high`, defaulting to `info` for missing or unrecognized severities.
- The warning block renders title, severity (as a styled summary), and body (shown inside a `Details` expander by default) only when `earnings_overlaps_window` is true, keeping the planner scan-friendly.
- No changes were made to earnings logic, warning generation rules, or tagging; this PR only wires existing fields into the UI and keeps changes isolated to a new planner UI helper.

### Testing
- Added `tests/test_planner_ui_warnings.py` with unit tests for severity fallback, overlap gating, body rendering, and header→warning→math ordering.
- Ran `pytest -q tests/test_planner_ui_warnings.py tests/test_planner_earnings_warnings.py` and all tests passed (`10 passed`).
- Existing planner earnings-warning logic tests in `tests/test_planner_earnings_warnings.py` were run alongside the new UI tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c877211b9c8322a1483bede6991e9b)