### PR TITLE
Add Streamlit dashboard shell, portfolio UI, shell helpers, and unit tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,85 @@
+"""Streamlit application shell for the JSE Decision Support Dashboard."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from app.data.ingest import ingest_dataset
+from app.demo.run_demo import run_demo
+from app.insights.analyst import render_analyst_insights
+from app.planner.allocation import generate_portfolio_allocation
+from app.planner.portfolio_ui import render_portfolio_plan
+from app.shell import build_analyst_dataset, coerce_trade_rows_from_ranked
+
+
+def main() -> None:
+    """Run the Streamlit shell with Analyst Insights and Portfolio Plan sections."""
+    import streamlit as st
+
+    st.set_page_config(
+        page_title="JSE Decision Support Dashboard",
+        page_icon="📈",
+        layout="wide",
+    )
+
+    st.title("JSE Decision Support Dashboard")
+    st.caption("Sprint 7 shell: dataset loading, Analyst Insights, and Portfolio Plan UI.")
+
+    canonical_df, meta, issues = ingest_dataset("demo")
+    st.markdown("### Data Status")
+    st.write(
+        {
+            "dataset_id": meta.get("dataset_id"),
+            "source": meta.get("source"),
+            "row_count": int(len(canonical_df)),
+            "validation_issues": issues,
+        }
+    )
+
+    if canonical_df.empty:
+        st.warning("No rows were loaded from the data layer. Please verify demo dataset files.")
+        return
+
+    st.markdown("### Main Dashboard")
+    st.dataframe(canonical_df.head(50), use_container_width=True)
+
+    demo_payload = run_demo()
+    ranked_df = demo_payload.get("ranked", pd.DataFrame())
+    analyst_df = build_analyst_dataset(canonical_df, ranked_df)
+
+    insights_tab, plan_tab = st.tabs(["Analyst Insights", "Portfolio Plan"])
+
+    with insights_tab:
+        render_analyst_insights(analyst_df, st_module=st, analyst_mode=True)
+
+    with plan_tab:
+        st.markdown("### Portfolio Plan")
+        total_capital = st.number_input(
+            "Total capital",
+            min_value=0.0,
+            value=100_000.0,
+            step=5_000.0,
+        )
+
+        if ranked_df.empty:
+            st.info("Portfolio Plan unavailable: ranked outputs were not generated.")
+            return
+
+        trade_rows = coerce_trade_rows_from_ranked(ranked_df)
+        allocation_payload = generate_portfolio_allocation(trade_rows, total_capital)
+        allocations = allocation_payload.get("allocations", [])
+
+        # Attach lightweight context fields used by portfolio UI reason labels.
+        enriched_allocations = []
+        for row, allocation in zip(trade_rows, allocations):
+            enriched_allocations.append({**allocation, **row})
+
+        render_portfolio_plan(
+            enriched_allocations,
+            total_capital=total_capital,
+            st_module=st,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package root for decision-support modules."""

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -1,0 +1,171 @@
+"""Streamlit helpers for rendering a user-facing portfolio plan."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+_ALLOCATOR_REASON_KEYS = (
+    "allocation_reason_clear",
+    "allocation_reason_pro",
+    "allocator_reason",
+    "allocation_reason",
+    "reason",
+)
+
+
+def build_portfolio_summary(
+    allocations: Sequence[Mapping[str, Any]],
+    total_capital: float,
+) -> dict[str, Any]:
+    """Build top-line portfolio summary values from allocation rows."""
+    safe_capital = float(total_capital or 0.0)
+    total_allocated_amount = round(
+        sum(float(trade.get("allocation_amount", 0.0) or 0.0) for trade in allocations),
+        2,
+    )
+    total_allocated_pct = (
+        round(total_allocated_amount / safe_capital, 4) if safe_capital > 0 else 0.0
+    )
+    cash_reserve_amount = round(safe_capital - total_allocated_amount, 2)
+    cash_reserve_pct = (
+        round(cash_reserve_amount / safe_capital, 4) if safe_capital > 0 else 0.0
+    )
+    funded_trade_count = sum(
+        1 for trade in allocations if float(trade.get("allocation_amount", 0.0) or 0.0) > 0
+    )
+
+    return {
+        "total_allocated_amount": total_allocated_amount,
+        "total_allocated_pct": total_allocated_pct,
+        "cash_reserve_amount": cash_reserve_amount,
+        "cash_reserve_pct": cash_reserve_pct,
+        "funded_trade_count": funded_trade_count,
+    }
+
+
+def split_trades_by_funding(
+    allocations: Sequence[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split allocations into funded and unfunded trades."""
+    funded_trades: list[dict[str, Any]] = []
+    unfunded_trades: list[dict[str, Any]] = []
+
+    for trade in allocations:
+        row = dict(trade)
+        amount = float(row.get("allocation_amount", 0.0) or 0.0)
+        if amount > 0:
+            funded_trades.append(row)
+        else:
+            unfunded_trades.append(row)
+
+    return funded_trades, unfunded_trades
+
+
+def generate_funding_reason(trade: Mapping[str, Any]) -> str:
+    """Generate a compact, user-facing funding reason label."""
+    quality_tier = str(trade.get("quality_tier", "")).strip().upper()
+    if quality_tier == "C":
+        return "Not funded — Tier C"
+
+    liquidity_pass = trade.get("liquidity_pass")
+    if liquidity_pass is False:
+        return "Not funded — Liquidity"
+
+    severity = str(trade.get("earnings_warning_severity", "")).strip().lower()
+    if severity == "high":
+        return "Reduced allocation — Earnings risk"
+
+    volatility_bucket = str(trade.get("volatility_bucket", "")).strip().lower()
+    if volatility_bucket == "high":
+        return "Reduced allocation — High volatility"
+
+    return "Eligible — meets criteria"
+
+
+def resolve_unfunded_reason(trade: Mapping[str, Any]) -> str:
+    """Resolve unfunded reason preferring allocator output before UI fallback labels."""
+    for key in _ALLOCATOR_REASON_KEYS:
+        value = trade.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return generate_funding_reason(trade)
+
+
+def render_portfolio_plan(
+    allocations: Sequence[Mapping[str, Any]],
+    total_capital: float,
+    st_module=None,
+) -> None:
+    """Render portfolio summary, funded/unfunded tables, and constraints."""
+    if st_module is None:
+        import streamlit as st_module
+
+    st_module.subheader("Portfolio Plan")
+
+    if not allocations:
+        st_module.info("Portfolio Plan unavailable: no allocation outputs were provided.")
+        return
+
+    summary = build_portfolio_summary(allocations, total_capital)
+    funded_trades, unfunded_trades = split_trades_by_funding(allocations)
+
+    st_module.markdown("#### Portfolio Summary")
+    summary_df = pd.DataFrame(
+        [
+            {
+                "Total Capital": float(total_capital or 0.0),
+                "Allocated Amount": summary["total_allocated_amount"],
+                "Allocated %": summary["total_allocated_pct"],
+                "Cash Reserve Amount": summary["cash_reserve_amount"],
+                "Cash Reserve %": summary["cash_reserve_pct"],
+                "Funded Trades": summary["funded_trade_count"],
+            }
+        ]
+    )
+    st_module.dataframe(summary_df, use_container_width=True)
+
+    st_module.markdown("#### Funded Trades")
+    if funded_trades:
+        funded_df = pd.DataFrame(
+            [
+                {
+                    "Instrument": trade.get("instrument", "Unknown"),
+                    "Quality Tier": trade.get("quality_tier", "N/A"),
+                    "Confidence": trade.get("confidence_label", "N/A"),
+                    "Allocation %": trade.get("allocation_pct", 0.0),
+                    "Allocation Amount": trade.get("allocation_amount", 0.0),
+                    "Funding Note": generate_funding_reason(trade),
+                }
+                for trade in funded_trades
+            ]
+        )
+        st_module.dataframe(funded_df, use_container_width=True)
+    else:
+        st_module.info("No funded trades for the selected inputs.")
+
+    st_module.markdown("#### Unfunded Trades")
+    if unfunded_trades:
+        unfunded_df = pd.DataFrame(
+            [
+                {
+                    "Instrument": trade.get("instrument", "Unknown"),
+                    "Quality Tier": trade.get("quality_tier", "N/A"),
+                    "Confidence": trade.get("confidence_label", "N/A"),
+                    "Reason": resolve_unfunded_reason(trade),
+                }
+                for trade in unfunded_trades
+            ]
+        )
+        st_module.dataframe(unfunded_df, use_container_width=True)
+    else:
+        st_module.info("No unfunded trades for the selected inputs.")
+
+    st_module.markdown("#### Constraints")
+    st_module.markdown(
+        "- Max portfolio exposure: 70%\n"
+        "- Min cash reserve: 30%\n"
+        "- Max funded trades: 3\n"
+        "- Tier C and liquidity failures are not funded"
+    )

--- a/app/shell.py
+++ b/app/shell.py
@@ -1,0 +1,41 @@
+"""Shared shell helpers for the Streamlit app entrypoint."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from app.costs.engine import run_cost_engine
+
+
+def coerce_trade_rows_from_ranked(ranked_df: pd.DataFrame) -> list[dict]:
+    """Build minimal planner trade rows from ranked outputs for UI wiring."""
+    trade_rows: list[dict] = []
+    for row in ranked_df.to_dict("records"):
+        quality_tier = str(row.get("tier", "B") or "B")
+        trade_rows.append(
+            {
+                "instrument": row.get("instrument", "Unknown"),
+                "quality_tier": quality_tier,
+                "liquidity_pass": True,
+                "volatility_bucket": "medium",
+                "earnings_warning_severity": "info",
+                "confidence_label": "strong" if quality_tier.upper() == "A" else "moderate",
+            }
+        )
+    return trade_rows
+
+
+def build_analyst_dataset(canonical_df: pd.DataFrame, ranked_df: pd.DataFrame) -> pd.DataFrame:
+    """Build a return-bearing dataset for Analyst Insights from existing demo outputs."""
+    entries = canonical_df[["instrument", "date"]].rename(columns={"date": "entry_date"})
+    trades_df, _, _, _ = run_cost_engine(
+        df_prices=canonical_df,
+        df_entries=entries,
+    )
+
+    if ranked_df.empty:
+        return trades_df
+
+    tier_lookup = ranked_df[["instrument", "tier"]].rename(columns={"tier": "quality_tier"})
+    enriched = trades_df.merge(tier_lookup, on="instrument", how="left")
+    return enriched

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.shell import build_analyst_dataset
+
+
+def test_build_analyst_dataset_returns_return_bearing_trades_with_quality_tier(monkeypatch):
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["AAA", "BBB"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-01"]),
+            "close": [10.0, 20.0],
+            "volume": [1000, 900],
+        }
+    )
+    ranked_df = pd.DataFrame({"instrument": ["AAA", "BBB"], "tier": ["A", "B"]})
+
+    trades_stub = pd.DataFrame(
+        {
+            "instrument": ["AAA", "BBB"],
+            "holding_window": [10, 10],
+            "net_return_pct": [0.02, -0.01],
+        }
+    )
+
+    def fake_run_cost_engine(df_prices, df_entries):
+        assert not df_prices.empty
+        assert not df_entries.empty
+        return trades_stub, pd.DataFrame(), None, None
+
+    monkeypatch.setattr("app.shell.run_cost_engine", fake_run_cost_engine)
+
+    analyst_df = build_analyst_dataset(canonical_df, ranked_df)
+
+    assert "net_return_pct" in analyst_df.columns
+    assert "quality_tier" in analyst_df.columns
+    assert list(analyst_df["quality_tier"]) == ["A", "B"]
+
+
+def test_build_analyst_dataset_handles_empty_ranked_df(monkeypatch):
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["AAA"],
+            "date": pd.to_datetime(["2024-01-01"]),
+            "close": [10.0],
+            "volume": [1000],
+        }
+    )
+
+    trades_stub = pd.DataFrame(
+        {
+            "instrument": ["AAA"],
+            "holding_window": [10],
+            "net_return_pct": [0.03],
+        }
+    )
+
+    monkeypatch.setattr(
+        "app.shell.run_cost_engine",
+        lambda df_prices, df_entries: (trades_stub, pd.DataFrame(), None, None),
+    )
+
+    analyst_df = build_analyst_dataset(canonical_df, pd.DataFrame())
+
+    assert "net_return_pct" in analyst_df.columns
+    assert "quality_tier" not in analyst_df.columns

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -1,0 +1,175 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.planner.portfolio_ui import (
+    build_portfolio_summary,
+    generate_funding_reason,
+    render_portfolio_plan,
+    resolve_unfunded_reason,
+    split_trades_by_funding,
+)
+
+
+class DummyStreamlit:
+    def __init__(self):
+        self.dataframes = []
+        self.info_messages = []
+
+    def subheader(self, _text):
+        return None
+
+    def markdown(self, _text):
+        return None
+
+    def info(self, text):
+        self.info_messages.append(text)
+
+    def dataframe(self, df, use_container_width=False):
+        self.dataframes.append((df.copy(), use_container_width))
+
+
+def test_build_portfolio_summary_calculates_totals():
+    summary = build_portfolio_summary(
+        [
+            {"allocation_amount": 25_000},
+            {"allocation_amount": 10_000},
+            {"allocation_amount": 0},
+        ],
+        total_capital=100_000,
+    )
+
+    assert summary["total_allocated_amount"] == 35_000
+    assert summary["total_allocated_pct"] == 0.35
+    assert summary["cash_reserve_amount"] == 65_000
+    assert summary["cash_reserve_pct"] == 0.65
+    assert summary["funded_trade_count"] == 2
+
+
+def test_split_trades_by_funding_separates_rows():
+    funded, unfunded = split_trades_by_funding(
+        [
+            {"instrument": "AAA", "allocation_amount": 100},
+            {"instrument": "BBB", "allocation_amount": 0},
+            {"instrument": "CCC", "allocation_amount": 50},
+        ]
+    )
+
+    assert [row["instrument"] for row in funded] == ["AAA", "CCC"]
+    assert [row["instrument"] for row in unfunded] == ["BBB"]
+
+
+def test_generate_funding_reason_labels():
+    assert generate_funding_reason({"quality_tier": "C"}) == "Not funded — Tier C"
+    assert generate_funding_reason({"liquidity_pass": False}) == "Not funded — Liquidity"
+    assert (
+        generate_funding_reason({"earnings_warning_severity": "high"})
+        == "Reduced allocation — Earnings risk"
+    )
+    assert (
+        generate_funding_reason({"volatility_bucket": "high"})
+        == "Reduced allocation — High volatility"
+    )
+    assert generate_funding_reason({"quality_tier": "A"}) == "Eligible — meets criteria"
+
+
+def test_helpers_handle_missing_optional_fields_gracefully():
+    summary = build_portfolio_summary([{}], total_capital=0)
+    funded, unfunded = split_trades_by_funding([{}])
+    reason = generate_funding_reason({})
+
+    assert summary["total_allocated_amount"] == 0
+    assert summary["cash_reserve_amount"] == 0
+    assert funded == []
+    assert len(unfunded) == 1
+    assert reason == "Eligible — meets criteria"
+
+
+def test_unfunded_reason_prefers_allocator_reason_field():
+    trade = {
+        "allocation_amount": 0,
+        "quality_tier": "A",
+        "allocation_reason_clear": "Constraint limited — max funded trades reached",
+    }
+    assert (
+        resolve_unfunded_reason(trade)
+        == "Constraint limited — max funded trades reached"
+    )
+
+
+def test_unfunded_reason_falls_back_when_allocator_reason_missing():
+    trade = {
+        "allocation_amount": 0,
+        "quality_tier": "C",
+    }
+    assert resolve_unfunded_reason(trade) == "Not funded — Tier C"
+
+
+
+
+def test_unfunded_reason_uses_new_priority_order():
+    trade = {
+        "allocation_amount": 0,
+        "allocation_reason_clear": "Clear reason",
+        "allocation_reason_pro": "Pro reason",
+        "allocator_reason": "Allocator reason",
+        "allocation_reason": "Allocation reason",
+        "reason": "Generic reason",
+    }
+    assert resolve_unfunded_reason(trade) == "Clear reason"
+
+def test_render_portfolio_plan_unfunded_table_shows_allocator_reason():
+    st = DummyStreamlit()
+    render_portfolio_plan(
+        allocations=[
+            {"instrument": "AAA", "allocation_amount": 1000, "quality_tier": "A"},
+            {
+                "instrument": "BBB",
+                "allocation_amount": 0,
+                "quality_tier": "A",
+                "allocation_reason_clear": "Constraint limited — max funded trades reached",
+            },
+        ],
+        total_capital=10_000,
+        st_module=st,
+    )
+
+    unfunded_df = st.dataframes[2][0]
+    assert unfunded_df.iloc[0]["Reason"] == "Constraint limited — max funded trades reached"
+
+
+def test_render_portfolio_plan_funded_rows_work_with_or_without_allocator_reason():
+    st = DummyStreamlit()
+    render_portfolio_plan(
+        allocations=[
+            {
+                "instrument": "AAA",
+                "allocation_amount": 1000,
+                "allocation_pct": 0.1,
+                "quality_tier": "A",
+                "allocator_reason": "ignored for funded note",
+            },
+            {
+                "instrument": "CCC",
+                "allocation_amount": 500,
+                "allocation_pct": 0.05,
+                "quality_tier": "B",
+            },
+            {
+                "instrument": "BBB",
+                "allocation_amount": 0,
+                "quality_tier": "C",
+            },
+        ],
+        total_capital=10_000,
+        st_module=st,
+    )
+
+    funded_df = st.dataframes[1][0]
+    assert list(funded_df["Instrument"]) == ["AAA", "CCC"]
+    assert list(funded_df["Funding Note"]) == [
+        "Eligible — meets criteria",
+        "Eligible — meets criteria",
+    ]


### PR DESCRIPTION
### Motivation
- Provide a Sprint 7 Streamlit shell for the JSE Decision Support Dashboard that includes dataset loading, Analyst Insights, and a Portfolio Plan UI.
- Surface portfolio allocation outputs and lightweight planner context to enable a user-facing funding view and reasons for funded/unfunded trades.
- Encapsulate shared wiring between ranked outputs and planner/analyst views and add unit tests to validate the UI helpers and shell logic.

### Description
- Add `app.py` Streamlit entrypoint that loads the demo dataset via `ingest_dataset`, displays data status, runs `run_demo`, builds the analyst dataset via `build_analyst_dataset`, and renders tabs for `render_analyst_insights` and `render_portfolio_plan` while wiring `coerce_trade_rows_from_ranked` and `generate_portfolio_allocation`.
- Add `app/planner/portfolio_ui.py` implementing `build_portfolio_summary`, `split_trades_by_funding`, `generate_funding_reason`, `resolve_unfunded_reason`, and `render_portfolio_plan` to render portfolio summary, funded/unfunded tables, and constraint notes.
- Add `app/shell.py` with `coerce_trade_rows_from_ranked` to build minimal planner rows from ranked outputs and `build_analyst_dataset` that reuses `run_cost_engine` to produce return-bearing analyst datasets and merge quality tiers from ranked outputs when present.
- Add package root `app/__init__.py` and unit tests `tests/test_app_shell.py` and `tests/test_portfolio_ui.py` to validate shell behavior and portfolio UI helper logic.

### Testing
- Ran unit tests with `pytest tests/test_app_shell.py tests/test_portfolio_ui.py` and all tests passed.
- Tests cover `build_analyst_dataset` merging tier metadata and handling empty ranked outputs and cover portfolio UI helpers including summary calculations, funding splits, reason generation, and `render_portfolio_plan` output formatting.
- No automated UI/end-to-end Streamlit tests were included in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb223dec6883229d1994a2f4189dc9)