### PR TITLE
Sprint 3: Add Clear vs Pro Jamaican-friendly trade guidance

### DIFF
--- a/app/planner/guidance.py
+++ b/app/planner/guidance.py
@@ -39,44 +39,71 @@ def generate_trade_guidance(trade_row: Mapping[str, Any]) -> Optional[dict]:
     holding_window = trade_row.get("holding_window")
     volatility_bucket = trade_row.get("volatility_bucket")
 
-    volatility_hint = (
-        f" Current volatility bucket: {volatility_bucket}."
+    volatility_hint_clear = (
+        f" Current price movement level: {volatility_bucket}."
         if volatility_bucket is not None and not pd.isna(volatility_bucket)
         else ""
     )
-    window_hint = (
-        f" Current holding window: {holding_window} trading days."
+    volatility_hint_pro = (
+        f" Current volatility level: {volatility_bucket}."
+        if volatility_bucket is not None and not pd.isna(volatility_bucket)
+        else ""
+    )
+    window_hint_clear = (
+        f" Your current plan is to hold for about {holding_window} trading days."
+        if holding_window is not None and not pd.isna(holding_window)
+        else ""
+    )
+    window_hint_pro = (
+        f" Current holding period: {holding_window} trading days."
         if holding_window is not None and not pd.isna(holding_window)
         else ""
     )
 
     if severity == "high":
         return {
-            "guidance_title": "High-risk earnings overlap guidance",
-            "guidance_body": (
-                "Consider reducing exposure or shortening the holding window before "
-                "the earnings catalyst."
-                f"{window_hint}{volatility_hint}"
+            "guidance_title": "High earnings overlap guidance",
+            "guidance_body_clear": (
+                "When the company releases its results, the price can go up or down "
+                "quickly. It may be safer to put in a smaller amount or wait until "
+                "after that."
+                f"{window_hint_clear}{volatility_hint_clear}"
+            ).strip(),
+            "guidance_body_pro": (
+                "Price can move significantly when results are released. Consider a "
+                "smaller position or waiting until after the announcement."
+                f"{window_hint_pro}{volatility_hint_pro}"
             ).strip(),
             "guidance_type": "high",
         }
     if severity == "caution":
         return {
-            "guidance_title": "Cautionary earnings overlap guidance",
-            "guidance_body": (
-                "Monitor price action closely or reduce position size while the trade "
-                "window intersects earnings-related uncertainty."
-                f"{window_hint}{volatility_hint}"
+            "guidance_title": "Caution earnings overlap guidance",
+            "guidance_body_clear": (
+                "The price might be a bit unpredictable around this time. You can "
+                "still invest, but it may be better to go in with less or keep an "
+                "eye on it."
+                f"{window_hint_clear}{volatility_hint_clear}"
+            ).strip(),
+            "guidance_body_pro": (
+                "Price may be less stable during this period. Consider a smaller "
+                "position or closer attention."
+                f"{window_hint_pro}{volatility_hint_pro}"
             ).strip(),
             "guidance_type": "caution",
         }
 
     return {
         "guidance_title": "Earnings overlap awareness",
-        "guidance_body": (
-            "This trade window intersects an earnings period; no immediate action is "
-            "required, but keep the event in view."
-            f"{window_hint}{volatility_hint}"
+        "guidance_body_clear": (
+            "The company is expected to release results soon. This can affect the "
+            "price, so just keep it in mind."
+            f"{window_hint_clear}{volatility_hint_clear}"
+        ).strip(),
+        "guidance_body_pro": (
+            "Upcoming results may affect price movement. No immediate action is "
+            "needed."
+            f"{window_hint_pro}{volatility_hint_pro}"
         ).strip(),
         "guidance_type": "info",
     }

--- a/app/planner/ui.py
+++ b/app/planner/ui.py
@@ -75,6 +75,7 @@ def render_trade_card(
     *,
     st_module=None,
     use_expander: bool = True,
+    guidance_mode: Optional[str] = None,
 ) -> None:
     """Render one planner trade card in scan-first order.
 
@@ -90,6 +91,11 @@ def render_trade_card(
         f"### {instrument} | Entry: {entry_date} | Window: {holding_window}D"
     )
 
+    selected_guidance_mode = _resolve_guidance_mode(
+        st_module=st_module,
+        guidance_mode=guidance_mode,
+    )
+
     render_earnings_warning_block(
         trade_row,
         st_module=st_module,
@@ -99,8 +105,21 @@ def render_trade_card(
         trade_row,
         st_module=st_module,
         use_expander=use_expander,
+        guidance_mode=selected_guidance_mode,
     )
     render_trade_math(trade_row)
+
+
+def _resolve_guidance_mode(*, st_module=None, guidance_mode: Optional[str]) -> str:
+    """Resolve whether guidance should render in clear or pro mode."""
+    if guidance_mode in {"clear", "pro"}:
+        return guidance_mode
+
+    if hasattr(st_module, "toggle"):
+        is_simple = st_module.toggle("Simple explanation", value=True)
+        return "clear" if is_simple else "pro"
+
+    return "clear"
 
 
 def _render_guidance_block(
@@ -108,6 +127,7 @@ def _render_guidance_block(
     *,
     st_module=None,
     use_expander: bool = True,
+    guidance_mode: str = "clear",
 ) -> bool:
     """Render guidance interpretation block below earnings warnings."""
     guidance = generate_trade_guidance(trade_row)
@@ -115,7 +135,11 @@ def _render_guidance_block(
         return False
 
     guidance_title = guidance["guidance_title"]
-    guidance_body = guidance["guidance_body"]
+    guidance_body = (
+        guidance["guidance_body_pro"]
+        if guidance_mode == "pro"
+        else guidance["guidance_body_clear"]
+    )
     guidance_type = guidance["guidance_type"]
     summary = f"**{guidance_title}** · `{guidance_type}`"
 

--- a/tests/test_planner_guidance.py
+++ b/tests/test_planner_guidance.py
@@ -21,8 +21,12 @@ def test_generate_trade_guidance_high_case():
 
     assert guidance is not None
     assert guidance["guidance_type"] == "high"
-    assert "reducing exposure" in guidance["guidance_body"]
-    assert "Current holding window: 7 trading days." in guidance["guidance_body"]
+    assert "put in a smaller amount" in guidance["guidance_body_clear"]
+    assert "smaller position" in guidance["guidance_body_pro"]
+    assert (
+        "Your current plan is to hold for about 7 trading days."
+        in guidance["guidance_body_clear"]
+    )
 
 
 def test_generate_trade_guidance_caution_case():
@@ -36,7 +40,8 @@ def test_generate_trade_guidance_caution_case():
 
     assert guidance is not None
     assert guidance["guidance_type"] == "caution"
-    assert "reduce position size" in guidance["guidance_body"]
+    assert "go in with less" in guidance["guidance_body_clear"]
+    assert "smaller position" in guidance["guidance_body_pro"]
 
 
 def test_generate_trade_guidance_info_case():
@@ -49,7 +54,8 @@ def test_generate_trade_guidance_info_case():
 
     assert guidance is not None
     assert guidance["guidance_type"] == "info"
-    assert "no immediate action is required" in guidance["guidance_body"]
+    assert "just keep it in mind" in guidance["guidance_body_clear"]
+    assert "No immediate action is needed." in guidance["guidance_body_pro"]
 
 
 def test_generate_trade_guidance_returns_none_without_explicit_true_overlap():
@@ -68,3 +74,5 @@ def test_generate_trade_guidance_falls_back_to_info_for_null_severity():
 
     assert guidance is not None
     assert guidance["guidance_type"] == "info"
+    assert "guidance_body_clear" in guidance
+    assert "guidance_body_pro" in guidance

--- a/tests/test_planner_ui_warnings.py
+++ b/tests/test_planner_ui_warnings.py
@@ -161,3 +161,40 @@ def test_trade_card_renders_info_guidance_below_warning():
 
     assert ("info", "**Earnings overlap awareness** · `info`") in st.calls
     assert ("expander", "Guidance", False) in st.calls
+
+
+def test_trade_card_switches_guidance_between_clear_and_pro():
+    st_clear = DummyStreamlit()
+    st_pro = DummyStreamlit()
+
+    def render_math(_row):
+        return None
+
+    trade_row = {
+        "instrument": "AAA",
+        "entry_date": "2024-01-02",
+        "holding_window": 10,
+        "earnings_overlaps_window": True,
+        "earnings_warning_severity": "high",
+    }
+
+    render_trade_card(
+        trade_row,
+        render_math,
+        st_module=st_clear,
+        use_expander=False,
+        guidance_mode="clear",
+    )
+    render_trade_card(
+        trade_row,
+        render_math,
+        st_module=st_pro,
+        use_expander=False,
+        guidance_mode="pro",
+    )
+
+    clear_writes = [call[1] for call in st_clear.calls if call[0] == "write"]
+    pro_writes = [call[1] for call in st_pro.calls if call[0] == "write"]
+
+    assert any("put in a smaller amount" in text for text in clear_writes)
+    assert any("smaller position" in text for text in pro_writes)


### PR DESCRIPTION
### Motivation
- Provide guidance text that an average Jamaican investor can read and act on while offering a concise “Pro” view for experienced users, without changing any existing decision logic. 
- Keep overlap gating, severity normalization/fallback, and all warning-generation rules unchanged while changing only phrasing, output structure, and UI selection.

### Description
- Change `generate_trade_guidance` to return a dual-body structure with `guidance_body_clear` and `guidance_body_pro` and keep `guidance_title` and `guidance_type` in the payload, while preserving severity mapping and overlap checks in `app/planner/guidance.py`.
- Replace technical jargon with everyday Jamaican-friendly phrasing in Clear mode and provide a tighter localized Pro wording; add separate per-mode `window` and `volatility` hints (`window_hint_clear`/`window_hint_pro`, `volatility_hint_clear`/`volatility_hint_pro`).
- Add UI selection support in `app/planner/ui.py` by accepting an optional `guidance_mode` in `render_trade_card`, implementing `_resolve_guidance_mode` which defaults to Clear and uses a `Simple explanation` toggle when available, and rendering the appropriate `guidance_body_clear` or `guidance_body_pro` in `_render_guidance_block`.
- Files changed: `app/planner/guidance.py`, `app/planner/ui.py`, `tests/test_planner_guidance.py`, `tests/test_planner_ui_warnings.py`.

### Testing
- Ran `pytest -q tests/test_planner_guidance.py tests/test_planner_ui_warnings.py` and received `13 passed`.
- Tests added/updated to validate that both `guidance_body_clear` and `guidance_body_pro` are returned, null severity falls back to `info`, null/non-explicit overlap returns `None`, and the UI can switch between Clear and Pro guidance text (new test `test_trade_card_switches_guidance_between_clear_and_pro`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c89b42b4c8832287491c452cee5cb1)