### PR TITLE
Add Analyst Insights module and planner UI hook for feature/matrix/exit review

### DIFF
--- a/app/insights/__init__.py
+++ b/app/insights/__init__.py
@@ -1,0 +1,19 @@
+"""Analyst insight tooling."""
+
+from .analyst import (
+    build_exit_analysis,
+    build_feature_insights,
+    build_performance_matrix,
+    grouped_trade_metrics,
+    render_analyst_insights,
+    resolve_return_column,
+)
+
+__all__ = [
+    "build_exit_analysis",
+    "build_feature_insights",
+    "build_performance_matrix",
+    "grouped_trade_metrics",
+    "render_analyst_insights",
+    "resolve_return_column",
+]

--- a/app/insights/analyst.py
+++ b/app/insights/analyst.py
@@ -1,0 +1,200 @@
+"""Analyst-focused insight helpers for validating system behavior."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+FEATURE_COLUMNS = [
+    "fast_slope_up",
+    "slow_slope_up",
+    "spread_widening",
+    "volume_confirmed",
+    "stale_5d",
+    "vol_bucket",
+]
+
+PREFERRED_RETURN_COLUMNS = ["net_return_pct", "net_return", "return_pct", "return"]
+
+
+def resolve_return_column(df: pd.DataFrame, preferred: Sequence[str] | None = None) -> str | None:
+    """Return the first available return column from preferred names."""
+    for column in preferred or PREFERRED_RETURN_COLUMNS:
+        if column in df.columns:
+            return column
+    return None
+
+
+def _missing_columns(df: pd.DataFrame, required_columns: Sequence[str]) -> list[str]:
+    return [column for column in required_columns if column not in df.columns]
+
+
+def grouped_trade_metrics(
+    df: pd.DataFrame,
+    group_columns: Sequence[str],
+    *,
+    return_column: str,
+) -> pd.DataFrame:
+    """Compute grouped analyst metrics for any dimensional slice."""
+    required_columns = [*group_columns, return_column]
+    missing = _missing_columns(df, required_columns)
+    if missing:
+        raise ValueError(f"Missing required columns: {missing}")
+
+    grouped = (
+        df.groupby(list(group_columns), dropna=False)
+        .agg(
+            count=(return_column, "size"),
+            win_rate=(return_column, lambda values: (values > 0).mean()),
+            avg_return=(return_column, "mean"),
+            median_return=(return_column, "median"),
+        )
+        .reset_index()
+        .sort_values("count", ascending=False)
+        .reset_index(drop=True)
+    )
+    return grouped
+
+
+def build_feature_insights(
+    df: pd.DataFrame,
+    *,
+    return_column: str,
+    feature_columns: Sequence[str] | None = None,
+) -> dict[str, pd.DataFrame]:
+    """Build grouped summaries for each available feature column."""
+    insights: dict[str, pd.DataFrame] = {}
+    for feature in feature_columns or FEATURE_COLUMNS:
+        if feature not in df.columns:
+            continue
+        insights[feature] = grouped_trade_metrics(
+            df,
+            [feature],
+            return_column=return_column,
+        )
+    return insights
+
+
+def build_performance_matrix(
+    df: pd.DataFrame,
+    *,
+    return_column: str,
+) -> Mapping[str, Any]:
+    """Build tier/window summary and matrix pivots."""
+    required = ["quality_tier", "holding_window", return_column]
+    missing = _missing_columns(df, required)
+    if missing:
+        raise ValueError(f"Missing required columns: {missing}")
+
+    summary = grouped_trade_metrics(
+        df,
+        ["quality_tier", "holding_window"],
+        return_column=return_column,
+    ).rename(columns={"count": "n_trades"})
+
+    win_rate_matrix = summary.pivot(
+        index="quality_tier",
+        columns="holding_window",
+        values="win_rate",
+    )
+    median_return_matrix = summary.pivot(
+        index="quality_tier",
+        columns="holding_window",
+        values="median_return",
+    )
+
+    best_setups = summary.sort_values(
+        ["win_rate", "median_return", "n_trades"],
+        ascending=[False, False, False],
+    ).reset_index(drop=True)
+
+    return {
+        "summary": summary,
+        "win_rate_matrix": win_rate_matrix,
+        "median_return_matrix": median_return_matrix,
+        "best_setups": best_setups,
+    }
+
+
+def build_exit_analysis(
+    df: pd.DataFrame,
+    *,
+    return_column: str,
+    include_holding_window: bool = True,
+) -> pd.DataFrame:
+    """Build grouped exit summaries for analyst review."""
+    group_columns = ["quality_tier", "exit_reason"]
+    if include_holding_window and "holding_window" in df.columns:
+        group_columns.append("holding_window")
+
+    return grouped_trade_metrics(
+        df,
+        group_columns,
+        return_column=return_column,
+    )
+
+
+def render_analyst_insights(
+    trades_df: pd.DataFrame,
+    *,
+    st_module=None,
+    analyst_mode: bool = True,
+) -> None:
+    """Render Analyst Insights tab in analyst mode, handling sparse schemas."""
+    if not analyst_mode:
+        return
+
+    if st_module is None:
+        import streamlit as st_module
+
+    return_column = resolve_return_column(trades_df)
+    if return_column is None:
+        st_module.info(
+            "Analyst Insights unavailable: no return column found. "
+            f"Expected one of {PREFERRED_RETURN_COLUMNS}."
+        )
+        return
+
+    insights_tab, matrix_tab, exit_tab = st_module.tabs(
+        ["Feature Insights", "Performance Matrix", "Exit Analysis"]
+    )
+
+    with insights_tab:
+        st_module.subheader("Feature Insights")
+        insights = build_feature_insights(trades_df, return_column=return_column)
+        if not insights:
+            st_module.info(
+                "No configured feature columns are present in the current dataset."
+            )
+        for feature, summary in insights.items():
+            st_module.markdown(f"#### {feature}")
+            st_module.dataframe(summary)
+
+    with matrix_tab:
+        st_module.subheader("Performance Matrix")
+        try:
+            matrix_payload = build_performance_matrix(
+                trades_df,
+                return_column=return_column,
+            )
+        except ValueError as error:
+            st_module.info(f"Performance Matrix unavailable: {error}")
+        else:
+            st_module.markdown("#### Grouped Summary")
+            st_module.dataframe(matrix_payload["summary"])
+            st_module.markdown("#### Win-Rate Matrix")
+            st_module.dataframe(matrix_payload["win_rate_matrix"])
+            st_module.markdown("#### Median-Return Matrix")
+            st_module.dataframe(matrix_payload["median_return_matrix"])
+            st_module.markdown("#### Best Setups")
+            st_module.dataframe(matrix_payload["best_setups"].head(10))
+
+    with exit_tab:
+        st_module.subheader("Exit Analysis")
+        if "exit_reason" not in trades_df.columns:
+            st_module.info("Exit Analysis unavailable: missing 'exit_reason' column.")
+        else:
+            st_module.dataframe(
+                build_exit_analysis(trades_df, return_column=return_column)
+            )

--- a/app/planner/ui.py
+++ b/app/planner/ui.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Mapping, Optional, Sequence
 import numpy as np
 import pandas as pd
 
+from app.insights.analyst import render_analyst_insights
 from app.planner.confidence import generate_trade_confidence
 from app.planner.guidance import generate_trade_guidance
 
@@ -239,3 +240,17 @@ def _render_guidance_block(
     else:
         st_module.write(guidance_body)
     return True
+
+
+def render_analyst_insights_section(
+    trades_df: pd.DataFrame,
+    *,
+    st_module=None,
+    analyst_mode: bool = True,
+) -> None:
+    """Render analyst insights in analyst mode without mutating engine outputs."""
+    render_analyst_insights(
+        trades_df,
+        st_module=st_module,
+        analyst_mode=analyst_mode,
+    )

--- a/tests/test_analyst_insights.py
+++ b/tests/test_analyst_insights.py
@@ -1,0 +1,96 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.insights.analyst import (
+    build_exit_analysis,
+    build_feature_insights,
+    build_performance_matrix,
+    grouped_trade_metrics,
+    resolve_return_column,
+)
+
+
+def _sample_trades() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "quality_tier": ["A", "A", "B", "B"],
+            "holding_window": [5, 10, 5, 10],
+            "net_return_pct": [0.02, -0.01, 0.03, 0.01],
+            "fast_slope_up": [True, True, False, False],
+            "vol_bucket": ["low", "high", "high", "low"],
+            "exit_reason": ["target_hit", "stop_hit", "target_hit", "time_exit"],
+        }
+    )
+
+
+def test_grouped_trade_metrics_generates_expected_columns_and_values():
+    summary = grouped_trade_metrics(
+        _sample_trades(),
+        ["quality_tier"],
+        return_column="net_return_pct",
+    )
+
+    assert list(summary.columns) == [
+        "quality_tier",
+        "count",
+        "win_rate",
+        "avg_return",
+        "median_return",
+    ]
+
+    row_a = summary[summary["quality_tier"] == "A"].iloc[0]
+    assert row_a["count"] == 2
+    assert row_a["win_rate"] == 0.5
+    assert row_a["median_return"] == 0.005
+
+
+def test_grouped_trade_metrics_raises_for_missing_columns():
+    with pytest.raises(ValueError, match="Missing required columns"):
+        grouped_trade_metrics(
+            _sample_trades().drop(columns=["quality_tier"]),
+            ["quality_tier"],
+            return_column="net_return_pct",
+        )
+
+
+def test_feature_insights_only_returns_available_features():
+    insights = build_feature_insights(
+        _sample_trades().drop(columns=["fast_slope_up"]),
+        return_column="net_return_pct",
+    )
+
+    assert "fast_slope_up" not in insights
+    assert "vol_bucket" in insights
+
+
+def test_performance_matrix_pivots_are_stable():
+    payload = build_performance_matrix(_sample_trades(), return_column="net_return_pct")
+
+    assert list(payload["summary"].columns) == [
+        "quality_tier",
+        "holding_window",
+        "n_trades",
+        "win_rate",
+        "avg_return",
+        "median_return",
+    ]
+    assert payload["win_rate_matrix"].shape == (2, 2)
+    assert payload["median_return_matrix"].shape == (2, 2)
+
+
+def test_exit_analysis_groups_by_quality_and_reason_and_window_when_available():
+    summary = build_exit_analysis(_sample_trades(), return_column="net_return_pct")
+
+    assert {"quality_tier", "exit_reason", "holding_window"}.issubset(summary.columns)
+
+
+def test_resolve_return_column_finds_preferred_choice():
+    df = pd.DataFrame({"return": [0.1]})
+    assert resolve_return_column(df) == "return"
+    assert resolve_return_column(pd.DataFrame({"x": [1]})) is None


### PR DESCRIPTION
### Motivation
- Provide an analyst-facing layer to validate and explain system behavior without changing any decision engines or business logic.
- Surface grouped feature summaries, performance-by-tier/window matrices, and exit-reason analytics to help diagnose and validate signal/quality outcomes.

### Description
- Added a new `app/insights/analyst.py` module implementing `resolve_return_column`, `grouped_trade_metrics`, `build_feature_insights`, `build_performance_matrix`, `build_exit_analysis`, and `render_analyst_insights` with Streamlit-native tabs and graceful handling of missing columns.
- Exported the analyst helpers via `app/insights/__init__.py` so they can be imported as `app.insights`.
- Added a UI integration helper `render_analyst_insights_section` in `app/planner/ui.py` that delegates to the new renderer so analyst views can be shown without touching signal, warning, confidence, or allocation logic.
- Added targeted tests in `tests/test_analyst_insights.py` to verify grouped metric generation, missing-column handling, return-column detection, and pivot/matrix shape stability.

### Testing
- Ran `pytest -q tests/test_analyst_insights.py tests/test_planner_ui_warnings.py`, and all tests passed (`19 passed`).
- The new tests cover grouped metrics behavior, feature filtering when columns are absent, performance matrix pivots, exit analysis grouping, and return-column resolution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9e75d916083229cf325c3f9a606f5)