### PR TITLE
Add deterministic trade confidence classification and planner UI block

### DIFF
--- a/app/planner/confidence.py
+++ b/app/planner/confidence.py
@@ -1,0 +1,110 @@
+"""Trade confidence classification layer for planner rows."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+HIGH_VOLATILITY_BUCKET = "high"
+
+
+def generate_trade_confidence(trade_row: Mapping[str, Any]) -> dict:
+    """Return confidence payload for a single trade row.
+
+    Classification order is deterministic and intentionally simple.
+    """
+    liquidity_pass = bool(trade_row.get("liquidity_pass"))
+    severity = _normalize_token(trade_row.get("severity"))
+    quality_tier = _normalize_token(trade_row.get("quality_tier")).upper()
+    volatility_bucket = _normalize_token(trade_row.get("volatility_bucket"))
+
+    if not liquidity_pass:
+        confidence_level = "avoid"
+    elif severity == "high":
+        confidence_level = "high risk"
+    elif quality_tier == "A" and volatility_bucket != HIGH_VOLATILITY_BUCKET:
+        confidence_level = "strong"
+    elif quality_tier in {"A", "B"}:
+        confidence_level = "moderate"
+    elif quality_tier == "C":
+        confidence_level = "watch"
+    else:
+        confidence_level = "moderate"
+
+    return _confidence_copy(confidence_level)
+
+
+def _normalize_token(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().lower()
+
+
+def _confidence_copy(confidence_level: str) -> dict:
+    if confidence_level == "avoid":
+        return {
+            "confidence_label": "avoid",
+            "confidence_title": "Avoid this setup",
+            "confidence_body_clear": (
+                "Liquidity did not pass, so entering this trade can be hard and riskier. "
+                "Prioritize better-liquid setups first."
+            ),
+            "confidence_body_pro": (
+                "Liquidity screen failed. Execution quality and slippage risk are elevated; "
+                "deprioritize this setup."
+            ),
+            "confidence_level": "avoid",
+        }
+
+    if confidence_level == "high risk":
+        return {
+            "confidence_label": "high risk",
+            "confidence_title": "High-risk setup",
+            "confidence_body_clear": (
+                "Warning severity is high, so this trade has elevated uncertainty. "
+                "Use extra caution or reduce size."
+            ),
+            "confidence_body_pro": (
+                "High severity context implies elevated event risk. Consider reduced exposure "
+                "or waiting for cleaner conditions."
+            ),
+            "confidence_level": "high risk",
+        }
+
+    if confidence_level == "strong":
+        return {
+            "confidence_label": "strong",
+            "confidence_title": "Strong confidence",
+            "confidence_body_clear": (
+                "Top quality tier with non-high volatility supports a stronger setup."
+            ),
+            "confidence_body_pro": (
+                "Tier A quality with contained volatility supports higher relative confidence."
+            ),
+            "confidence_level": "strong",
+        }
+
+    if confidence_level == "watch":
+        return {
+            "confidence_label": "watch",
+            "confidence_title": "Watch closely",
+            "confidence_body_clear": (
+                "Tier C quality suggests this trade needs monitoring before committing more capital."
+            ),
+            "confidence_body_pro": (
+                "Tier C profile indicates lower conviction; keep on watchlist unless other factors improve."
+            ),
+            "confidence_level": "watch",
+        }
+
+    return {
+        "confidence_label": "moderate",
+        "confidence_title": "Moderate confidence",
+        "confidence_body_clear": (
+            "This setup is usable but not top-priority. Consider balanced sizing."
+        ),
+        "confidence_body_pro": (
+            "Signal quality is acceptable but not elite; maintain standard risk controls."
+        ),
+        "confidence_level": "moderate",
+    }

--- a/app/planner/ui.py
+++ b/app/planner/ui.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Mapping, Optional, Sequence
 import numpy as np
 import pandas as pd
 
+from app.planner.confidence import generate_trade_confidence
 from app.planner.guidance import generate_trade_guidance
 
 SEVERITY_LEVELS = {"info", "caution", "high"}
@@ -79,7 +80,7 @@ def render_trade_card(
 ) -> None:
     """Render one planner trade card in scan-first order.
 
-    Order: header -> earnings warning block -> guidance block -> trade math details.
+    Order: header -> earnings warning block -> confidence block -> guidance block -> trade math details.
     """
     if st_module is None:
         import streamlit as st_module
@@ -97,6 +98,12 @@ def render_trade_card(
         trade_row,
         st_module=st_module,
         use_expander=use_expander,
+    )
+    _render_confidence_block(
+        trade_row,
+        st_module=st_module,
+        use_expander=use_expander,
+        guidance_mode=selected_guidance_mode,
     )
     _render_guidance_block(
         trade_row,
@@ -163,6 +170,39 @@ def _resolve_guidance_mode(guidance_mode: Optional[str]) -> str:
     if guidance_mode in {"clear", "pro"}:
         return guidance_mode
     return "clear"
+
+
+def _render_confidence_block(
+    trade_row: Mapping[str, Any],
+    *,
+    st_module=None,
+    use_expander: bool = True,
+    guidance_mode: str = "clear",
+) -> bool:
+    """Render confidence classification block below warnings."""
+    confidence = generate_trade_confidence(trade_row)
+    confidence_title = confidence["confidence_title"]
+    confidence_body = (
+        confidence["confidence_body_pro"]
+        if guidance_mode == "pro"
+        else confidence["confidence_body_clear"]
+    )
+    confidence_level = confidence["confidence_level"]
+    summary = f"**{confidence_title}** · `{confidence_level}`"
+
+    if confidence_level in {"avoid", "high risk"}:
+        st_module.error(summary)
+    elif confidence_level == "watch":
+        st_module.warning(summary)
+    else:
+        st_module.info(summary)
+
+    if use_expander:
+        with st_module.expander("Confidence", expanded=False):
+            st_module.write(confidence_body)
+    else:
+        st_module.write(confidence_body)
+    return True
 
 
 def _render_guidance_block(

--- a/tests/test_planner_confidence.py
+++ b/tests/test_planner_confidence.py
@@ -1,0 +1,106 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.planner.confidence import generate_trade_confidence
+
+
+def test_generate_trade_confidence_avoid_on_failed_liquidity():
+    payload = generate_trade_confidence(
+        {
+            "liquidity_pass": False,
+            "severity": "info",
+            "quality_tier": "A",
+            "volatility_bucket": "low",
+        }
+    )
+
+    assert payload["confidence_level"] == "avoid"
+    assert payload["confidence_label"] == "avoid"
+
+
+def test_generate_trade_confidence_high_risk_on_high_severity():
+    payload = generate_trade_confidence(
+        {
+            "liquidity_pass": True,
+            "severity": "high",
+            "quality_tier": "A",
+            "volatility_bucket": "low",
+        }
+    )
+
+    assert payload["confidence_level"] == "high risk"
+
+
+def test_generate_trade_confidence_strong_for_a_non_high_volatility():
+    payload = generate_trade_confidence(
+        {
+            "liquidity_pass": True,
+            "severity": "caution",
+            "quality_tier": "A",
+            "volatility_bucket": "medium",
+        }
+    )
+
+    assert payload["confidence_level"] == "strong"
+
+
+def test_generate_trade_confidence_moderate_for_a_with_high_volatility():
+    payload = generate_trade_confidence(
+        {
+            "liquidity_pass": True,
+            "severity": "info",
+            "quality_tier": "A",
+            "volatility_bucket": "high",
+        }
+    )
+
+    assert payload["confidence_level"] == "moderate"
+
+
+def test_generate_trade_confidence_moderate_for_b_tier():
+    payload = generate_trade_confidence(
+        {
+            "liquidity_pass": True,
+            "severity": "info",
+            "quality_tier": "B",
+            "volatility_bucket": "high",
+        }
+    )
+
+    assert payload["confidence_level"] == "moderate"
+
+
+def test_generate_trade_confidence_watch_for_c_tier():
+    payload = generate_trade_confidence(
+        {
+            "liquidity_pass": True,
+            "severity": "info",
+            "quality_tier": "C",
+            "volatility_bucket": "low",
+        }
+    )
+
+    assert payload["confidence_level"] == "watch"
+
+
+def test_generate_trade_confidence_fallback_to_moderate():
+    payload = generate_trade_confidence(
+        {
+            "liquidity_pass": True,
+            "severity": "info",
+            "quality_tier": "D",
+            "volatility_bucket": "low",
+        }
+    )
+
+    assert payload["confidence_level"] == "moderate"
+    assert set(payload.keys()) == {
+        "confidence_label",
+        "confidence_title",
+        "confidence_body_clear",
+        "confidence_body_pro",
+        "confidence_level",
+    }

--- a/tests/test_planner_ui_warnings.py
+++ b/tests/test_planner_ui_warnings.py
@@ -118,7 +118,7 @@ def test_warning_block_renders_for_numpy_true_overlap():
     assert ("error", "**High risk earnings window** · `high`") in st.calls
 
 
-def test_trade_card_order_is_header_then_warning_then_math():
+def test_trade_card_order_is_header_then_warning_then_confidence_then_guidance_then_math():
     st = DummyStreamlit()
 
     def render_math(_row):
@@ -133,17 +133,22 @@ def test_trade_card_order_is_header_then_warning_then_math():
             "earnings_warning_severity": "high",
             "earnings_warning_title": "High risk earnings window",
             "earnings_warning_body": "Body",
+            "liquidity_pass": True,
+            "severity": "info",
+            "quality_tier": "B",
+            "volatility_bucket": "high",
         },
         render_math,
         st_module=st,
     )
 
-    event_order = [event[0] for event in st.calls]
-    first_error = event_order.index("error")
-    second_error = event_order.index("error", first_error + 1)
-    assert event_order.index("markdown") < first_error
-    assert first_error < second_error
-    assert second_error < event_order.index("math")
+    warning_index = st.calls.index(("error", "**High risk earnings window** · `high`"))
+    confidence_index = st.calls.index(("info", "**Moderate confidence** · `moderate`"))
+    guidance_index = st.calls.index(("error", "**High earnings overlap guidance** · `high`"))
+    math_index = st.calls.index(("math", "rendered"))
+
+    assert st.calls.index(("markdown", "### AAA | Entry: 2024-01-02 | Window: 10D")) < warning_index
+    assert warning_index < confidence_index < guidance_index < math_index
 
 
 def test_trade_card_renders_info_guidance_below_warning():
@@ -183,6 +188,10 @@ def test_trade_card_switches_guidance_between_clear_and_pro():
         "holding_window": 10,
         "earnings_overlaps_window": True,
         "earnings_warning_severity": "high",
+        "quality_tier": "A",
+        "volatility_bucket": "low",
+        "liquidity_pass": True,
+        "severity": "info",
     }
 
     render_trade_card(
@@ -205,7 +214,39 @@ def test_trade_card_switches_guidance_between_clear_and_pro():
 
     assert any("put in a smaller amount" in text for text in clear_writes)
     assert any("smaller position" in text for text in pro_writes)
+    assert any("stronger setup" in text for text in clear_writes)
+    assert any("relative confidence" in text for text in pro_writes)
 
+
+
+
+def test_trade_card_renders_confidence_block_between_warning_and_guidance():
+    st = DummyStreamlit()
+
+    def render_math(_row):
+        st.calls.append(("math", "rendered"))
+
+    render_trade_card(
+        {
+            "instrument": "AAA",
+            "entry_date": "2024-01-02",
+            "holding_window": 10,
+            "earnings_overlaps_window": True,
+            "earnings_warning_severity": "caution",
+            "quality_tier": "C",
+            "volatility_bucket": "medium",
+            "liquidity_pass": True,
+            "severity": "caution",
+        },
+        render_math,
+        st_module=st,
+    )
+
+    assert ("warning", "**Watch closely** · `watch`") in st.calls
+    warning_index = st.calls.index(("warning", "**Earnings window warning** · `caution`"))
+    confidence_index = st.calls.index(("warning", "**Watch closely** · `watch`"))
+    guidance_index = st.calls.index(("warning", "**Caution earnings overlap guidance** · `caution`"))
+    assert warning_index < confidence_index < guidance_index
 
 def test_trade_card_does_not_create_toggle_widget_per_card():
     st = DummyStreamlit(toggle_value=False)


### PR DESCRIPTION
### Motivation
- Provide a simple, deterministic decision-support layer that classifies each planner trade by overall confidence so users can prioritize capital deployment. 
- Keep logic explainable (no scoring formulas) and reuse existing UI guidance mode switching without adding toggles.

### Description
- Add a pure function `generate_trade_confidence(trade_row) -> dict` in `app/planner/confidence.py` implementing the ordered rules: failed liquidity → "avoid", severity == "high" → "high risk", tier A + non-high volatility → "strong", tier A/B → "moderate", tier C → "watch`, fallback → "moderate". 
- Return payload with keys `confidence_label`, `confidence_title`, `confidence_body_clear`, `confidence_body_pro`, and `confidence_level` and simple copy for each bucket. 
- Render a confidence block in `render_trade_card(...)` by adding `_render_confidence_block(...)` to `app/planner/ui.py`, placed between earnings warnings and guidance, and choose clear/pro body using the existing `guidance_mode`. 
- Add unit tests `tests/test_planner_confidence.py` for all branches and extend `tests/test_planner_ui_warnings.py` to assert confidence rendering, ordering (warning → confidence → guidance), and clear/pro switching, while leaving existing guidance and earnings logic unchanged.

### Testing
- Ran `pytest -q tests/test_planner_confidence.py tests/test_planner_ui_warnings.py` and all tests passed (`20 passed`).
- Executed a small sample script calling `generate_trade_confidence(...)` to produce example payloads for `avoid`, `high risk`, `strong`, `moderate`, and `watch` and verified the returned dictionary shapes and text content.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8a7c372248322bea6375dc35fd323)