### PR TITLE
Add embedded insight layer and portfolio explanation helpers; surface explanations in UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import pandas as pd
 from app.data.ingest import ingest_dataset
 from app.demo.run_demo import run_demo
 from app.insights.analyst import render_analyst_insights
+from app.insights.embedded import generate_embedded_insights, render_embedded_insights
 from app.planner.allocation import generate_portfolio_allocation
 from app.planner.portfolio_ui import render_portfolio_plan
 from app.shell import build_analyst_dataset, coerce_trade_rows_from_ranked
@@ -23,7 +24,7 @@ def main() -> None:
     )
 
     st.title("JSE Decision Support Dashboard")
-    st.caption("Sprint 7 shell: dataset loading, Analyst Insights, and Portfolio Plan UI.")
+    st.caption("Sprint 8 shell: dataset loading, Analyst Insights, Portfolio Plan, and Explanation Layer.")
 
     canonical_df, meta, issues = ingest_dataset("demo")
     st.markdown("### Data Status")
@@ -73,6 +74,9 @@ def main() -> None:
         enriched_allocations = []
         for row, allocation in zip(trade_rows, allocations):
             enriched_allocations.append({**allocation, **row})
+
+        insights_payload = generate_embedded_insights(trade_rows, enriched_allocations)
+        render_embedded_insights(insights_payload, st_module=st)
 
         render_portfolio_plan(
             enriched_allocations,

--- a/app/insights/embedded.py
+++ b/app/insights/embedded.py
@@ -1,0 +1,211 @@
+"""Embedded in-app insight layer for observational portfolio commentary."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+def generate_embedded_insights(
+    trade_rows: Sequence[Mapping[str, Any]],
+    allocations: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, list[str]]:
+    """Return neutral, plain-language insights for current planner data."""
+    rows = [dict(row) for row in trade_rows]
+    allocs = [dict(row) for row in allocations] if allocations is not None else []
+
+    what_is_happening: list[str] = []
+    what_to_watch: list[str] = []
+
+    volatility_line = _volatility_insight(rows)
+    if volatility_line:
+        what_is_happening.append(volatility_line)
+
+    tier_line = _tier_insight(rows)
+    if tier_line:
+        what_is_happening.append(tier_line)
+
+    selection_line = _selection_insight(allocs)
+    if selection_line:
+        what_is_happening.append(selection_line)
+
+    consistency_line = _consistency_insight(rows)
+    if consistency_line:
+        what_to_watch.append(consistency_line)
+
+    holding_line = _holding_window_insight(rows)
+    if holding_line:
+        what_to_watch.append(holding_line)
+
+    risk_line = _risk_signal_insight(rows)
+    if risk_line:
+        what_to_watch.append(risk_line)
+
+    if not what_is_happening:
+        what_is_happening.append("Right now, data look limited, so system observations are basic.")
+    if not what_to_watch:
+        what_to_watch.append("Watchlist is light right now because key comparison fields are missing.")
+
+    return {
+        "what_is_happening": what_is_happening[:3],
+        "what_to_watch": what_to_watch[:3],
+    }
+
+
+def render_embedded_insights(insights: Mapping[str, Sequence[str]], *, st_module=None) -> None:
+    """Render embedded insights as simple bullet lists."""
+    if st_module is None:
+        import streamlit as st_module
+
+    st_module.markdown("#### Embedded Insight Layer")
+    st_module.markdown("**What is happening**")
+    for line in insights.get("what_is_happening", []):
+        st_module.markdown(f"- {line}")
+
+    st_module.markdown("**What to watch**")
+    for line in insights.get("what_to_watch", []):
+        st_module.markdown(f"- {line}")
+
+
+def _volatility_insight(rows: Sequence[Mapping[str, Any]]) -> str:
+    counts = _count_tokens(rows, "volatility_bucket")
+    total = sum(counts.values())
+    if total == 0:
+        return ""
+
+    top_bucket = max(counts, key=counts.get)
+    share = counts[top_bucket] / total
+
+    if top_bucket == "high" and share >= 0.5:
+        return "High volatility dominate now, so price swings look sharper across most setups."
+    if top_bucket == "medium" and share >= 0.5:
+        return "Medium volatility dominate now, so market movement look more steady than extreme."
+    if top_bucket == "low" and share >= 0.5:
+        return "Low volatility dominate now, so movement look calmer in most setups."
+
+    return "Volatility mix broad right now, with no single bucket fully dominating."
+
+
+def _tier_insight(rows: Sequence[Mapping[str, Any]]) -> str:
+    counts = _count_tokens(rows, "quality_tier", uppercase=True)
+    total = sum(counts.values())
+    if total == 0:
+        return ""
+
+    tier_a_share = counts.get("A", 0) / total
+    if tier_a_share >= 0.5:
+        return "Tier A setups make up most rows, so stronger-quality setups are leading the slate."
+
+    top_tier = max(counts, key=counts.get)
+    return f"Tier {top_tier} appears most often in current rows."
+
+
+def _selection_insight(allocs: Sequence[Mapping[str, Any]]) -> str:
+    if not allocs:
+        return ""
+
+    funded = sum(1 for row in allocs if float(row.get("allocation_amount", 0.0) or 0.0) > 0)
+    eligible_unfunded = sum(
+        1
+        for row in allocs
+        if bool(row.get("eligible_for_funding"))
+        and float(row.get("allocation_amount", 0.0) or 0.0) <= 0
+    )
+
+    if eligible_unfunded > 0:
+        return (
+            f"{funded} trade(s) funded, while {eligible_unfunded} eligible trade(s) stayed out due to ranking and limits."
+        )
+    return f"{funded} trade(s) funded, and no eligible trade was left outside funded positions."
+
+
+def _consistency_insight(rows: Sequence[Mapping[str, Any]]) -> str:
+    avg = _mean_numeric(rows, "avg_return")
+    median = _mean_numeric(rows, "median_return")
+    if avg is None or median is None:
+        return ""
+
+    gap = avg - median
+    if gap > max(0.01, abs(median) * 0.5):
+        return "Average return sits well above median return, so outcomes look uneven across trades."
+    return "Average and median return are close, so outcomes look more consistent right now."
+
+
+def _holding_window_insight(rows: Sequence[Mapping[str, Any]]) -> str:
+    grouped: dict[int, list[float]] = {}
+    for row in rows:
+        window = _int_or_none(row.get("holding_window"))
+        win_rate = _float_or_none(row.get("win_rate"))
+        if window is None or win_rate is None:
+            continue
+        grouped.setdefault(window, []).append(win_rate)
+
+    if len(grouped) < 2:
+        return ""
+
+    shortest = min(grouped)
+    longest = max(grouped)
+    short_wr = sum(grouped[shortest]) / len(grouped[shortest])
+    long_wr = sum(grouped[longest]) / len(grouped[longest])
+
+    if short_wr >= long_wr + 0.10:
+        return f"Short holding window ({shortest}D) shows steadier hit rate than long window ({longest}D)."
+    if long_wr >= short_wr + 0.10:
+        return f"Long holding window ({longest}D) looks steadier than short window ({shortest}D)."
+
+    return f"Short ({shortest}D) and long ({longest}D) windows show similar stability right now."
+
+
+def _risk_signal_insight(rows: Sequence[Mapping[str, Any]]) -> str:
+    win_rate = _mean_numeric(rows, "win_rate")
+    avg_return = _mean_numeric(rows, "avg_return")
+    if win_rate is None or avg_return is None:
+        return ""
+
+    if win_rate < 0.45 and avg_return > 0.01:
+        return "Win rate is low while average return is high, so current return profile looks high-variance."
+    return "Win rate and average return are moving in a balanced range for now."
+
+
+def _count_tokens(
+    rows: Sequence[Mapping[str, Any]],
+    field: str,
+    *,
+    uppercase: bool = False,
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        raw = row.get(field)
+        if raw is None:
+            continue
+        token = str(raw).strip()
+        if not token:
+            continue
+        token = token.upper() if uppercase else token.lower()
+        counts[token] = counts.get(token, 0) + 1
+    return counts
+
+
+def _mean_numeric(rows: Sequence[Mapping[str, Any]], field: str) -> float | None:
+    values = [_float_or_none(row.get(field)) for row in rows]
+    clean = [value for value in values if value is not None]
+    if not clean:
+        return None
+    return sum(clean) / len(clean)
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/app/planner/allocation.py
+++ b/app/planner/allocation.py
@@ -67,7 +67,7 @@ def generate_portfolio_allocation(
     funded_count = 0
     allocations_by_idx: dict[int, dict[str, Any]] = {}
 
-    for item in ordered_rows:
+    for order_idx, item in enumerate(ordered_rows, start=1):
         row = item["row"]
         instrument = _display_text(row.get("instrument"), fallback="Unknown")
         preconstraint_pct = item["preconstraint_pct"]
@@ -94,6 +94,10 @@ def generate_portfolio_allocation(
             "confidence_label": item["confidence_label"],
             "allocation_pct": round(allocation_pct, 4),
             "allocation_amount": round(allocation_pct * float(total_capital), 2),
+            "selection_rank": order_idx,
+            "funded_rank": funded_count if allocation_pct > 0 else None,
+            "eligible_for_funding": bool(item["hard_stop_reason"] is None and preconstraint_pct > 0),
+            "max_funded_trades": MAX_FUNDED_TRADES,
             "allocation_reason_clear": _build_reason_clear(
                 item,
                 allocation_pct,

--- a/app/planner/explanations.py
+++ b/app/planner/explanations.py
@@ -1,0 +1,178 @@
+"""Plain-language explanation helpers for portfolio funding decisions."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+REASON_KEYS = (
+    "allocation_reason_clear",
+    "allocation_reason_pro",
+    "allocator_reason",
+    "allocation_reason",
+    "reason",
+)
+
+_HARD_STOP_MARKERS = (
+    "tier c",
+    "quality tier c",
+    "low tier",
+    "liquidity",
+    "not eligible",
+    "ineligible",
+    "hard rule",
+    "hard-stop",
+)
+
+_CONSTRAINT_MARKERS = (
+    "max funded trades",
+    "max portfolio exposure",
+    "capacity",
+)
+
+
+def resolve_explicit_reason(trade: Mapping[str, Any]) -> str:
+    """Return allocator-provided reason text using priority order."""
+    for key in REASON_KEYS:
+        value = trade.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def classify_decision_status(trade: Mapping[str, Any]) -> str:
+    """Classify funded/unfunded outcomes for explanation display."""
+    allocation_amount = float(trade.get("allocation_amount", 0.0) or 0.0)
+    if allocation_amount > 0:
+        return "funded"
+
+    explicit_reason = _token(resolve_explicit_reason(trade))
+    if _is_hard_stop(trade, explicit_reason):
+        return "not eligible"
+
+    if any(marker in explicit_reason for marker in _CONSTRAINT_MARKERS):
+        return "eligible but constrained"
+
+    return "unfunded"
+
+
+def explain_portfolio_decision(trade: Mapping[str, Any]) -> str:
+    """Explain why a trade was funded or not funded using available planner fields."""
+    status = classify_decision_status(trade)
+    explicit_reason = resolve_explicit_reason(trade)
+
+    if status == "funded":
+        if explicit_reason:
+            base_text = f"Funded. {explicit_reason}"
+        else:
+            allocation_pct = float(trade.get("allocation_pct", 0.0) or 0.0)
+            base_text = f"Funded. Final allocation is {allocation_pct:.0%}."
+        return _append_ranking_context(base_text, trade, status)
+
+    if explicit_reason:
+        base_text = f"Not funded. {explicit_reason}"
+        return _append_ranking_context(base_text, trade, status)
+
+    quality_tier = _token(trade.get("quality_tier")).upper()
+    if quality_tier == "C":
+        return "Not funded. Trade is not eligible because quality tier C is excluded by rule."
+
+    if trade.get("liquidity_pass") is False:
+        return "Not funded. Trade is not eligible because the liquidity screen failed."
+
+    if status == "eligible but constrained":
+        base_text = "Not funded. Trade was eligible, but portfolio constraints prevented funding."
+        return _append_ranking_context(base_text, trade, status)
+
+    severity = _token(trade.get("earnings_warning_severity"))
+    volatility = _token(trade.get("volatility_bucket"))
+    if severity == "high" or volatility == "high":
+        return "Not funded. Trade remained eligible, but risk adjustments reduced allocation to zero."
+
+    return _append_ranking_context(
+        "Not funded. No explicit allocator reason was provided in this output.",
+        trade,
+        status,
+    )
+
+
+def explain_primary_rule_or_constraint(trade: Mapping[str, Any]) -> str:
+    """Describe the main rule/constraint affecting the outcome."""
+    explicit_reason = _token(resolve_explicit_reason(trade))
+
+    if _is_hard_stop(trade, explicit_reason):
+        quality_tier = _token(trade.get("quality_tier")).upper()
+        if quality_tier == "C" or "tier c" in explicit_reason:
+            return "Primary driver: quality tier C rule."
+        if trade.get("liquidity_pass") is False or "liquidity" in explicit_reason:
+            return "Primary driver: liquidity eligibility rule."
+        return "Primary driver: eligibility hard-stop rule."
+
+    if "max funded trades" in explicit_reason:
+        return "Primary driver: max funded trades limit."
+    if "max portfolio exposure" in explicit_reason:
+        return "Primary driver: max portfolio exposure limit."
+    if "capacity" in explicit_reason:
+        return "Primary driver: portfolio constraint."
+
+    severity = _token(trade.get("earnings_warning_severity"))
+    volatility = _token(trade.get("volatility_bucket"))
+    if severity == "high" or volatility == "high":
+        return "Primary driver: risk adjustment factors."
+
+    return "Primary driver: no explicit rule or constraint label available."
+
+
+def _append_ranking_context(base_text: str, trade: Mapping[str, Any], status: str) -> str:
+    rank = _int_or_none(trade.get("selection_rank"))
+    funded_rank = _int_or_none(trade.get("funded_rank"))
+    eligible = bool(trade.get("eligible_for_funding"))
+    explicit_reason = _token(resolve_explicit_reason(trade))
+
+    if status == "funded" and funded_rank is not None:
+        if funded_rank == 1:
+            return base_text + " Ranked #1 among eligible trades and selected as a top-ranked eligible trade."
+        return (
+            base_text
+            + f" Ranked #{funded_rank} among funded positions and selected ahead of lower-priority eligible trades."
+        )
+
+    if status == "eligible but constrained" and rank is not None:
+        if "max funded trades" in explicit_reason:
+            return (
+                base_text
+                + f" Trade remained eligible at rank #{rank}, but funded slots were filled before this position."
+            )
+        if "max portfolio exposure" in explicit_reason:
+            return (
+                base_text
+                + f" Trade remained eligible at rank #{rank}, but portfolio exposure was fully used before this position."
+            )
+
+    if status == "unfunded" and eligible and rank is not None:
+        return base_text + f" Trade remained eligible but finished outside funded positions at rank #{rank}."
+
+    return base_text
+
+
+def _is_hard_stop(trade: Mapping[str, Any], explicit_reason: str) -> bool:
+    quality_tier = _token(trade.get("quality_tier")).upper()
+    if quality_tier == "C":
+        return True
+    if trade.get("liquidity_pass") is False:
+        return True
+    return any(marker in explicit_reason for marker in _HARD_STOP_MARKERS)
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _token(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().lower()

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -6,13 +6,16 @@ from typing import Any, Mapping, Sequence
 
 import pandas as pd
 
-_ALLOCATOR_REASON_KEYS = (
-    "allocation_reason_clear",
-    "allocation_reason_pro",
-    "allocator_reason",
-    "allocation_reason",
-    "reason",
+from app.planner.explanations import (
+    REASON_KEYS,
+    classify_decision_status,
+    explain_portfolio_decision,
+    explain_primary_rule_or_constraint,
+    resolve_explicit_reason,
 )
+
+
+_ALLOCATOR_REASON_KEYS = REASON_KEYS
 
 
 def build_portfolio_summary(
@@ -64,33 +67,16 @@ def split_trades_by_funding(
 
 
 def generate_funding_reason(trade: Mapping[str, Any]) -> str:
-    """Generate a compact, user-facing funding reason label."""
-    quality_tier = str(trade.get("quality_tier", "")).strip().upper()
-    if quality_tier == "C":
-        return "Not funded — Tier C"
-
-    liquidity_pass = trade.get("liquidity_pass")
-    if liquidity_pass is False:
-        return "Not funded — Liquidity"
-
-    severity = str(trade.get("earnings_warning_severity", "")).strip().lower()
-    if severity == "high":
-        return "Reduced allocation — Earnings risk"
-
-    volatility_bucket = str(trade.get("volatility_bucket", "")).strip().lower()
-    if volatility_bucket == "high":
-        return "Reduced allocation — High volatility"
-
-    return "Eligible — meets criteria"
+    """Generate a compact funding explanation using explicit reasons first."""
+    return explain_portfolio_decision(trade)
 
 
 def resolve_unfunded_reason(trade: Mapping[str, Any]) -> str:
-    """Resolve unfunded reason preferring allocator output before UI fallback labels."""
-    for key in _ALLOCATOR_REASON_KEYS:
-        value = trade.get(key)
-        if value is not None and str(value).strip():
-            return str(value).strip()
-    return generate_funding_reason(trade)
+    """Resolve unfunded reason preferring allocator output before fallback labels."""
+    explicit_reason = resolve_explicit_reason(trade)
+    if explicit_reason:
+        return explicit_reason
+    return explain_portfolio_decision(trade)
 
 
 def render_portfolio_plan(
@@ -103,6 +89,9 @@ def render_portfolio_plan(
         import streamlit as st_module
 
     st_module.subheader("Portfolio Plan")
+    st_module.caption(
+        "Funded trades received non-zero allocation. Unfunded trades remained at 0% after eligibility rules and portfolio constraints were applied."
+    )
 
     if not allocations:
         st_module.info("Portfolio Plan unavailable: no allocation outputs were provided.")
@@ -136,7 +125,10 @@ def render_portfolio_plan(
                     "Confidence": trade.get("confidence_label", "N/A"),
                     "Allocation %": trade.get("allocation_pct", 0.0),
                     "Allocation Amount": trade.get("allocation_amount", 0.0),
-                    "Funding Note": generate_funding_reason(trade),
+                    "Selection Rank": trade.get("selection_rank", "N/A"),
+                    "Decision Status": classify_decision_status(trade),
+                    "Explanation": explain_portfolio_decision(trade),
+                    "Primary Rule/Constraint": explain_primary_rule_or_constraint(trade),
                 }
                 for trade in funded_trades
             ]
@@ -153,7 +145,11 @@ def render_portfolio_plan(
                     "Instrument": trade.get("instrument", "Unknown"),
                     "Quality Tier": trade.get("quality_tier", "N/A"),
                     "Confidence": trade.get("confidence_label", "N/A"),
+                    "Selection Rank": trade.get("selection_rank", "N/A"),
+                    "Decision Status": classify_decision_status(trade),
                     "Reason": resolve_unfunded_reason(trade),
+                    "Explanation": explain_portfolio_decision(trade),
+                    "Primary Rule/Constraint": explain_primary_rule_or_constraint(trade),
                 }
                 for trade in unfunded_trades
             ]

--- a/tests/test_embedded_insights.py
+++ b/tests/test_embedded_insights.py
@@ -1,0 +1,73 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.insights.embedded import generate_embedded_insights
+
+
+def test_embedded_insights_returns_both_sections_and_max_three_items():
+    trade_rows = [
+        {
+            "quality_tier": "A",
+            "volatility_bucket": "medium",
+            "win_rate": 0.62,
+            "avg_return": 0.03,
+            "median_return": 0.02,
+            "holding_window": 5,
+        },
+        {
+            "quality_tier": "A",
+            "volatility_bucket": "medium",
+            "win_rate": 0.48,
+            "avg_return": 0.04,
+            "median_return": 0.01,
+            "holding_window": 20,
+        },
+    ]
+    allocations = [
+        {"allocation_amount": 10_000, "eligible_for_funding": True},
+        {"allocation_amount": 0, "eligible_for_funding": True},
+    ]
+
+    payload = generate_embedded_insights(trade_rows, allocations)
+
+    assert set(payload.keys()) == {"what_is_happening", "what_to_watch"}
+    assert 1 <= len(payload["what_is_happening"]) <= 3
+    assert 1 <= len(payload["what_to_watch"]) <= 3
+
+
+def test_embedded_insights_flags_inconsistency_when_avg_far_above_median():
+    payload = generate_embedded_insights(
+        [
+            {
+                "quality_tier": "B",
+                "volatility_bucket": "high",
+                "win_rate": 0.40,
+                "avg_return": 0.05,
+                "median_return": 0.01,
+                "holding_window": 10,
+            },
+            {
+                "quality_tier": "B",
+                "volatility_bucket": "high",
+                "win_rate": 0.42,
+                "avg_return": 0.04,
+                "median_return": 0.01,
+                "holding_window": 20,
+            },
+        ],
+        [{"allocation_amount": 0, "eligible_for_funding": True}],
+    )
+
+    joined = " ".join(payload["what_to_watch"]).lower()
+    assert "average return sits well above median return" in joined
+    assert "high-variance" in joined
+
+
+def test_embedded_insights_fallback_when_data_is_limited():
+    payload = generate_embedded_insights([], [])
+
+    assert payload["what_is_happening"]
+    assert payload["what_to_watch"]

--- a/tests/test_planner_allocation.py
+++ b/tests/test_planner_allocation.py
@@ -165,6 +165,10 @@ def test_output_structure_is_stable():
         "confidence_label",
         "allocation_pct",
         "allocation_amount",
+        "selection_rank",
+        "funded_rank",
+        "eligible_for_funding",
+        "max_funded_trades",
         "allocation_reason_clear",
         "allocation_reason_pro",
     }
@@ -246,3 +250,33 @@ def test_total_allocated_plus_cash_reserve_reconciles_to_capital():
         2,
     )
     assert reconciled_total == round(total_capital, 2)
+
+
+def test_allocation_outputs_selection_rank_and_funded_rank_fields():
+    payload = generate_portfolio_allocation(
+        [
+            {
+                "instrument": "S1",
+                "quality_tier": "A",
+                "liquidity_pass": True,
+                "volatility_bucket": "low",
+                "earnings_warning_severity": "info",
+                "confidence_label": "strong",
+            },
+            {
+                "instrument": "S2",
+                "quality_tier": "A",
+                "liquidity_pass": True,
+                "volatility_bucket": "low",
+                "earnings_warning_severity": "info",
+                "confidence_label": "moderate",
+            },
+        ],
+        100_000,
+    )
+
+    by_symbol = {row["instrument"]: row for row in payload["allocations"]}
+    assert by_symbol["S1"]["selection_rank"] == 1
+    assert by_symbol["S1"]["funded_rank"] == 1
+    assert by_symbol["S2"]["selection_rank"] == 2
+    assert by_symbol["S2"]["eligible_for_funding"] is True

--- a/tests/test_planner_explanations.py
+++ b/tests/test_planner_explanations.py
@@ -1,0 +1,110 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.planner.explanations import (
+    classify_decision_status,
+    explain_portfolio_decision,
+    explain_primary_rule_or_constraint,
+    resolve_explicit_reason,
+)
+
+
+def test_resolve_explicit_reason_uses_priority_order():
+    trade = {
+        "allocation_reason_pro": "pro reason",
+        "allocation_reason_clear": "clear reason",
+        "allocator_reason": "allocator reason",
+    }
+    assert resolve_explicit_reason(trade) == "clear reason"
+
+
+def test_funded_top_ranked_explanation_is_added_when_rank_fields_available():
+    text = explain_portfolio_decision(
+        {
+            "allocation_amount": 10_000,
+            "allocation_pct": 0.30,
+            "selection_rank": 1,
+            "funded_rank": 1,
+            "eligible_for_funding": True,
+        }
+    )
+    assert "top-ranked eligible trade" in text
+
+
+def test_eligible_but_ranked_outside_funded_positions_explains_priority_limit():
+    text = explain_portfolio_decision(
+        {
+            "allocation_amount": 0,
+            "selection_rank": 4,
+            "eligible_for_funding": True,
+            "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
+        }
+    )
+    assert classify_decision_status(
+        {
+            "allocation_amount": 0,
+            "selection_rank": 4,
+            "eligible_for_funding": True,
+            "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
+        }
+    ) == "eligible but constrained"
+    assert "funded slots were filled" in text
+
+
+def test_hard_stop_stays_not_eligible_even_if_constraint_word_appears():
+    trade = {
+        "allocation_amount": 0,
+        "quality_tier": "C",
+        "allocation_reason_clear": "Hard rule applied: quality tier C is not funded; portfolio constraint context present.",
+    }
+
+    assert classify_decision_status(trade) == "not eligible"
+    assert explain_primary_rule_or_constraint(trade) == "Primary driver: quality tier C rule."
+
+
+def test_preconstraints_text_is_not_classified_as_constrained():
+    trade = {
+        "allocation_amount": 0,
+        "quality_tier": "A",
+        "liquidity_pass": True,
+        "allocation_reason_clear": "Final allocation is 0% because pre-constraints reduced allocation to zero.",
+    }
+
+    assert classify_decision_status(trade) == "unfunded"
+
+
+def test_genuine_exposure_constraint_is_classified_as_constrained():
+    trade = {
+        "allocation_amount": 0,
+        "quality_tier": "A",
+        "liquidity_pass": True,
+        "allocation_reason_clear": "Final allocation is 0% because max portfolio exposure reached (70%).",
+    }
+
+    assert classify_decision_status(trade) == "eligible but constrained"
+    assert explain_primary_rule_or_constraint(trade) == "Primary driver: max portfolio exposure limit."
+
+
+def test_liquidity_failure_is_not_eligible():
+    trade = {
+        "allocation_amount": 0,
+        "liquidity_pass": False,
+        "allocation_reason_clear": "Liquidity screen failed before sizing constraints.",
+    }
+
+    assert classify_decision_status(trade) == "not eligible"
+    assert explain_primary_rule_or_constraint(trade) == "Primary driver: liquidity eligibility rule."
+
+
+def test_fallback_when_rank_fields_unavailable_remains_neutral():
+    text = explain_portfolio_decision(
+        {
+            "allocation_amount": 0,
+            "quality_tier": "A",
+            "liquidity_pass": True,
+        }
+    )
+    assert text == "Not funded. No explicit allocator reason was provided in this output."

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -17,9 +17,13 @@ class DummyStreamlit:
     def __init__(self):
         self.dataframes = []
         self.info_messages = []
+        self.captions = []
 
     def subheader(self, _text):
         return None
+
+    def caption(self, text):
+        self.captions.append(text)
 
     def markdown(self, _text):
         return None
@@ -61,86 +65,75 @@ def test_split_trades_by_funding_separates_rows():
     assert [row["instrument"] for row in unfunded] == ["BBB"]
 
 
-def test_generate_funding_reason_labels():
-    assert generate_funding_reason({"quality_tier": "C"}) == "Not funded — Tier C"
-    assert generate_funding_reason({"liquidity_pass": False}) == "Not funded — Liquidity"
-    assert (
-        generate_funding_reason({"earnings_warning_severity": "high"})
-        == "Reduced allocation — Earnings risk"
+def test_generate_funding_reason_prefers_allocator_reason_when_available():
+    text = generate_funding_reason(
+        {
+            "allocation_amount": 1000,
+            "allocation_reason_clear": "Strong confidence starts at 30%. Final allocation is 20%.",
+        }
     )
-    assert (
-        generate_funding_reason({"volatility_bucket": "high"})
-        == "Reduced allocation — High volatility"
-    )
-    assert generate_funding_reason({"quality_tier": "A"}) == "Eligible — meets criteria"
-
-
-def test_helpers_handle_missing_optional_fields_gracefully():
-    summary = build_portfolio_summary([{}], total_capital=0)
-    funded, unfunded = split_trades_by_funding([{}])
-    reason = generate_funding_reason({})
-
-    assert summary["total_allocated_amount"] == 0
-    assert summary["cash_reserve_amount"] == 0
-    assert funded == []
-    assert len(unfunded) == 1
-    assert reason == "Eligible — meets criteria"
+    assert text.startswith("Funded.")
+    assert "Final allocation is 20%" in text
 
 
 def test_unfunded_reason_prefers_allocator_reason_field():
     trade = {
         "allocation_amount": 0,
         "quality_tier": "A",
-        "allocation_reason_clear": "Constraint limited — max funded trades reached",
+        "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
     }
     assert (
         resolve_unfunded_reason(trade)
-        == "Constraint limited — max funded trades reached"
+        == "Final allocation is 0% because max funded trades reached (3)."
     )
 
 
-def test_unfunded_reason_falls_back_when_allocator_reason_missing():
+def test_unfunded_reason_falls_back_to_rule_explanation_when_reason_missing():
     trade = {
         "allocation_amount": 0,
         "quality_tier": "C",
     }
-    assert resolve_unfunded_reason(trade) == "Not funded — Tier C"
+    assert "not eligible" in resolve_unfunded_reason(trade)
 
 
-
-
-def test_unfunded_reason_uses_new_priority_order():
-    trade = {
-        "allocation_amount": 0,
-        "allocation_reason_clear": "Clear reason",
-        "allocation_reason_pro": "Pro reason",
-        "allocator_reason": "Allocator reason",
-        "allocation_reason": "Allocation reason",
-        "reason": "Generic reason",
-    }
-    assert resolve_unfunded_reason(trade) == "Clear reason"
-
-def test_render_portfolio_plan_unfunded_table_shows_allocator_reason():
+def test_render_portfolio_plan_unfunded_table_shows_status_and_explanations():
     st = DummyStreamlit()
     render_portfolio_plan(
         allocations=[
-            {"instrument": "AAA", "allocation_amount": 1000, "quality_tier": "A"},
             {
                 "instrument": "BBB",
                 "allocation_amount": 0,
                 "quality_tier": "A",
-                "allocation_reason_clear": "Constraint limited — max funded trades reached",
+                "liquidity_pass": True,
+                "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
             },
         ],
         total_capital=10_000,
         st_module=st,
     )
 
-    unfunded_df = st.dataframes[2][0]
-    assert unfunded_df.iloc[0]["Reason"] == "Constraint limited — max funded trades reached"
+    unfunded_df = st.dataframes[1][0]
+    assert unfunded_df.iloc[0]["Decision Status"] == "eligible but constrained"
+    assert "max funded trades reached" in unfunded_df.iloc[0]["Reason"]
+    assert "Primary driver" in unfunded_df.iloc[0]["Primary Rule/Constraint"]
 
 
-def test_render_portfolio_plan_funded_rows_work_with_or_without_allocator_reason():
+def test_render_portfolio_plan_adds_context_note_for_funded_vs_unfunded():
+    st = DummyStreamlit()
+    render_portfolio_plan(
+        allocations=[
+            {"instrument": "AAA", "allocation_amount": 1000, "allocation_pct": 0.1, "quality_tier": "A"},
+            {"instrument": "BBB", "allocation_amount": 0, "quality_tier": "C"},
+        ],
+        total_capital=10_000,
+        st_module=st,
+    )
+
+    assert st.captions
+    assert "Funded trades received non-zero allocation" in st.captions[0]
+
+
+def test_render_portfolio_plan_shows_selection_rank_column():
     st = DummyStreamlit()
     render_portfolio_plan(
         allocations=[
@@ -149,18 +142,17 @@ def test_render_portfolio_plan_funded_rows_work_with_or_without_allocator_reason
                 "allocation_amount": 1000,
                 "allocation_pct": 0.1,
                 "quality_tier": "A",
-                "allocator_reason": "ignored for funded note",
-            },
-            {
-                "instrument": "CCC",
-                "allocation_amount": 500,
-                "allocation_pct": 0.05,
-                "quality_tier": "B",
+                "selection_rank": 1,
+                "funded_rank": 1,
+                "eligible_for_funding": True,
             },
             {
                 "instrument": "BBB",
                 "allocation_amount": 0,
-                "quality_tier": "C",
+                "quality_tier": "A",
+                "selection_rank": 4,
+                "eligible_for_funding": True,
+                "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
             },
         ],
         total_capital=10_000,
@@ -168,8 +160,8 @@ def test_render_portfolio_plan_funded_rows_work_with_or_without_allocator_reason
     )
 
     funded_df = st.dataframes[1][0]
-    assert list(funded_df["Instrument"]) == ["AAA", "CCC"]
-    assert list(funded_df["Funding Note"]) == [
-        "Eligible — meets criteria",
-        "Eligible — meets criteria",
-    ]
+    unfunded_df = st.dataframes[2][0]
+    assert "Selection Rank" in funded_df.columns
+    assert "Selection Rank" in unfunded_df.columns
+    assert "top-ranked eligible trade" in funded_df.iloc[0]["Explanation"]
+    assert "funded slots were filled" in unfunded_df.iloc[0]["Explanation"]


### PR DESCRIPTION
### Motivation
- Provide an in-app, plain-language explanation layer for portfolio planning to increase transparency of funding decisions and signal-level observations. 
- Surface allocator context (selection rank, funded rank, eligibility, and primary drivers) in the UI so users can inspect why trades were funded or not. 
- Add basic embedded insights summarizing volatility, tier mix, selection/funding status, and risk/holding signals to help users know what to watch. 

### Description
- Added an embedded insight module `app.insights.embedded` with `generate_embedded_insights` and `render_embedded_insights` to produce and display concise "what is happening" and "what to watch" messages. 
- Implemented plain-language explanation helpers in `app.planner.explanations` including `resolve_explicit_reason`, `classify_decision_status`, `explain_portfolio_decision`, and `explain_primary_rule_or_constraint`. 
- Extended allocator output in `app.planner.allocation.generate_portfolio_allocation` to include `selection_rank`, `funded_rank`, `eligible_for_funding`, and `max_funded_trades` and preserved existing reason fields. 
- Updated `app.planner.portfolio_ui` to use the new explanation helpers and show additional columns (`Selection Rank`, `Decision Status`, `Explanation`, `Primary Rule/Constraint`) and to prefer allocator-provided reason text when present. 
- Integrated the embedded insights and explanation layer into the app shell in `app.py` so that embedded insights are generated and rendered alongside the portfolio plan. 
- Added and updated unit tests: `tests/test_embedded_insights.py`, `tests/test_planner_explanations.py`, updated `tests/test_planner_allocation.py`, and updated `tests/test_portfolio_ui.py` to validate new fields and behaviors. 

### Testing
- Ran the new and updated unit tests with `pytest` including `tests/test_embedded_insights.py`, `tests/test_planner_explanations.py`, `tests/test_planner_allocation.py`, and `tests/test_portfolio_ui.py`; all executed tests passed. 
- Verified allocation output shape and new fields via unit tests that assert presence and semantics of `selection_rank`, `funded_rank`, and `eligible_for_funding` in `generate_portfolio_allocation`. 
- Verified explanation text and UI table columns via unit tests that assert `explain_portfolio_decision`, `classify_decision_status`, and rendered DataFrame contents in `render_portfolio_plan`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc9e4418a8832299387791af2daea6)