### PR TITLE
Add decision guidance layer for earnings warnings

### DIFF
--- a/app/planner/guidance.py
+++ b/app/planner/guidance.py
@@ -1,0 +1,82 @@
+"""Trade guidance interpretation layer for planner warnings."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+import numpy as np
+import pandas as pd
+
+
+SEVERITY_TYPES = {"info", "caution", "high"}
+
+
+def _overlap_is_explicit_true(overlap_value: Any) -> bool:
+    """Return True only for explicit boolean true values."""
+    return isinstance(overlap_value, (bool, np.bool_)) and bool(overlap_value)
+
+
+def _normalize_guidance_severity(raw_severity: Any) -> str:
+    """Normalize incoming severity with safe fallback."""
+    if raw_severity is None or pd.isna(raw_severity):
+        return "info"
+    severity = (
+        raw_severity.strip().lower()
+        if isinstance(raw_severity, str)
+        else str(raw_severity).strip().lower()
+    )
+    if severity not in SEVERITY_TYPES:
+        return "info"
+    return severity
+
+
+def generate_trade_guidance(trade_row: Mapping[str, Any]) -> Optional[dict]:
+    """Return actionable guidance payload for a single trade row."""
+    if not _overlap_is_explicit_true(trade_row.get("earnings_overlaps_window")):
+        return None
+
+    severity = _normalize_guidance_severity(trade_row.get("earnings_warning_severity"))
+    holding_window = trade_row.get("holding_window")
+    volatility_bucket = trade_row.get("volatility_bucket")
+
+    volatility_hint = (
+        f" Current volatility bucket: {volatility_bucket}."
+        if volatility_bucket is not None and not pd.isna(volatility_bucket)
+        else ""
+    )
+    window_hint = (
+        f" Current holding window: {holding_window} trading days."
+        if holding_window is not None and not pd.isna(holding_window)
+        else ""
+    )
+
+    if severity == "high":
+        return {
+            "guidance_title": "High-risk earnings overlap guidance",
+            "guidance_body": (
+                "Consider reducing exposure or shortening the holding window before "
+                "the earnings catalyst."
+                f"{window_hint}{volatility_hint}"
+            ).strip(),
+            "guidance_type": "high",
+        }
+    if severity == "caution":
+        return {
+            "guidance_title": "Cautionary earnings overlap guidance",
+            "guidance_body": (
+                "Monitor price action closely or reduce position size while the trade "
+                "window intersects earnings-related uncertainty."
+                f"{window_hint}{volatility_hint}"
+            ).strip(),
+            "guidance_type": "caution",
+        }
+
+    return {
+        "guidance_title": "Earnings overlap awareness",
+        "guidance_body": (
+            "This trade window intersects an earnings period; no immediate action is "
+            "required, but keep the event in view."
+            f"{window_hint}{volatility_hint}"
+        ).strip(),
+        "guidance_type": "info",
+    }

--- a/app/planner/ui.py
+++ b/app/planner/ui.py
@@ -7,6 +7,8 @@ from typing import Any, Callable, Mapping, Optional
 import numpy as np
 import pandas as pd
 
+from app.planner.guidance import generate_trade_guidance
+
 SEVERITY_LEVELS = {"info", "caution", "high"}
 
 
@@ -76,7 +78,7 @@ def render_trade_card(
 ) -> None:
     """Render one planner trade card in scan-first order.
 
-    Order: header -> earnings warning block -> trade math details.
+    Order: header -> earnings warning block -> guidance block -> trade math details.
     """
     if st_module is None:
         import streamlit as st_module
@@ -93,4 +95,40 @@ def render_trade_card(
         st_module=st_module,
         use_expander=use_expander,
     )
+    _render_guidance_block(
+        trade_row,
+        st_module=st_module,
+        use_expander=use_expander,
+    )
     render_trade_math(trade_row)
+
+
+def _render_guidance_block(
+    trade_row: Mapping[str, Any],
+    *,
+    st_module=None,
+    use_expander: bool = True,
+) -> bool:
+    """Render guidance interpretation block below earnings warnings."""
+    guidance = generate_trade_guidance(trade_row)
+    if guidance is None:
+        return False
+
+    guidance_title = guidance["guidance_title"]
+    guidance_body = guidance["guidance_body"]
+    guidance_type = guidance["guidance_type"]
+    summary = f"**{guidance_title}** · `{guidance_type}`"
+
+    if guidance_type == "high":
+        st_module.error(summary)
+    elif guidance_type == "caution":
+        st_module.warning(summary)
+    else:
+        st_module.info(summary)
+
+    if use_expander:
+        with st_module.expander("Guidance", expanded=False):
+            st_module.write(guidance_body)
+    else:
+        st_module.write(guidance_body)
+    return True

--- a/tests/test_planner_guidance.py
+++ b/tests/test_planner_guidance.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.planner.guidance import generate_trade_guidance
+
+
+def test_generate_trade_guidance_high_case():
+    guidance = generate_trade_guidance(
+        {
+            "earnings_overlaps_window": True,
+            "earnings_warning_severity": "HIGH",
+            "holding_window": 7,
+            "volatility_bucket": "high",
+        }
+    )
+
+    assert guidance is not None
+    assert guidance["guidance_type"] == "high"
+    assert "reducing exposure" in guidance["guidance_body"]
+    assert "Current holding window: 7 trading days." in guidance["guidance_body"]
+
+
+def test_generate_trade_guidance_caution_case():
+    guidance = generate_trade_guidance(
+        {
+            "earnings_overlaps_window": np.bool_(True),
+            "earnings_warning_severity": "caution",
+            "volatility_bucket": "medium",
+        }
+    )
+
+    assert guidance is not None
+    assert guidance["guidance_type"] == "caution"
+    assert "reduce position size" in guidance["guidance_body"]
+
+
+def test_generate_trade_guidance_info_case():
+    guidance = generate_trade_guidance(
+        {
+            "earnings_overlaps_window": True,
+            "earnings_warning_severity": "info",
+        }
+    )
+
+    assert guidance is not None
+    assert guidance["guidance_type"] == "info"
+    assert "no immediate action is required" in guidance["guidance_body"]
+
+
+def test_generate_trade_guidance_returns_none_without_explicit_true_overlap():
+    assert generate_trade_guidance({"earnings_overlaps_window": None}) is None
+    assert generate_trade_guidance({"earnings_overlaps_window": np.nan}) is None
+    assert generate_trade_guidance({"earnings_overlaps_window": 1}) is None
+
+
+def test_generate_trade_guidance_falls_back_to_info_for_null_severity():
+    guidance = generate_trade_guidance(
+        {
+            "earnings_overlaps_window": True,
+            "earnings_warning_severity": None,
+        }
+    )
+
+    assert guidance is not None
+    assert guidance["guidance_type"] == "info"

--- a/tests/test_planner_ui_warnings.py
+++ b/tests/test_planner_ui_warnings.py
@@ -132,5 +132,32 @@ def test_trade_card_order_is_header_then_warning_then_math():
     )
 
     event_order = [event[0] for event in st.calls]
-    assert event_order.index("markdown") < event_order.index("error")
-    assert event_order.index("error") < event_order.index("math")
+    first_error = event_order.index("error")
+    second_error = event_order.index("error", first_error + 1)
+    assert event_order.index("markdown") < first_error
+    assert first_error < second_error
+    assert second_error < event_order.index("math")
+
+
+def test_trade_card_renders_info_guidance_below_warning():
+    st = DummyStreamlit()
+
+    def render_math(_row):
+        st.calls.append(("math", "rendered"))
+
+    render_trade_card(
+        {
+            "instrument": "AAA",
+            "entry_date": "2024-01-02",
+            "holding_window": 10,
+            "earnings_overlaps_window": True,
+            "earnings_warning_severity": "info",
+            "earnings_warning_title": "ℹ️ Post-earnings window",
+            "earnings_warning_body": "Body",
+        },
+        render_math,
+        st_module=st,
+    )
+
+    assert ("info", "**Earnings overlap awareness** · `info`") in st.calls
+    assert ("expander", "Guidance", False) in st.calls


### PR DESCRIPTION
### Motivation
- Provide a pure interpretation layer that converts earnings overlap warnings into concise, human-readable guidance to help traders make decisions without altering existing warning or engine logic.
- Ensure guidance only appears when `earnings_overlaps_window` is explicitly boolean `True` and safely handle missing/null severity values.
- Surface guidance in the planner UI immediately below the existing earnings warning block using a minimal expander to keep the UI clean.

### Description
- Added a new module `app/planner/guidance.py` implementing `generate_trade_guidance(trade_row)` that gates on explicit-true overlap, normalizes severity (fallback to `info`), and maps `high`/`caution`/`info` to actionable guidance payloads including `guidance_title`, `guidance_body`, and `guidance_type`.
- Integrated guidance into the UI by importing `generate_trade_guidance` in `app/planner/ui.py` and adding `_render_guidance_block` which renders the guidance block under the warning block (uses an expander labeled "Guidance").
- Added `tests/test_planner_guidance.py` with unit tests for `high`/`caution`/`info` cases, explicit-true overlap handling, and null-severity fallback, and updated `tests/test_planner_ui_warnings.py` to assert guidance rendering order and presence.

### Testing
- Ran `pytest -q tests/test_planner_guidance.py tests/test_planner_ui_warnings.py` and all tests passed (`12 passed`).
- Guidance behavior verified for severity mapping, null handling, and UI placement under the existing warning block.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c88c93993483229c3dd8873e02f085)