### PR TITLE
Add Streamlit app shell and Portfolio Plan UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,104 @@
+"""Streamlit application shell for the JSE Decision Support Dashboard."""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from app.data.ingest import ingest_dataset
+from app.demo.run_demo import run_demo
+from app.insights.analyst import render_analyst_insights
+from app.planner.allocation import generate_portfolio_allocation
+from app.planner.portfolio_ui import render_portfolio_plan
+
+
+def _coerce_trade_rows_from_ranked(ranked_df: pd.DataFrame) -> list[dict]:
+    """Build minimal planner trade rows from ranked outputs.
+
+    Assumption: ranked outputs do not yet carry full planner fields, so this adapter
+    uses safe defaults and preserves available ranking fields for UI visibility.
+    """
+    trade_rows: list[dict] = []
+    for row in ranked_df.to_dict("records"):
+        quality_tier = str(row.get("tier", "B") or "B")
+        trade_rows.append(
+            {
+                "instrument": row.get("instrument", "Unknown"),
+                "quality_tier": quality_tier,
+                "liquidity_pass": True,
+                "volatility_bucket": "medium",
+                "earnings_warning_severity": "info",
+                "confidence_label": "strong" if quality_tier.upper() == "A" else "moderate",
+            }
+        )
+    return trade_rows
+
+
+def main() -> None:
+    """Run the Streamlit shell with Analyst Insights and Portfolio Plan sections."""
+    st.set_page_config(
+        page_title="JSE Decision Support Dashboard",
+        page_icon="📈",
+        layout="wide",
+    )
+
+    st.title("JSE Decision Support Dashboard")
+    st.caption("Sprint 7 shell: dataset loading, Analyst Insights, and Portfolio Plan UI.")
+
+    canonical_df, meta, issues = ingest_dataset("demo")
+    st.markdown("### Data Status")
+    st.write(
+        {
+            "dataset_id": meta.get("dataset_id"),
+            "source": meta.get("source"),
+            "row_count": int(len(canonical_df)),
+            "validation_issues": issues,
+        }
+    )
+
+    if canonical_df.empty:
+        st.warning("No rows were loaded from the data layer. Please verify demo dataset files.")
+        return
+
+    st.markdown("### Main Dashboard")
+    st.dataframe(canonical_df.head(50), use_container_width=True)
+
+    demo_payload = run_demo()
+    ranked_df = demo_payload.get("ranked", pd.DataFrame())
+
+    insights_tab, plan_tab = st.tabs(["Analyst Insights", "Portfolio Plan"])
+
+    with insights_tab:
+        render_analyst_insights(canonical_df, st_module=st, analyst_mode=True)
+
+    with plan_tab:
+        st.markdown("### Portfolio Plan")
+        total_capital = st.number_input(
+            "Total capital",
+            min_value=0.0,
+            value=100_000.0,
+            step=5_000.0,
+        )
+
+        if ranked_df.empty:
+            st.info("Portfolio Plan unavailable: ranked outputs were not generated.")
+            return
+
+        trade_rows = _coerce_trade_rows_from_ranked(ranked_df)
+        allocation_payload = generate_portfolio_allocation(trade_rows, total_capital)
+        allocations = allocation_payload.get("allocations", [])
+
+        # Attach lightweight context fields used by portfolio UI reason labels.
+        enriched_allocations = []
+        for row, allocation in zip(trade_rows, allocations):
+            enriched_allocations.append({**allocation, **row})
+
+        render_portfolio_plan(
+            enriched_allocations,
+            total_capital=total_capital,
+            st_module=st,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package root for decision-support modules."""

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -1,0 +1,154 @@
+"""Streamlit helpers for rendering a user-facing portfolio plan."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+
+def build_portfolio_summary(
+    allocations: Sequence[Mapping[str, Any]],
+    total_capital: float,
+) -> dict[str, Any]:
+    """Build top-line portfolio summary values from allocation rows."""
+    safe_capital = float(total_capital or 0.0)
+    total_allocated_amount = round(
+        sum(float(trade.get("allocation_amount", 0.0) or 0.0) for trade in allocations),
+        2,
+    )
+    total_allocated_pct = (
+        round(total_allocated_amount / safe_capital, 4) if safe_capital > 0 else 0.0
+    )
+    cash_reserve_amount = round(safe_capital - total_allocated_amount, 2)
+    cash_reserve_pct = (
+        round(cash_reserve_amount / safe_capital, 4) if safe_capital > 0 else 0.0
+    )
+    funded_trade_count = sum(
+        1 for trade in allocations if float(trade.get("allocation_amount", 0.0) or 0.0) > 0
+    )
+
+    return {
+        "total_allocated_amount": total_allocated_amount,
+        "total_allocated_pct": total_allocated_pct,
+        "cash_reserve_amount": cash_reserve_amount,
+        "cash_reserve_pct": cash_reserve_pct,
+        "funded_trade_count": funded_trade_count,
+    }
+
+
+def split_trades_by_funding(
+    allocations: Sequence[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split allocations into funded and unfunded trades."""
+    funded_trades: list[dict[str, Any]] = []
+    unfunded_trades: list[dict[str, Any]] = []
+
+    for trade in allocations:
+        row = dict(trade)
+        amount = float(row.get("allocation_amount", 0.0) or 0.0)
+        if amount > 0:
+            funded_trades.append(row)
+        else:
+            unfunded_trades.append(row)
+
+    return funded_trades, unfunded_trades
+
+
+def generate_funding_reason(trade: Mapping[str, Any]) -> str:
+    """Generate a compact, user-facing funding reason label."""
+    quality_tier = str(trade.get("quality_tier", "")).strip().upper()
+    if quality_tier == "C":
+        return "Not funded — Tier C"
+
+    liquidity_pass = trade.get("liquidity_pass")
+    if liquidity_pass is False:
+        return "Not funded — Liquidity"
+
+    severity = str(trade.get("earnings_warning_severity", "")).strip().lower()
+    if severity == "high":
+        return "Reduced allocation — Earnings risk"
+
+    volatility_bucket = str(trade.get("volatility_bucket", "")).strip().lower()
+    if volatility_bucket == "high":
+        return "Reduced allocation — High volatility"
+
+    return "Eligible — meets criteria"
+
+
+def render_portfolio_plan(
+    allocations: Sequence[Mapping[str, Any]],
+    total_capital: float,
+    st_module=None,
+) -> None:
+    """Render portfolio summary, funded/unfunded tables, and constraints."""
+    if st_module is None:
+        import streamlit as st_module
+
+    st_module.subheader("Portfolio Plan")
+
+    if not allocations:
+        st_module.info("Portfolio Plan unavailable: no allocation outputs were provided.")
+        return
+
+    summary = build_portfolio_summary(allocations, total_capital)
+    funded_trades, unfunded_trades = split_trades_by_funding(allocations)
+
+    st_module.markdown("#### Portfolio Summary")
+    summary_df = pd.DataFrame(
+        [
+            {
+                "Total Capital": float(total_capital or 0.0),
+                "Allocated Amount": summary["total_allocated_amount"],
+                "Allocated %": summary["total_allocated_pct"],
+                "Cash Reserve Amount": summary["cash_reserve_amount"],
+                "Cash Reserve %": summary["cash_reserve_pct"],
+                "Funded Trades": summary["funded_trade_count"],
+            }
+        ]
+    )
+    st_module.dataframe(summary_df, use_container_width=True)
+
+    st_module.markdown("#### Funded Trades")
+    if funded_trades:
+        funded_df = pd.DataFrame(
+            [
+                {
+                    "Instrument": trade.get("instrument", "Unknown"),
+                    "Quality Tier": trade.get("quality_tier", "N/A"),
+                    "Confidence": trade.get("confidence_label", "N/A"),
+                    "Allocation %": trade.get("allocation_pct", 0.0),
+                    "Allocation Amount": trade.get("allocation_amount", 0.0),
+                    "Funding Note": generate_funding_reason(trade),
+                }
+                for trade in funded_trades
+            ]
+        )
+        st_module.dataframe(funded_df, use_container_width=True)
+    else:
+        st_module.info("No funded trades for the selected inputs.")
+
+    st_module.markdown("#### Unfunded Trades")
+    if unfunded_trades:
+        unfunded_df = pd.DataFrame(
+            [
+                {
+                    "Instrument": trade.get("instrument", "Unknown"),
+                    "Quality Tier": trade.get("quality_tier", "N/A"),
+                    "Confidence": trade.get("confidence_label", "N/A"),
+                    "Reason": generate_funding_reason(trade),
+                }
+                for trade in unfunded_trades
+            ]
+        )
+        st_module.dataframe(unfunded_df, use_container_width=True)
+    else:
+        st_module.info("No unfunded trades for the selected inputs.")
+
+    st_module.markdown("#### Constraints")
+    st_module.markdown(
+        "- Max portfolio exposure: 70%\n"
+        "- Min cash reserve: 30%\n"
+        "- Max funded trades: 3\n"
+        "- Tier C and liquidity failures are not funded"
+    )

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.planner.portfolio_ui import (
+    build_portfolio_summary,
+    generate_funding_reason,
+    split_trades_by_funding,
+)
+
+
+def test_build_portfolio_summary_calculates_totals():
+    summary = build_portfolio_summary(
+        [
+            {"allocation_amount": 25_000},
+            {"allocation_amount": 10_000},
+            {"allocation_amount": 0},
+        ],
+        total_capital=100_000,
+    )
+
+    assert summary["total_allocated_amount"] == 35_000
+    assert summary["total_allocated_pct"] == 0.35
+    assert summary["cash_reserve_amount"] == 65_000
+    assert summary["cash_reserve_pct"] == 0.65
+    assert summary["funded_trade_count"] == 2
+
+
+def test_split_trades_by_funding_separates_rows():
+    funded, unfunded = split_trades_by_funding(
+        [
+            {"instrument": "AAA", "allocation_amount": 100},
+            {"instrument": "BBB", "allocation_amount": 0},
+            {"instrument": "CCC", "allocation_amount": 50},
+        ]
+    )
+
+    assert [row["instrument"] for row in funded] == ["AAA", "CCC"]
+    assert [row["instrument"] for row in unfunded] == ["BBB"]
+
+
+def test_generate_funding_reason_labels():
+    assert generate_funding_reason({"quality_tier": "C"}) == "Not funded — Tier C"
+    assert generate_funding_reason({"liquidity_pass": False}) == "Not funded — Liquidity"
+    assert (
+        generate_funding_reason({"earnings_warning_severity": "high"})
+        == "Reduced allocation — Earnings risk"
+    )
+    assert (
+        generate_funding_reason({"volatility_bucket": "high"})
+        == "Reduced allocation — High volatility"
+    )
+    assert generate_funding_reason({"quality_tier": "A"}) == "Eligible — meets criteria"
+
+
+def test_helpers_handle_missing_optional_fields_gracefully():
+    summary = build_portfolio_summary([{}], total_capital=0)
+    funded, unfunded = split_trades_by_funding([{}])
+    reason = generate_funding_reason({})
+
+    assert summary["total_allocated_amount"] == 0
+    assert summary["cash_reserve_amount"] == 0
+    assert funded == []
+    assert len(unfunded) == 1
+    assert reason == "Eligible — meets criteria"


### PR DESCRIPTION
### Motivation
- Provide a runnable, lightweight Streamlit surface so the planner and analyst outputs can be viewed by users without changing backend engines. 
- Surface portfolio allocation outputs as a readable portfolio plan that separates funded vs unfunded trades and shows summary totals. 
- Keep allocation, confidence, warning, and scoring logic unchanged and build only UI/shell/helpers and tests. 

### Description
- Added top-level Streamlit entrypoint `app.py` which configures the page, loads canonical demo data via `ingest_dataset("demo")`, shows a simple main dashboard, renders Analyst Insights, and exposes a "Portfolio Plan" tab that integrates with the existing allocation engine. 
- Added `app/planner/portfolio_ui.py` implementing `build_portfolio_summary`, `split_trades_by_funding`, `generate_funding_reason`, and `render_portfolio_plan`, with table-first, minimal styling, readable headers, and graceful fallbacks. 
- Introduced a small adapter `_coerce_trade_rows_from_ranked` in `app.py` that maps `run_demo()` ranked outputs to minimal planner trade rows using conservative defaults (`liquidity_pass=True`, `volatility_bucket='medium'`, `earnings_warning_severity='info'`, and a simple `tier -> confidence` mapping) as an integration point without altering engine behavior. 
- Added `app/__init__.py` so the package imports resolve with the new root `app.py`, and `tests/test_portfolio_ui.py` with unit tests for the new helpers. 

### Testing
- Ran `pytest -q tests/test_portfolio_ui.py tests/test_planner_allocation.py tests/test_analyst_insights.py` and all tests passed (25 passed). 
- Unit tests cover portfolio summary calculations, funded/unfunded splitting, funding reason labels, and graceful handling of missing optional fields. 
- No changes were made to signal, scoring, warning, confidence, or allocation engine logic; tests for existing planner allocation and analyst insights were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb223dec6883229d1994a2f4189dc9)