### PR TITLE
Refactor funded trade explanation layer into concise single-sentence Why column

### DIFF
--- a/app/planner/explanations.py
+++ b/app/planner/explanations.py
@@ -110,6 +110,24 @@ def explain_portfolio_decision(trade: Mapping[str, Any]) -> str:
     )
 
 
+def explain_funded_trade_why(
+    trade: Mapping[str, Any],
+    *,
+    include_rank: bool = True,
+) -> str:
+    """Return a short, user-first reason for funded rows."""
+    base = _funded_base_message(trade)
+
+    if not include_rank:
+        return base
+
+    rank = _int_or_none(trade.get("selection_rank"))
+    if rank is None:
+        return base
+    trimmed = base[:-1] if base.endswith(".") else base
+    return f"{trimmed}, ranked #{rank}."
+
+
 def explain_primary_rule_or_constraint(trade: Mapping[str, Any]) -> str:
     """Describe the main rule/constraint affecting the outcome."""
     explicit_reason = _token(resolve_explicit_reason(trade))
@@ -170,6 +188,37 @@ def _append_ranking_context(base_text: str, trade: Mapping[str, Any], status: st
         return base_text + f" Trade remained eligible but finished outside funded positions at rank #{rank}."
 
     return base_text
+
+
+def _funded_base_message(trade: Mapping[str, Any]) -> str:
+    if _is_lower_allocation_vs_peers(trade):
+        return "Selected — smaller position due to relative strength."
+
+    quality_tier = _token(trade.get("quality_tier")).upper()
+    confidence = _token(trade.get("confidence_label"))
+
+    if quality_tier == "A" and confidence == "strong":
+        return "Selected — strong setup with good confirmation."
+    if quality_tier == "A" and confidence == "moderate":
+        return "Selected — solid setup with decent confirmation."
+    if quality_tier == "B":
+        return "Selected — decent setup but not the strongest."
+    return "Selected — setup met the bar for funding."
+
+
+def _is_lower_allocation_vs_peers(trade: Mapping[str, Any]) -> bool:
+    if bool(trade.get("lower_allocation_vs_peers")):
+        return True
+
+    explicit_reason = _token(resolve_explicit_reason(trade))
+    markers = (
+        "relative strength",
+        "smaller position",
+        "smaller size",
+        "reduced size",
+        "below base",
+    )
+    return any(marker in explicit_reason for marker in markers)
 
 
 def _is_hard_stop(trade: Mapping[str, Any], explicit_reason: str) -> bool:

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -9,6 +9,7 @@ import pandas as pd
 from app.planner.explanations import (
     REASON_KEYS,
     classify_decision_status,
+    explain_funded_trade_why,
     explain_portfolio_decision,
     explain_primary_rule_or_constraint,
     resolve_explicit_reason,
@@ -67,16 +68,23 @@ def split_trades_by_funding(
 
 
 def generate_funding_reason(trade: Mapping[str, Any]) -> str:
-    """Generate a compact funding explanation using explicit reasons first."""
-    return explain_portfolio_decision(trade)
+    """Generate a short single-sentence 'Why' message for funded rows."""
+    return explain_funded_trade_why(trade)
 
 
 def resolve_unfunded_reason(trade: Mapping[str, Any]) -> str:
     """Resolve unfunded reason preferring allocator output before fallback labels."""
     explicit_reason = resolve_explicit_reason(trade)
     if explicit_reason:
-        return explicit_reason
-    return explain_portfolio_decision(trade)
+        return _first_sentence(explicit_reason)
+    status = classify_decision_status(trade)
+    if status == "not eligible":
+        return "not eligible after rule checks."
+    if status == "eligible but constrained":
+        return "Eligible, but portfolio limits kept it out."
+    if status == "reduced to zero":
+        return "Eligible, but risk sizing reduced it to zero."
+    return _first_sentence(explain_portfolio_decision(trade))
 
 
 def render_portfolio_plan(
@@ -90,7 +98,7 @@ def render_portfolio_plan(
 
     st_module.subheader("Portfolio Plan")
     st_module.caption(
-        "Funded trades received non-zero allocation. Unfunded trades remained at 0% after eligibility rules and portfolio constraints were applied."
+        "Quick reasons are shown in the Why column so rows stay easy to scan."
     )
 
     if not allocations:
@@ -126,9 +134,7 @@ def render_portfolio_plan(
                     "Allocation %": trade.get("allocation_pct", 0.0),
                     "Allocation Amount": trade.get("allocation_amount", 0.0),
                     "Selection Rank": trade.get("selection_rank", "N/A"),
-                    "Decision Status": classify_decision_status(trade),
-                    "Explanation": explain_portfolio_decision(trade),
-                    "Primary Rule/Constraint": explain_primary_rule_or_constraint(trade),
+                    "Why": generate_funding_reason(trade),
                 }
                 for trade in funded_trades
             ]
@@ -148,7 +154,7 @@ def render_portfolio_plan(
                     "Selection Rank": trade.get("selection_rank", "N/A"),
                     "Decision Status": classify_decision_status(trade),
                     "Reason": resolve_unfunded_reason(trade),
-                    "Explanation": explain_portfolio_decision(trade),
+                    "Why": resolve_unfunded_reason(trade),
                     "Primary Rule/Constraint": explain_primary_rule_or_constraint(trade),
                 }
                 for trade in unfunded_trades
@@ -165,3 +171,14 @@ def render_portfolio_plan(
         "- Max funded trades: 3\n"
         "- Tier C and liquidity failures are not funded"
     )
+
+
+def _first_sentence(text: str) -> str:
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return ""
+
+    sentence = cleaned.split(".")[0].strip()
+    if not sentence:
+        return ""
+    return f"{sentence}."

--- a/tests/test_planner_explanations.py
+++ b/tests/test_planner_explanations.py
@@ -6,6 +6,7 @@ sys.path.append(str(ROOT))
 
 from app.planner.explanations import (
     classify_decision_status,
+    explain_funded_trade_why,
     explain_portfolio_decision,
     explain_primary_rule_or_constraint,
     resolve_explicit_reason,
@@ -132,3 +133,37 @@ def test_generic_fallback_stays_unfunded_when_no_markers_present():
     }
 
     assert classify_decision_status(trade) == "unfunded"
+
+
+def test_funded_why_mapping_for_tier_a_strong():
+    text = explain_funded_trade_why({"quality_tier": "A", "confidence_label": "strong"})
+    assert text == "Selected — strong setup with good confirmation."
+
+
+def test_funded_why_mapping_for_tier_a_moderate():
+    text = explain_funded_trade_why({"quality_tier": "A", "confidence_label": "moderate"})
+    assert text == "Selected — solid setup with decent confirmation."
+
+
+def test_funded_why_mapping_for_tier_b():
+    text = explain_funded_trade_why({"quality_tier": "B", "confidence_label": "strong"})
+    assert text == "Selected — decent setup but not the strongest."
+
+
+def test_funded_why_uses_relative_strength_wording_for_smaller_position():
+    text = explain_funded_trade_why(
+        {
+            "quality_tier": "A",
+            "confidence_label": "strong",
+            "allocation_reason_clear": "Reduced size due to relative strength against peers.",
+        }
+    )
+    assert text == "Selected — smaller position due to relative strength."
+
+
+def test_funded_why_rank_stays_single_sentence():
+    text = explain_funded_trade_why(
+        {"quality_tier": "A", "confidence_label": "strong", "selection_rank": 2}
+    )
+    assert text.count(".") == 1
+    assert text.endswith("ranked #2.")

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -69,11 +69,11 @@ def test_generate_funding_reason_prefers_allocator_reason_when_available():
     text = generate_funding_reason(
         {
             "allocation_amount": 1000,
-            "allocation_reason_clear": "Strong confidence starts at 30%. Final allocation is 20%.",
+            "quality_tier": "A",
+            "confidence_label": "strong",
         }
     )
-    assert text.startswith("Funded.")
-    assert "Final allocation is 20%" in text
+    assert text == "Selected — strong setup with good confirmation."
 
 
 def test_unfunded_reason_prefers_allocator_reason_field():
@@ -82,10 +82,7 @@ def test_unfunded_reason_prefers_allocator_reason_field():
         "quality_tier": "A",
         "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
     }
-    assert (
-        resolve_unfunded_reason(trade)
-        == "Final allocation is 0% because max funded trades reached (3)."
-    )
+    assert resolve_unfunded_reason(trade) == "Final allocation is 0% because max funded trades reached (3)."
 
 
 def test_unfunded_reason_falls_back_to_rule_explanation_when_reason_missing():
@@ -130,22 +127,23 @@ def test_render_portfolio_plan_adds_context_note_for_funded_vs_unfunded():
     )
 
     assert st.captions
-    assert "Funded trades received non-zero allocation" in st.captions[0]
+    assert "Why column" in st.captions[0]
 
 
 def test_render_portfolio_plan_shows_selection_rank_column():
     st = DummyStreamlit()
     render_portfolio_plan(
         allocations=[
-            {
-                "instrument": "AAA",
-                "allocation_amount": 1000,
-                "allocation_pct": 0.1,
-                "quality_tier": "A",
-                "selection_rank": 1,
-                "funded_rank": 1,
-                "eligible_for_funding": True,
-            },
+                {
+                    "instrument": "AAA",
+                    "allocation_amount": 1000,
+                    "allocation_pct": 0.1,
+                    "quality_tier": "A",
+                    "confidence_label": "strong",
+                    "selection_rank": 1,
+                    "funded_rank": 1,
+                    "eligible_for_funding": True,
+                },
             {
                 "instrument": "BBB",
                 "allocation_amount": 0,
@@ -163,5 +161,6 @@ def test_render_portfolio_plan_shows_selection_rank_column():
     unfunded_df = st.dataframes[2][0]
     assert "Selection Rank" in funded_df.columns
     assert "Selection Rank" in unfunded_df.columns
-    assert "top-ranked eligible trade" in funded_df.iloc[0]["Explanation"]
-    assert "funded slots were filled" in unfunded_df.iloc[0]["Explanation"]
+    assert "Why" in funded_df.columns
+    assert funded_df.iloc[0]["Why"] == "Selected — strong setup with good confirmation, ranked #1."
+    assert "Why" in unfunded_df.columns


### PR DESCRIPTION
### Motivation
- Funded explanations were too long, repeated visible table values, and used system-focused wording making rows hard to scan.
- The goal is a single short, user-first sentence per row (Jamaican-friendly tone) that avoids repeating allocation %, rank, or confidence shown in columns.

### Description
- Added `explain_funded_trade_why()` with `_funded_base_message()` to emit one short sentence per funded row and `_is_lower_allocation_vs_peers()` to detect smaller-position cases. 
- Mapping rules implemented: Tier A + strong → “Selected — strong setup with good confirmation.”, Tier A + moderate → “Selected — solid setup with decent confirmation.”, Tier B → “Selected — decent setup but not the strongest.”, lower-allocation vs peers → “Selected — smaller position due to relative strength.”; optional rank appended in the same sentence as `, ranked #N.`. 
- Replaced the funded-table `Explanation` column with a compact `Why` column and updated the caption to emphasize quick reasons; unfunded rows now return the first sentence of allocator text or short fallback labels like `not eligible after rule checks.` to avoid verbosity. 
- Updated helper `_first_sentence()` and `resolve_unfunded_reason()` to trim long allocator text to a single concise sentence; adjustments were made in `app/planner/explanations.py` and `app/planner/portfolio_ui.py` and corresponding tests were updated.

### Testing
- Ran the focused test suite with `pytest -q tests/test_planner_explanations.py tests/test_portfolio_ui.py` and all tests passed. 
- New/updated tests include mapping and single-sentence assertions in `tests/test_planner_explanations.py` and UI column/caption checks in `tests/test_portfolio_ui.py`, and these tests succeeded (23 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0042400e88322ade192f459ef8cef)