### PR TITLE
Refactor Portfolio Plan explanation layer to single plain-language Why field

### DIFF
--- a/app/planner/explanations.py
+++ b/app/planner/explanations.py
@@ -34,6 +34,14 @@ _REDUCED_TO_ZERO_MARKERS = (
     "reduced allocation to zero",
 )
 
+_STATUS_WHY_TEXT = {
+    "funded": "Selected — one of the strongest setups right now.",
+    "eligible but constrained": "Not funded — better trades already used up the available slots.",
+    "not eligible": "Not funded — this setup didn’t meet the rules.",
+    "reduced to zero": "Not funded — risk rules cut this position to zero.",
+    "unfunded": "Not funded — this setup wasn’t strong enough.",
+}
+
 
 def resolve_explicit_reason(trade: Mapping[str, Any]) -> str:
     """Return allocator-provided reason text using priority order."""
@@ -67,109 +75,21 @@ def classify_decision_status(trade: Mapping[str, Any]) -> str:
 
 
 def explain_portfolio_decision(trade: Mapping[str, Any]) -> str:
-    """Explain why a trade was funded or not funded using available planner fields."""
+    """Return one short plain-language sentence for portfolio plan rows."""
     status = classify_decision_status(trade)
-    explicit_reason = resolve_explicit_reason(trade)
-
-    if status == "funded":
-        if explicit_reason:
-            base_text = f"Funded. {explicit_reason}"
-        else:
-            allocation_pct = float(trade.get("allocation_pct", 0.0) or 0.0)
-            base_text = f"Funded. Final allocation is {allocation_pct:.0%}."
-        return _append_ranking_context(base_text, trade, status)
-
-    if explicit_reason:
-        base_text = f"Not funded. {explicit_reason}"
-        return _append_ranking_context(base_text, trade, status)
-
-    quality_tier = _token(trade.get("quality_tier")).upper()
-    if quality_tier == "C":
-        return "Not funded. Trade is not eligible because quality tier C is excluded by rule."
-
-    if trade.get("liquidity_pass") is False:
-        return "Not funded. Trade is not eligible because the liquidity screen failed."
-
-    if status == "eligible but constrained":
-        base_text = "Not funded. Trade was eligible, but portfolio constraints prevented funding."
-        return _append_ranking_context(base_text, trade, status)
-
-    if status == "reduced to zero":
-        base_text = "Not funded. Trade passed hard eligibility, but risk sizing reduced allocation to 0%."
-        return _append_ranking_context(base_text, trade, status)
-
-    severity = _token(trade.get("earnings_warning_severity"))
-    volatility = _token(trade.get("volatility_bucket"))
-    if severity == "high" or volatility == "high":
-        return "Not funded. Trade remained eligible, but risk adjustments reduced allocation to zero."
-
-    return _append_ranking_context(
-        "Not funded. No explicit allocator reason was provided in this output.",
-        trade,
-        status,
-    )
+    base_text = _STATUS_WHY_TEXT.get(status, _STATUS_WHY_TEXT["unfunded"])
+    return _append_rank(base_text, trade)
 
 
-def explain_primary_rule_or_constraint(trade: Mapping[str, Any]) -> str:
-    """Describe the main rule/constraint affecting the outcome."""
-    explicit_reason = _token(resolve_explicit_reason(trade))
-
-    if _is_hard_stop(trade, explicit_reason):
-        quality_tier = _token(trade.get("quality_tier")).upper()
-        if quality_tier == "C" or "tier c" in explicit_reason:
-            return "Primary driver: quality tier C rule."
-        if trade.get("liquidity_pass") is False or "liquidity" in explicit_reason:
-            return "Primary driver: liquidity eligibility rule."
-        return "Primary driver: eligibility hard-stop rule."
-
-    if "max funded trades" in explicit_reason:
-        return "Primary driver: max funded trades limit."
-    if "max portfolio exposure" in explicit_reason:
-        return "Primary driver: max portfolio exposure limit."
-    if "capacity" in explicit_reason:
-        return "Primary driver: portfolio constraint."
-
-    severity = _token(trade.get("earnings_warning_severity"))
-    volatility = _token(trade.get("volatility_bucket"))
-    if severity == "high" or volatility == "high":
-        return "Primary driver: risk adjustment factors."
-
-    return "Primary driver: no explicit rule or constraint label available."
-
-
-def _append_ranking_context(base_text: str, trade: Mapping[str, Any], status: str) -> str:
+def _append_rank(base_text: str, trade: Mapping[str, Any]) -> str:
     rank = _int_or_none(trade.get("selection_rank"))
-    funded_rank = _int_or_none(trade.get("funded_rank"))
-    eligible = bool(trade.get("eligible_for_funding"))
-    explicit_reason = _token(resolve_explicit_reason(trade))
+    if rank is None:
+        rank = _int_or_none(trade.get("funded_rank"))
+    if rank is None:
+        return base_text
 
-    if status == "funded" and funded_rank is not None:
-        if funded_rank == 1:
-            return base_text + " Ranked #1 among eligible trades and selected as a top-ranked eligible trade."
-        return (
-            base_text
-            + f" Ranked #{funded_rank} among funded positions and selected ahead of lower-priority eligible trades."
-        )
-
-    if status == "eligible but constrained" and rank is not None:
-        if "max funded trades" in explicit_reason:
-            return (
-                base_text
-                + f" Trade remained eligible at rank #{rank}, but funded slots were filled before this position."
-            )
-        if "max portfolio exposure" in explicit_reason:
-            return (
-                base_text
-                + f" Trade remained eligible at rank #{rank}, but portfolio exposure was fully used before this position."
-            )
-
-    if status == "reduced to zero" and rank is not None:
-        return base_text + f" Trade was evaluated at rank #{rank}, but sizing rules left final allocation at 0%."
-
-    if status == "unfunded" and eligible and rank is not None:
-        return base_text + f" Trade remained eligible but finished outside funded positions at rank #{rank}."
-
-    return base_text
+    sentence = base_text if base_text.endswith(".") else f"{base_text}."
+    return f"{sentence} Ranked #{rank}"
 
 
 def _is_hard_stop(trade: Mapping[str, Any], explicit_reason: str) -> bool:

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -10,8 +10,6 @@ from app.planner.explanations import (
     REASON_KEYS,
     classify_decision_status,
     explain_portfolio_decision,
-    explain_primary_rule_or_constraint,
-    resolve_explicit_reason,
 )
 
 
@@ -67,15 +65,12 @@ def split_trades_by_funding(
 
 
 def generate_funding_reason(trade: Mapping[str, Any]) -> str:
-    """Generate a compact funding explanation using explicit reasons first."""
+    """Generate one short why sentence for funded rows."""
     return explain_portfolio_decision(trade)
 
 
 def resolve_unfunded_reason(trade: Mapping[str, Any]) -> str:
-    """Resolve unfunded reason preferring allocator output before fallback labels."""
-    explicit_reason = resolve_explicit_reason(trade)
-    if explicit_reason:
-        return explicit_reason
+    """Generate one short why sentence for unfunded rows."""
     return explain_portfolio_decision(trade)
 
 
@@ -90,7 +85,7 @@ def render_portfolio_plan(
 
     st_module.subheader("Portfolio Plan")
     st_module.caption(
-        "Funded trades received non-zero allocation. Unfunded trades remained at 0% after eligibility rules and portfolio constraints were applied."
+        "Each row gives a quick plain-language reason why a setup was selected or left out."
     )
 
     if not allocations:
@@ -127,8 +122,7 @@ def render_portfolio_plan(
                     "Allocation Amount": trade.get("allocation_amount", 0.0),
                     "Selection Rank": trade.get("selection_rank", "N/A"),
                     "Decision Status": classify_decision_status(trade),
-                    "Explanation": explain_portfolio_decision(trade),
-                    "Primary Rule/Constraint": explain_primary_rule_or_constraint(trade),
+                    "Why": generate_funding_reason(trade),
                 }
                 for trade in funded_trades
             ]
@@ -147,9 +141,7 @@ def render_portfolio_plan(
                     "Confidence": trade.get("confidence_label", "N/A"),
                     "Selection Rank": trade.get("selection_rank", "N/A"),
                     "Decision Status": classify_decision_status(trade),
-                    "Reason": resolve_unfunded_reason(trade),
-                    "Explanation": explain_portfolio_decision(trade),
-                    "Primary Rule/Constraint": explain_primary_rule_or_constraint(trade),
+                    "Why": resolve_unfunded_reason(trade),
                 }
                 for trade in unfunded_trades
             ]

--- a/tests/test_planner_explanations.py
+++ b/tests/test_planner_explanations.py
@@ -1,15 +1,25 @@
+import re
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-from app.planner.explanations import (
-    classify_decision_status,
-    explain_portfolio_decision,
-    explain_primary_rule_or_constraint,
-    resolve_explicit_reason,
+from app.planner.explanations import classify_decision_status, explain_portfolio_decision, resolve_explicit_reason
+
+
+TECHNICAL_TERMS = (
+    "allocation",
+    "pre-constraints",
+    "allocator",
+    "portfolio exposure",
 )
+
+
+def _single_sentence(text: str) -> bool:
+    cleaned = re.sub(r"\.\s*Ranked\s+#\d+$", "", text.replace("—", " "))
+    parts = [part.strip() for part in re.split(r"[.!?]", cleaned) if part.strip()]
+    return len(parts) == 1
 
 
 def test_resolve_explicit_reason_uses_priority_order():
@@ -21,53 +31,43 @@ def test_resolve_explicit_reason_uses_priority_order():
     assert resolve_explicit_reason(trade) == "clear reason"
 
 
-def test_funded_top_ranked_explanation_is_added_when_rank_fields_available():
+def test_funded_status_maps_to_simple_why_with_optional_rank():
     text = explain_portfolio_decision(
         {
             "allocation_amount": 10_000,
-            "allocation_pct": 0.30,
             "selection_rank": 1,
-            "funded_rank": 1,
-            "eligible_for_funding": True,
         }
     )
-    assert "top-ranked eligible trade" in text
+
+    assert text == "Selected — one of the strongest setups right now. Ranked #1"
 
 
-def test_eligible_but_ranked_outside_funded_positions_explains_priority_limit():
-    text = explain_portfolio_decision(
-        {
-            "allocation_amount": 0,
-            "selection_rank": 4,
-            "eligible_for_funding": True,
-            "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
-        }
+def test_eligible_but_constrained_maps_to_simple_why():
+    trade = {
+        "allocation_amount": 0,
+        "selection_rank": 4,
+        "eligible_for_funding": True,
+        "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
+    }
+    assert classify_decision_status(trade) == "eligible but constrained"
+    assert (
+        explain_portfolio_decision(trade)
+        == "Not funded — better trades already used up the available slots. Ranked #4"
     )
-    assert classify_decision_status(
-        {
-            "allocation_amount": 0,
-            "selection_rank": 4,
-            "eligible_for_funding": True,
-            "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
-        }
-    ) == "eligible but constrained"
-    assert "funded slots were filled" in text
 
 
-def test_hard_stop_stays_not_eligible_even_if_constraint_word_appears():
+def test_hard_stop_maps_to_not_eligible_why():
     trade = {
         "allocation_amount": 0,
         "quality_tier": "C",
-        "allocation_reason_clear": "Hard rule applied: quality tier C is not funded; portfolio constraint context present.",
+        "allocation_reason_clear": "Hard rule applied: quality tier C is not funded.",
     }
 
     assert classify_decision_status(trade) == "not eligible"
-    assert explain_primary_rule_or_constraint(trade) == "Primary driver: quality tier C rule."
+    assert explain_portfolio_decision(trade) == "Not funded — this setup didn’t meet the rules."
 
 
-
-
-def test_eligible_for_funding_false_is_reduced_to_zero_when_not_hard_stop():
+def test_eligible_for_funding_false_maps_to_reduced_to_zero_why():
     trade = {
         "allocation_amount": 0,
         "quality_tier": "A",
@@ -76,54 +76,10 @@ def test_eligible_for_funding_false_is_reduced_to_zero_when_not_hard_stop():
     }
 
     assert classify_decision_status(trade) == "reduced to zero"
-    assert "risk sizing reduced allocation to 0%" in explain_portfolio_decision(trade)
-
-def test_preconstraints_text_is_classified_as_reduced_to_zero():
-    trade = {
-        "allocation_amount": 0,
-        "quality_tier": "A",
-        "liquidity_pass": True,
-        "allocation_reason_clear": "Final allocation is 0% because pre-constraints reduced allocation to zero.",
-    }
-
-    assert classify_decision_status(trade) == "reduced to zero"
+    assert explain_portfolio_decision(trade) == "Not funded — risk rules cut this position to zero."
 
 
-def test_genuine_exposure_constraint_is_classified_as_constrained():
-    trade = {
-        "allocation_amount": 0,
-        "quality_tier": "A",
-        "liquidity_pass": True,
-        "allocation_reason_clear": "Final allocation is 0% because max portfolio exposure reached (70%).",
-    }
-
-    assert classify_decision_status(trade) == "eligible but constrained"
-    assert explain_primary_rule_or_constraint(trade) == "Primary driver: max portfolio exposure limit."
-
-
-def test_liquidity_failure_is_not_eligible():
-    trade = {
-        "allocation_amount": 0,
-        "liquidity_pass": False,
-        "allocation_reason_clear": "Liquidity screen failed before sizing constraints.",
-    }
-
-    assert classify_decision_status(trade) == "not eligible"
-    assert explain_primary_rule_or_constraint(trade) == "Primary driver: liquidity eligibility rule."
-
-
-def test_fallback_when_rank_fields_unavailable_remains_neutral():
-    text = explain_portfolio_decision(
-        {
-            "allocation_amount": 0,
-            "quality_tier": "A",
-            "liquidity_pass": True,
-        }
-    )
-    assert text == "Not funded. No explicit allocator reason was provided in this output."
-
-
-def test_generic_fallback_stays_unfunded_when_no_markers_present():
+def test_fallback_maps_to_not_strong_enough_why():
     trade = {
         "allocation_amount": 0,
         "quality_tier": "A",
@@ -132,3 +88,12 @@ def test_generic_fallback_stays_unfunded_when_no_markers_present():
     }
 
     assert classify_decision_status(trade) == "unfunded"
+    assert explain_portfolio_decision(trade) == "Not funded — this setup wasn’t strong enough."
+
+
+def test_why_is_one_sentence_short_and_non_technical():
+    text = explain_portfolio_decision({"allocation_amount": 0, "quality_tier": "C", "selection_rank": 8})
+
+    assert _single_sentence(text)
+    assert len(text) <= 90
+    assert all(term not in text.lower() for term in TECHNICAL_TERMS)

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -65,38 +65,30 @@ def test_split_trades_by_funding_separates_rows():
     assert [row["instrument"] for row in unfunded] == ["BBB"]
 
 
-def test_generate_funding_reason_prefers_allocator_reason_when_available():
+def test_generate_funding_reason_uses_why_mapping():
     text = generate_funding_reason(
         {
             "allocation_amount": 1000,
-            "allocation_reason_clear": "Strong confidence starts at 30%. Final allocation is 20%.",
+            "selection_rank": 2,
         }
     )
-    assert text.startswith("Funded.")
-    assert "Final allocation is 20%" in text
+    assert text == "Selected — one of the strongest setups right now. Ranked #2"
 
 
-def test_unfunded_reason_prefers_allocator_reason_field():
+def test_unfunded_reason_uses_single_why_sentence():
     trade = {
         "allocation_amount": 0,
         "quality_tier": "A",
         "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
+        "selection_rank": 5,
     }
     assert (
         resolve_unfunded_reason(trade)
-        == "Final allocation is 0% because max funded trades reached (3)."
+        == "Not funded — better trades already used up the available slots. Ranked #5"
     )
 
 
-def test_unfunded_reason_falls_back_to_rule_explanation_when_reason_missing():
-    trade = {
-        "allocation_amount": 0,
-        "quality_tier": "C",
-    }
-    assert "not eligible" in resolve_unfunded_reason(trade)
-
-
-def test_render_portfolio_plan_unfunded_table_shows_status_and_explanations():
+def test_render_portfolio_plan_unfunded_table_shows_single_why_column():
     st = DummyStreamlit()
     render_portfolio_plan(
         allocations=[
@@ -105,6 +97,7 @@ def test_render_portfolio_plan_unfunded_table_shows_status_and_explanations():
                 "allocation_amount": 0,
                 "quality_tier": "A",
                 "liquidity_pass": True,
+                "selection_rank": 5,
                 "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
             },
         ],
@@ -114,11 +107,13 @@ def test_render_portfolio_plan_unfunded_table_shows_status_and_explanations():
 
     unfunded_df = st.dataframes[1][0]
     assert unfunded_df.iloc[0]["Decision Status"] == "eligible but constrained"
-    assert "max funded trades reached" in unfunded_df.iloc[0]["Reason"]
-    assert "Primary driver" in unfunded_df.iloc[0]["Primary Rule/Constraint"]
+    assert unfunded_df.iloc[0]["Why"] == "Not funded — better trades already used up the available slots. Ranked #5"
+    assert "Reason" not in unfunded_df.columns
+    assert "Explanation" not in unfunded_df.columns
+    assert "Primary Rule/Constraint" not in unfunded_df.columns
 
 
-def test_render_portfolio_plan_adds_context_note_for_funded_vs_unfunded():
+def test_render_portfolio_plan_adds_plain_language_context_note():
     st = DummyStreamlit()
     render_portfolio_plan(
         allocations=[
@@ -130,10 +125,10 @@ def test_render_portfolio_plan_adds_context_note_for_funded_vs_unfunded():
     )
 
     assert st.captions
-    assert "Funded trades received non-zero allocation" in st.captions[0]
+    assert "quick plain-language reason" in st.captions[0]
 
 
-def test_render_portfolio_plan_shows_selection_rank_column():
+def test_render_portfolio_plan_shows_why_column_for_funded_and_unfunded():
     st = DummyStreamlit()
     render_portfolio_plan(
         allocations=[
@@ -161,7 +156,7 @@ def test_render_portfolio_plan_shows_selection_rank_column():
 
     funded_df = st.dataframes[1][0]
     unfunded_df = st.dataframes[2][0]
-    assert "Selection Rank" in funded_df.columns
-    assert "Selection Rank" in unfunded_df.columns
-    assert "top-ranked eligible trade" in funded_df.iloc[0]["Explanation"]
-    assert "funded slots were filled" in unfunded_df.iloc[0]["Explanation"]
+    assert "Why" in funded_df.columns
+    assert "Why" in unfunded_df.columns
+    assert funded_df.iloc[0]["Why"] == "Selected — one of the strongest setups right now. Ranked #1"
+    assert unfunded_df.iloc[0]["Why"] == "Not funded — better trades already used up the available slots. Ranked #4"


### PR DESCRIPTION
### Motivation
- The UI repeated explanation text across multiple columns and required horizontal scrolling, making rows hard to read. 
- The previous "Reason"/"Explanation"/"Primary Rule/Constraint" outputs duplicated information and used technical/internal language. 
- We need one short, natural-language sentence per row to improve clarity and prevent redundancy. 

### Description
- Replaced the prior multi-line explanation logic with a single `explain_portfolio_decision` that maps decision statuses to one short plain-English sentence (`Why`) and optionally appends `Ranked #N` when rank is present. 
- Removed `Primary Rule/Constraint`, `Reason`, and `Explanation` fields from the `portfolio_ui` output and updated funded/unfunded table rows to include only one `Why` column alongside core fields. 
- Implemented the status→text mapping in `app/planner/explanations.py` as: `funded` → "Selected — one of the strongest setups right now.", `eligible but constrained` → "Not funded — better trades already used up the available slots.", `not eligible` → "Not funded — this setup didn’t meet the rules.", `reduced to zero` → "Not funded — risk rules cut this position to zero.", fallback `unfunded` → "Not funded — this setup wasn’t strong enough.". 
- Updated `app/planner/portfolio_ui.py` to use `Why` for both funded and unfunded rows and simplified the UI caption to plain language. 

### Testing
- Updated tests in `tests/test_planner_explanations.py` and `tests/test_portfolio_ui.py` to assert single-sentence `Why` outputs, correct status-to-text mapping, optional rank suffix, and absence of duplicate columns. 
- Ran `pytest -q tests/test_planner_explanations.py tests/test_portfolio_ui.py` and all tests passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d003dc6cc08322ae08ad81135cb891)