### PR TITLE
Add Ticker Intelligence layer and Ticker Analysis UI tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 
+from app.analysis.ticker_intelligence import compute_ticker_metrics
 from app.data.ingest import ingest_dataset
 from app.demo.run_demo import run_demo
 from app.insights.analyst import render_analyst_insights
@@ -48,10 +49,41 @@ def main() -> None:
     ranked_df = demo_payload.get("ranked", pd.DataFrame())
     analyst_df = build_analyst_dataset(canonical_df, ranked_df)
 
-    insights_tab, plan_tab = st.tabs(["Analyst Insights", "Portfolio Plan"])
+    insights_tab, ticker_tab, plan_tab = st.tabs(["Analyst Insights", "Ticker Analysis", "Portfolio Plan"])
 
     with insights_tab:
         render_analyst_insights(analyst_df, st_module=st, analyst_mode=True)
+
+    with ticker_tab:
+        st.markdown("### Ticker Analysis")
+        if analyst_df.empty or "instrument" not in analyst_df.columns:
+            st.info("Ticker Analysis is unavailable because no ticker rows are loaded.")
+        else:
+            ticker_options = sorted(analyst_df["instrument"].dropna().astype(str).unique())
+            if not ticker_options:
+                st.info("Ticker Analysis is unavailable because no tickers are available.")
+            else:
+                selected_ticker = st.selectbox("Select ticker", ticker_options)
+                ticker_payload = compute_ticker_metrics(analyst_df, selected_ticker)
+
+                st.markdown("#### Summary")
+                st.write(ticker_payload["summary"])
+
+                st.markdown("#### Stats")
+                stats_table = pd.DataFrame([ticker_payload["stats"]]).rename(
+                    columns={
+                        "win_rate": "Win Rate",
+                        "median_return": "Median Return",
+                        "avg_return": "Average Return",
+                        "best_window": "Best Window",
+                        "signal_count": "Signal Count",
+                    }
+                )
+                st.dataframe(stats_table, use_container_width=True)
+
+                st.markdown("#### Behavior")
+                for key in ["holding_window", "consistency", "reliability", "tier_profile"]:
+                    st.markdown(f"- {ticker_payload['behavior'][key]}")
 
     with plan_tab:
         st.markdown("### Portfolio Plan")

--- a/app/analysis/__init__.py
+++ b/app/analysis/__init__.py
@@ -1,0 +1,13 @@
+"""Ticker analysis helpers for user-friendly stock behavior insights."""
+
+from .ticker_intelligence import (
+    build_ticker_behavior,
+    build_ticker_summary,
+    compute_ticker_metrics,
+)
+
+__all__ = [
+    "compute_ticker_metrics",
+    "build_ticker_summary",
+    "build_ticker_behavior",
+]

--- a/app/analysis/ticker_intelligence.py
+++ b/app/analysis/ticker_intelligence.py
@@ -1,0 +1,168 @@
+"""Ticker intelligence layer with plain-language behavior summaries."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+RETURN_COLUMNS = ["net_return_pct", "net_return", "return_pct", "return"]
+
+
+def _resolve_return_column(df: pd.DataFrame) -> str | None:
+    for column in RETURN_COLUMNS:
+        if column in df.columns:
+            return column
+    return None
+
+
+def _empty_payload() -> dict[str, Any]:
+    return {
+        "summary": "No clean return data showed up for this ticker yet.",
+        "stats": {
+            "win_rate": 0.0,
+            "median_return": 0.0,
+            "avg_return": 0.0,
+            "best_window": "N/A",
+            "signal_count": 0,
+        },
+        "behavior": {
+            "holding_window": "There is not enough 5D or 20D data to compare holding windows right now.",
+            "consistency": "No consistency read is available because return data is missing.",
+            "reliability": "Reliability cannot be read because there are no completed signals.",
+            "tier_profile": "Tier profile cannot be read because tier data is missing.",
+        },
+    }
+
+
+def build_ticker_summary(metrics: dict[str, Any]) -> str:
+    stats = metrics["stats"]
+    signal_count = int(stats["signal_count"])
+    win_rate = float(stats["win_rate"]) * 100
+    median_return = float(stats["median_return"]) * 100
+    best_window = stats["best_window"]
+
+    base = (
+        f"{metrics['ticker']} closed positive {win_rate:.0f}% of the time with a median return of "
+        f"{median_return:.2f}% and looked strongest at the {best_window} window."
+    )
+
+    if signal_count < 8:
+        return base[:-1] + f", but this read comes from only {signal_count} signals."
+    return base
+
+
+def build_ticker_behavior(metrics: dict[str, Any]) -> dict[str, str]:
+    by_window = metrics.get("by_window", {})
+
+    five_day = by_window.get(5)
+    twenty_day = by_window.get(20)
+    if five_day and twenty_day:
+        if five_day["avg_return"] > twenty_day["avg_return"]:
+            holding_window = "The 5D window moved stronger than 20D for this ticker in this dataset."
+        elif five_day["avg_return"] < twenty_day["avg_return"]:
+            holding_window = "The 20D window moved stronger than 5D for this ticker in this dataset."
+        else:
+            holding_window = "The 5D and 20D windows came out nearly the same for this ticker."
+    else:
+        holding_window = "There is not enough 5D or 20D data to compare holding windows right now."
+
+    avg_return = float(metrics["stats"]["avg_return"])
+    median_return = float(metrics["stats"]["median_return"])
+    if abs(avg_return - median_return) <= 0.002:
+        consistency = "Average and median returns are close, so results look fairly steady."
+    elif avg_return > median_return:
+        consistency = "Average return sits above median return, so a few bigger wins are lifting the average."
+    else:
+        consistency = "Median return sits above average return, so weaker outliers are pulling the average down."
+
+    win_rate = float(metrics["stats"]["win_rate"])
+    if win_rate >= 0.6:
+        reliability = "Win rate reads as reliable because most signals closed positive."
+    elif win_rate >= 0.5:
+        reliability = "Win rate reads as moderate because positive and negative closes are fairly mixed."
+    else:
+        reliability = "Win rate reads as uneven because negative closes showed up more often."
+
+    tier_counts = metrics.get("tier_counts", {})
+    if tier_counts:
+        top_tier = max(tier_counts, key=tier_counts.get)
+        top_share = (tier_counts[top_tier] / sum(tier_counts.values())) * 100
+        tier_profile = f"Tier mix leans to {top_tier}, with about {top_share:.0f}% of tagged rows in that tier."
+    else:
+        tier_profile = "Tier profile cannot be read because tier data is missing."
+
+    return {
+        "holding_window": holding_window,
+        "consistency": consistency,
+        "reliability": reliability,
+        "tier_profile": tier_profile,
+    }
+
+
+def compute_ticker_metrics(df: pd.DataFrame, ticker: str) -> dict[str, Any]:
+    if df.empty or "instrument" not in df.columns:
+        return _empty_payload()
+
+    return_column = _resolve_return_column(df)
+    if return_column is None:
+        return _empty_payload()
+
+    scoped = df[df["instrument"].astype(str) == str(ticker)].copy()
+    scoped = scoped.dropna(subset=[return_column])
+    if scoped.empty:
+        return _empty_payload()
+
+    scoped["return_value"] = pd.to_numeric(scoped[return_column], errors="coerce")
+    scoped = scoped.dropna(subset=["return_value"])
+    if scoped.empty:
+        return _empty_payload()
+
+    grouped = scoped.groupby("holding_window") if "holding_window" in scoped.columns else None
+    by_window: dict[int, dict[str, float]] = {}
+    if grouped is not None:
+        for window, values in grouped:
+            by_window[int(window)] = {
+                "avg_return": float(values["return_value"].mean()),
+                "median_return": float(values["return_value"].median()),
+                "win_rate": float((values["return_value"] > 0).mean()),
+                "count": int(values["return_value"].size),
+            }
+
+    if by_window:
+        best_window = max(
+            by_window,
+            key=lambda w: (
+                by_window[w]["avg_return"],
+                by_window[w]["median_return"],
+                by_window[w]["win_rate"],
+            ),
+        )
+        best_window_label = f"{best_window}D"
+    else:
+        best_window_label = "N/A"
+
+    tier_column = "quality_tier" if "quality_tier" in scoped.columns else "tier" if "tier" in scoped.columns else None
+    tier_counts = (
+        scoped[tier_column].astype(str).value_counts().to_dict() if tier_column is not None else {}
+    )
+
+    metrics: dict[str, Any] = {
+        "ticker": str(ticker),
+        "stats": {
+            "win_rate": float((scoped["return_value"] > 0).mean()),
+            "median_return": float(scoped["return_value"].median()),
+            "avg_return": float(scoped["return_value"].mean()),
+            "best_window": best_window_label,
+            "signal_count": int(scoped["return_value"].size),
+        },
+        "by_window": by_window,
+        "tier_counts": tier_counts,
+    }
+    metrics["summary"] = build_ticker_summary(metrics)
+    metrics["behavior"] = build_ticker_behavior(metrics)
+    return {
+        "summary": metrics["summary"],
+        "stats": metrics["stats"],
+        "behavior": metrics["behavior"],
+    }

--- a/tests/test_ticker_intelligence.py
+++ b/tests/test_ticker_intelligence.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.analysis.ticker_intelligence import compute_ticker_metrics
+
+
+def _sample_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB", "NCB", "NCB", "NCB", "NCB", "NCB", "NCB", "JMMB"],
+            "holding_window": [5, 5, 20, 20, 5, 20, 5, 20, 5],
+            "net_return_pct": [0.02, -0.01, 0.03, 0.01, 0.00, -0.02, 0.01, 0.02, 0.04],
+            "quality_tier": ["A", "A", "B", "B", "A", "B", "A", "B", "A"],
+        }
+    )
+
+
+def test_compute_ticker_metrics_returns_required_structure():
+    payload = compute_ticker_metrics(_sample_df(), "NCB")
+
+    assert set(payload.keys()) == {"summary", "stats", "behavior"}
+    assert set(payload["stats"].keys()) == {
+        "win_rate",
+        "median_return",
+        "avg_return",
+        "best_window",
+        "signal_count",
+    }
+    assert set(payload["behavior"].keys()) == {
+        "holding_window",
+        "consistency",
+        "reliability",
+        "tier_profile",
+    }
+
+
+def test_compute_ticker_metrics_generates_summary_with_best_window():
+    payload = compute_ticker_metrics(_sample_df(), "NCB")
+
+    assert "NCB closed positive" in payload["summary"]
+    assert payload["stats"]["best_window"] in payload["summary"]
+
+
+def test_compute_ticker_metrics_flags_low_sample_size_in_summary():
+    df = pd.DataFrame(
+        {
+            "instrument": ["TEST", "TEST", "TEST"],
+            "holding_window": [5, 20, 5],
+            "net_return_pct": [0.01, -0.01, 0.02],
+        }
+    )
+
+    payload = compute_ticker_metrics(df, "TEST")
+
+    assert payload["stats"]["signal_count"] == 3
+    assert "only 3 signals" in payload["summary"]
+
+
+def test_compute_ticker_metrics_handles_missing_data():
+    df = pd.DataFrame({"instrument": ["AAA"], "holding_window": [5]})
+
+    payload = compute_ticker_metrics(df, "AAA")
+
+    assert payload["stats"]["signal_count"] == 0
+    assert payload["stats"]["best_window"] == "N/A"
+    assert "No clean return data" in payload["summary"]


### PR DESCRIPTION
### Motivation
- Implement Sprint 9 to let users pick a ticker and receive simple, non-technical observations about how that stock behaves.
- Provide a small, reusable analysis layer that computes summary stats and plain-language behavior sentences for use in the Streamlit UI.

### Description
- Added a new analysis module `app/analysis/ticker_intelligence.py` implementing `compute_ticker_metrics(df, ticker)`, `build_ticker_summary(metrics)`, and `build_ticker_behavior(metrics)` to produce the required payload structure. 
- Exported functions via `app/analysis/__init__.py` and wired the analysis into the UI by adding a new `Ticker Analysis` tab in `app.py` with a ticker dropdown, summary, stats table, and behavior bullet list. 
- Implemented logic for 5D vs 20D holding-window comparison, average vs median consistency, win-rate based reliability tiers, tier-distribution profiling, and a low sample-size warning in the summary. 
- Added unit tests in `tests/test_ticker_intelligence.py` to validate output structure, summary wording, low-sample handling, and missing-data behavior. 

### Testing
- Ran `pytest -q tests/test_ticker_intelligence.py tests/test_app_shell.py` and all tests passed. 
- Test run result: `6 passed` for the requested test set. 
- The new tests verify structure, summary content, low-sample messaging, and missing-data fallbacks for `compute_ticker_metrics`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d018bae1548322b2b1e54499eb364a)