### PR TITLE
Add Sprint 10 Ticker Drilldown and Ticker Analysis UI sections

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from app.analysis.ticker_intelligence import compute_ticker_metrics
+from app.analysis.ticker_drilldown import build_ticker_drilldown
 from app.data.ingest import ingest_dataset
 from app.demo.run_demo import run_demo
 from app.insights.analyst import render_analyst_insights
@@ -64,26 +64,72 @@ def main() -> None:
                 st.info("Ticker Analysis is unavailable because no tickers are available.")
             else:
                 selected_ticker = st.selectbox("Select ticker", ticker_options)
-                ticker_payload = compute_ticker_metrics(analyst_df, selected_ticker)
+                ticker_payload = build_ticker_drilldown(analyst_df, selected_ticker)
 
-                st.markdown("#### Summary")
-                st.write(ticker_payload["summary"])
+                st.markdown("#### Pattern Summary")
+                st.write(ticker_payload["pattern_summary"])
 
-                st.markdown("#### Stats")
-                stats_table = pd.DataFrame([ticker_payload["stats"]]).rename(
-                    columns={
-                        "win_rate": "Win Rate",
-                        "median_return": "Median Return",
-                        "avg_return": "Average Return",
-                        "best_window": "Best Window",
-                        "signal_count": "Signal Count",
+                signal_df = pd.DataFrame(ticker_payload["signals"])
+                signal_count = int(len(signal_df))
+                if signal_df.empty or "return_pct" not in signal_df.columns:
+                    key_stats = {
+                        "Signal Count": signal_count,
+                        "Win Rate": 0.0,
+                        "Median Return": 0.0,
+                        "Average Return": 0.0,
                     }
-                )
-                st.dataframe(stats_table, use_container_width=True)
+                else:
+                    returns = pd.to_numeric(signal_df["return_pct"], errors="coerce").dropna()
+                    if returns.empty:
+                        key_stats = {
+                            "Signal Count": signal_count,
+                            "Win Rate": 0.0,
+                            "Median Return": 0.0,
+                            "Average Return": 0.0,
+                        }
+                    else:
+                        key_stats = {
+                            "Signal Count": signal_count,
+                            "Win Rate": float((returns > 0).mean()),
+                            "Median Return": float(returns.median()),
+                            "Average Return": float(returns.mean()),
+                        }
 
-                st.markdown("#### Behavior")
-                for key in ["holding_window", "consistency", "reliability", "tier_profile"]:
-                    st.markdown(f"- {ticker_payload['behavior'][key]}")
+                st.markdown("#### Key Stats")
+                st.dataframe(pd.DataFrame([key_stats]), use_container_width=True)
+
+                st.markdown("#### Holding Window Comparison")
+                holding_window_df = pd.DataFrame.from_dict(
+                    ticker_payload["holding_window_stats"], orient="index"
+                )
+                if holding_window_df.empty:
+                    st.info("No holding window data is ready for this ticker yet.")
+                else:
+                    st.dataframe(holding_window_df.reset_index().rename(columns={"index": "holding_window"}), use_container_width=True)
+
+                st.markdown("#### Tier Performance")
+                tier_df = pd.DataFrame.from_dict(ticker_payload["tier_performance"], orient="index")
+                if tier_df.empty:
+                    st.info("No tier breakdown is ready for this ticker yet.")
+                else:
+                    st.dataframe(tier_df.reset_index().rename(columns={"index": "quality_tier"}), use_container_width=True)
+
+                st.markdown("#### Volatility Performance")
+                volatility_df = pd.DataFrame.from_dict(ticker_payload["volatility_performance"], orient="index")
+                if volatility_df.empty:
+                    st.info("No volatility breakdown is ready for this ticker yet.")
+                else:
+                    st.dataframe(volatility_df.reset_index().rename(columns={"index": "volatility_bucket"}), use_container_width=True)
+
+                st.markdown("#### Return Distribution")
+                distribution_df = pd.DataFrame([ticker_payload["return_distribution"]])
+                st.dataframe(distribution_df, use_container_width=True)
+
+                st.markdown("#### Signal Breakdown")
+                if signal_df.empty:
+                    st.info("No signal history is available for this ticker yet.")
+                else:
+                    st.dataframe(signal_df, use_container_width=True)
 
     with plan_tab:
         st.markdown("### Portfolio Plan")

--- a/app/analysis/__init__.py
+++ b/app/analysis/__init__.py
@@ -1,5 +1,6 @@
 """Ticker analysis helpers for user-friendly stock behavior insights."""
 
+from .ticker_drilldown import build_ticker_drilldown
 from .ticker_intelligence import (
     build_ticker_behavior,
     build_ticker_summary,
@@ -10,4 +11,5 @@ __all__ = [
     "compute_ticker_metrics",
     "build_ticker_summary",
     "build_ticker_behavior",
+    "build_ticker_drilldown",
 ]

--- a/app/analysis/ticker_drilldown.py
+++ b/app/analysis/ticker_drilldown.py
@@ -1,0 +1,267 @@
+"""Ticker drilldown layer for deeper, structured stock behavior analysis."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+
+TICKER_COLUMNS = ["ticker", "instrument"]
+RETURN_COLUMNS = ["net_return_pct", "return_pct"]
+TIER_COLUMNS = ["quality_tier", "tier"]
+
+
+def _resolve_first_column(df: pd.DataFrame, candidates: list[str]) -> str | None:
+    for column in candidates:
+        if column in df.columns:
+            return column
+    return None
+
+
+def _resolve_ticker_column(df: pd.DataFrame) -> str | None:
+    return _resolve_first_column(df, TICKER_COLUMNS)
+
+
+def _resolve_return_column(df: pd.DataFrame) -> str | None:
+    return _resolve_first_column(df, RETURN_COLUMNS)
+
+
+def _resolve_tier_column(df: pd.DataFrame) -> str | None:
+    return _resolve_first_column(df, TIER_COLUMNS)
+
+
+def _scope_to_ticker(df: pd.DataFrame, ticker: str) -> pd.DataFrame:
+    ticker_column = _resolve_ticker_column(df)
+    if df.empty or ticker_column is None:
+        return pd.DataFrame(columns=df.columns)
+    scoped = df[df[ticker_column].astype(str) == str(ticker)].copy()
+    return scoped
+
+
+def _format_holding_window(value: Any) -> str:
+    if pd.isna(value):
+        return "unknown"
+    try:
+        numeric_value = float(value)
+        if numeric_value.is_integer():
+            return f"{int(numeric_value)}D"
+    except (TypeError, ValueError):
+        pass
+
+    value_str = str(value).strip()
+    if not value_str:
+        return "unknown"
+    if value_str.upper().endswith("D"):
+        return value_str.upper()
+    return f"{value_str}D"
+
+
+def _build_group_stats(group_df: pd.DataFrame, return_column: str) -> dict[str, float | int]:
+    returns = pd.to_numeric(group_df[return_column], errors="coerce").dropna()
+    count = int(returns.size)
+    if count == 0:
+        return {"count": 0, "win_rate": 0.0, "median_return": 0.0, "avg_return": 0.0}
+
+    wins = int((returns > 0).sum())
+    return {
+        "count": count,
+        "win_rate": float(wins / count),
+        "median_return": float(returns.median()),
+        "avg_return": float(returns.mean()),
+    }
+
+
+def compute_signal_breakdown(df: pd.DataFrame, ticker: str) -> list[dict[str, Any]]:
+    scoped = _scope_to_ticker(df, ticker)
+    if scoped.empty:
+        return []
+
+    return_column = _resolve_return_column(scoped)
+    tier_column = _resolve_tier_column(scoped)
+
+    if "date" in scoped.columns:
+        scoped["_sort_date"] = pd.to_datetime(scoped["date"], errors="coerce")
+        scoped = scoped.sort_values("_sort_date", ascending=False, na_position="last")
+
+    signals: list[dict[str, Any]] = []
+    for _, row in scoped.iterrows():
+        signal: dict[str, Any] = {}
+
+        if "date" in scoped.columns and not pd.isna(row.get("date")):
+            parsed_date = pd.to_datetime(row.get("date"), errors="coerce")
+            signal["date"] = parsed_date.strftime("%Y-%m-%d") if not pd.isna(parsed_date) else str(row.get("date"))
+
+        if "holding_window" in scoped.columns:
+            signal["holding_window"] = _format_holding_window(row.get("holding_window"))
+
+        if return_column is not None:
+            return_value = pd.to_numeric(row.get(return_column), errors="coerce")
+            if not pd.isna(return_value):
+                return_float = float(return_value)
+                signal["return_pct"] = return_float
+                signal["win_loss"] = "Win" if return_float > 0 else "Loss"
+
+        if tier_column is not None and not pd.isna(row.get(tier_column)):
+            signal["quality_tier"] = str(row.get(tier_column))
+
+        if "volatility_bucket" in scoped.columns and not pd.isna(row.get("volatility_bucket")):
+            signal["volatility_bucket"] = str(row.get("volatility_bucket"))
+
+        signals.append(signal)
+
+    return signals
+
+
+def compute_holding_window_stats(df: pd.DataFrame, ticker: str) -> dict[str, dict[str, float | int]]:
+    scoped = _scope_to_ticker(df, ticker)
+    return_column = _resolve_return_column(scoped)
+    if scoped.empty or return_column is None or "holding_window" not in scoped.columns:
+        return {}
+
+    stats: dict[str, dict[str, float | int]] = {}
+    for window, group in scoped.groupby("holding_window", dropna=True):
+        stats[_format_holding_window(window)] = _build_group_stats(group, return_column)
+
+    return stats
+
+
+def compute_return_distribution(df: pd.DataFrame, ticker: str) -> dict[str, int]:
+    distribution = {"negative": 0, "small_positive": 0, "strong_positive": 0}
+    scoped = _scope_to_ticker(df, ticker)
+    return_column = _resolve_return_column(scoped)
+    if scoped.empty or return_column is None:
+        return distribution
+
+    returns = pd.to_numeric(scoped[return_column], errors="coerce").dropna()
+    if returns.empty:
+        return distribution
+
+    distribution["negative"] = int((returns <= 0).sum())
+    distribution["small_positive"] = int(((returns > 0) & (returns < 0.03)).sum())
+    distribution["strong_positive"] = int((returns >= 0.03).sum())
+    return distribution
+
+
+def compute_tier_performance(df: pd.DataFrame, ticker: str) -> dict[str, dict[str, float | int]]:
+    scoped = _scope_to_ticker(df, ticker)
+    return_column = _resolve_return_column(scoped)
+    tier_column = _resolve_tier_column(scoped)
+    if scoped.empty or return_column is None or tier_column is None:
+        return {}
+
+    stats: dict[str, dict[str, float | int]] = {}
+    for tier, group in scoped.groupby(tier_column, dropna=True):
+        stats[str(tier)] = _build_group_stats(group, return_column)
+
+    return stats
+
+
+def compute_volatility_performance(df: pd.DataFrame, ticker: str) -> dict[str, dict[str, float | int]]:
+    scoped = _scope_to_ticker(df, ticker)
+    return_column = _resolve_return_column(scoped)
+    if scoped.empty or return_column is None or "volatility_bucket" not in scoped.columns:
+        return {}
+
+    stats: dict[str, dict[str, float | int]] = {}
+    for bucket, group in scoped.groupby("volatility_bucket", dropna=True):
+        stats[str(bucket)] = _build_group_stats(group, return_column)
+
+    return stats
+
+
+def _pick_best_bucket(stats: dict[str, dict[str, float | int]]) -> tuple[str, dict[str, float | int]] | None:
+    if not stats:
+        return None
+
+    ranked = sorted(
+        stats.items(),
+        key=lambda item: (
+            float(item[1].get("win_rate", 0.0)),
+            float(item[1].get("median_return", 0.0)),
+            float(item[1].get("avg_return", 0.0)),
+            int(item[1].get("count", 0)),
+        ),
+        reverse=True,
+    )
+    return ranked[0]
+
+
+def build_pattern_summary(
+    holding_window_stats: dict[str, dict[str, float | int]],
+    tier_performance: dict[str, dict[str, float | int]],
+    volatility_performance: dict[str, dict[str, float | int]],
+    return_distribution: dict[str, int],
+    signal_count: int,
+) -> str:
+    if signal_count < 3:
+        return "There is not much data for this stock yet, so the pattern is still limited."
+
+    if len(holding_window_stats) >= 2:
+        ranked_windows = sorted(
+            holding_window_stats.items(),
+            key=lambda item: (
+                float(item[1].get("win_rate", 0.0)),
+                float(item[1].get("median_return", 0.0)),
+                float(item[1].get("avg_return", 0.0)),
+            ),
+            reverse=True,
+        )
+        top_window, top_stats = ranked_windows[0]
+        second_window, second_stats = ranked_windows[1]
+        if (
+            float(top_stats.get("win_rate", 0.0)) >= float(second_stats.get("win_rate", 0.0)) + 0.1
+            or float(top_stats.get("median_return", 0.0))
+            >= float(second_stats.get("median_return", 0.0)) + 0.003
+        ):
+            return f"This stock tends to hold up better on {top_window} than {second_window} in this dataset."
+
+    best_tier = _pick_best_bucket(tier_performance)
+    if best_tier is not None and len(tier_performance) >= 2:
+        tier_name, tier_stats = best_tier
+        if int(tier_stats.get("count", 0)) >= 2 and float(tier_stats.get("win_rate", 0.0)) >= 0.6:
+            return f"This stock looks strongest when the {tier_name} quality setups show up."
+
+    best_volatility = _pick_best_bucket(volatility_performance)
+    if best_volatility is not None and len(volatility_performance) >= 2:
+        bucket, bucket_stats = best_volatility
+        if int(bucket_stats.get("count", 0)) >= 2:
+            return f"For this stock, {bucket} volatility setups have looked more stable so far."
+
+    negative = int(return_distribution.get("negative", 0))
+    strong_positive = int(return_distribution.get("strong_positive", 0))
+    if negative > strong_positive:
+        return "This stock has shown more weak closes than strong wins in this sample."
+
+    return "This stock has mixed results so far, with no single pattern standing out clearly."
+
+
+def build_ticker_drilldown(df: pd.DataFrame, ticker: str) -> dict[str, Any]:
+    scoped = _scope_to_ticker(df, ticker)
+    signal_count = int(len(scoped))
+
+    signals = compute_signal_breakdown(df, ticker)
+    holding_window_stats = compute_holding_window_stats(df, ticker)
+    return_distribution = compute_return_distribution(df, ticker)
+    tier_performance = compute_tier_performance(df, ticker)
+    volatility_performance = compute_volatility_performance(df, ticker)
+
+    if signal_count == 0:
+        pattern_summary = "There is not enough data to say much about this stock yet."
+    else:
+        pattern_summary = build_pattern_summary(
+            holding_window_stats=holding_window_stats,
+            tier_performance=tier_performance,
+            volatility_performance=volatility_performance,
+            return_distribution=return_distribution,
+            signal_count=signal_count,
+        )
+
+    return {
+        "signals": signals,
+        "holding_window_stats": holding_window_stats,
+        "return_distribution": return_distribution,
+        "tier_performance": tier_performance,
+        "volatility_performance": volatility_performance,
+        "pattern_summary": pattern_summary,
+    }

--- a/tests/test_ticker_drilldown.py
+++ b/tests/test_ticker_drilldown.py
@@ -1,0 +1,127 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.analysis.ticker_drilldown import (
+    build_ticker_drilldown,
+    compute_holding_window_stats,
+    compute_return_distribution,
+    compute_signal_breakdown,
+    compute_tier_performance,
+    compute_volatility_performance,
+)
+
+
+def _sample_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB", "NCB", "NCB", "NCB", "JMMB"],
+            "date": pd.to_datetime(
+                [
+                    "2025-01-01",
+                    "2025-01-10",
+                    "2025-02-01",
+                    "2025-02-12",
+                    "2025-03-01",
+                    "2025-01-08",
+                ]
+            ),
+            "holding_window": [5, 5, 20, 20, 5, 5],
+            "net_return_pct": [0.02, -0.01, 0.04, 0.01, 0.00, 0.03],
+            "quality_tier": ["A", "B", "A", "C", "A", "B"],
+            "volatility_bucket": ["low", "mid", "mid", "high", "low", "mid"],
+        }
+    )
+
+
+def test_compute_signal_breakdown_extracts_selected_ticker_and_win_loss():
+    signals = compute_signal_breakdown(_sample_df(), "NCB")
+
+    assert len(signals) == 5
+    assert signals[0]["date"] == "2025-03-01"
+    assert all(row.get("quality_tier") in {"A", "B", "C"} for row in signals)
+    assert {row["win_loss"] for row in signals if "win_loss" in row} == {"Win", "Loss"}
+
+
+def test_compute_holding_window_stats_groups_rows_correctly():
+    stats = compute_holding_window_stats(_sample_df(), "NCB")
+
+    assert set(stats.keys()) == {"5D", "20D"}
+    assert stats["5D"]["count"] == 3
+    assert stats["20D"]["count"] == 2
+    assert round(stats["20D"]["win_rate"], 2) == 1.0
+
+
+def test_compute_return_distribution_buckets_values():
+    distribution = compute_return_distribution(_sample_df(), "NCB")
+
+    assert distribution == {"negative": 2, "small_positive": 2, "strong_positive": 1}
+
+
+def test_compute_tier_performance_groups_by_quality_tier():
+    tier_stats = compute_tier_performance(_sample_df(), "NCB")
+
+    assert set(tier_stats.keys()) == {"A", "B", "C"}
+    assert tier_stats["A"]["count"] == 3
+    assert round(tier_stats["C"]["avg_return"], 2) == 0.01
+
+
+def test_compute_volatility_performance_groups_by_bucket():
+    vol_stats = compute_volatility_performance(_sample_df(), "NCB")
+
+    assert set(vol_stats.keys()) == {"low", "mid", "high"}
+    assert vol_stats["mid"]["count"] == 2
+
+
+def test_build_ticker_drilldown_low_sample_summary():
+    df = pd.DataFrame(
+        {
+            "instrument": ["AAA", "AAA"],
+            "holding_window": [5, 20],
+            "net_return_pct": [0.01, -0.02],
+        }
+    )
+
+    payload = build_ticker_drilldown(df, "AAA")
+
+    assert "not much data" in payload["pattern_summary"].lower()
+
+
+def test_build_ticker_drilldown_handles_missing_columns_gracefully():
+    df = pd.DataFrame({"instrument": ["AAA", "AAA"], "date": ["2025-01-01", "2025-01-02"]})
+
+    payload = build_ticker_drilldown(df, "AAA")
+
+    assert payload["holding_window_stats"] == {}
+    assert payload["tier_performance"] == {}
+    assert payload["volatility_performance"] == {}
+    assert payload["return_distribution"] == {"negative": 0, "small_positive": 0, "strong_positive": 0}
+    assert len(payload["signals"]) == 2
+
+
+def test_build_ticker_drilldown_handles_empty_dataframe():
+    payload = build_ticker_drilldown(pd.DataFrame(), "AAA")
+
+    assert payload["signals"] == []
+    assert payload["holding_window_stats"] == {}
+    assert payload["return_distribution"] == {"negative": 0, "small_positive": 0, "strong_positive": 0}
+    assert payload["tier_performance"] == {}
+    assert payload["volatility_performance"] == {}
+    assert "not enough data" in payload["pattern_summary"].lower()
+
+
+def test_build_ticker_drilldown_output_structure():
+    payload = build_ticker_drilldown(_sample_df(), "NCB")
+
+    assert set(payload.keys()) == {
+        "signals",
+        "holding_window_stats",
+        "return_distribution",
+        "tier_performance",
+        "volatility_performance",
+        "pattern_summary",
+    }


### PR DESCRIPTION
### Motivation
- Extend the Ticker Analysis experience so users can get a deeper, structured read on a selected ticker without adding predictions, recommendations, or marketing language.
- Provide clear, small outputs that help answer which holding windows, tiers, or volatility buckets tend to perform for a ticker and surface raw signal rows for inspection.
- Keep behavior observational, simple language, and graceful handling when columns or data are missing.

### Description
- Add `app/analysis/ticker_drilldown.py` implementing `compute_signal_breakdown`, `compute_holding_window_stats`, `compute_return_distribution`, `compute_tier_performance`, `compute_volatility_performance`, `build_pattern_summary`, and `build_ticker_drilldown` with safe fallbacks and column resolution for `ticker/instrument`, `net_return_pct/return_pct`, and `quality_tier/tier`.
- Wire the drilldown into the Ticker Analysis UI in `app.py`, rendering sections in order: Pattern Summary, Key Stats, Holding Window Comparison, Tier Performance, Volatility Performance, Return Distribution, and Signal Breakdown.
- Export `build_ticker_drilldown` from `app/analysis/__init__.py` and add `tests/test_ticker_drilldown.py` covering extraction, grouping, distribution buckets, tier/volatility grouping, low-sample summary, missing-column handling, empty-data handling, and output shape.

### Testing
- Ran targeted test suite with `pytest -q tests/test_ticker_drilldown.py tests/test_ticker_intelligence.py tests/test_app_shell.py` which completed successfully with all tests passing.
- Ran `pytest -q tests/test_analyst_insights.py` which also passed in this environment.
- The new drilldown tests validate signal extraction, holding-window grouping, return buckets, tier/volatility grouping, low-sample messaging, missing-column behavior, empty dataframe behavior, and final payload shape.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2cd6732e8832299ffbf9b6b16a633)