### PR TITLE
Restore return-column aliases and correct return-distribution cutoffs in ticker drilldown

### DIFF
--- a/app/analysis/ticker_drilldown.py
+++ b/app/analysis/ticker_drilldown.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 TICKER_COLUMNS = ["ticker", "instrument"]
-RETURN_COLUMNS = ["net_return_pct", "return_pct"]
+RETURN_COLUMNS = ["net_return_pct", "return_pct", "net_return", "return"]
 TIER_COLUMNS = ["quality_tier", "tier"]
 
 
@@ -138,8 +138,8 @@ def compute_return_distribution(df: pd.DataFrame, ticker: str) -> dict[str, int]
         return distribution
 
     distribution["negative"] = int((returns <= 0).sum())
-    distribution["small_positive"] = int(((returns > 0) & (returns < 0.03)).sum())
-    distribution["strong_positive"] = int((returns >= 0.03).sum())
+    distribution["small_positive"] = int(((returns > 0) & (returns < 3.0)).sum())
+    distribution["strong_positive"] = int((returns >= 3.0).sum())
     return distribution
 
 

--- a/tests/test_ticker_drilldown.py
+++ b/tests/test_ticker_drilldown.py
@@ -31,7 +31,7 @@ def _sample_df() -> pd.DataFrame:
                 ]
             ),
             "holding_window": [5, 5, 20, 20, 5, 5],
-            "net_return_pct": [0.02, -0.01, 0.04, 0.01, 0.00, 0.03],
+            "net_return_pct": [2.0, -1.0, 4.0, 1.0, 0.0, 3.0],
             "quality_tier": ["A", "B", "A", "C", "A", "B"],
             "volatility_bucket": ["low", "mid", "mid", "high", "low", "mid"],
         }
@@ -67,7 +67,7 @@ def test_compute_tier_performance_groups_by_quality_tier():
 
     assert set(tier_stats.keys()) == {"A", "B", "C"}
     assert tier_stats["A"]["count"] == 3
-    assert round(tier_stats["C"]["avg_return"], 2) == 0.01
+    assert round(tier_stats["C"]["avg_return"], 2) == 1.0
 
 
 def test_compute_volatility_performance_groups_by_bucket():
@@ -82,7 +82,7 @@ def test_build_ticker_drilldown_low_sample_summary():
         {
             "instrument": ["AAA", "AAA"],
             "holding_window": [5, 20],
-            "net_return_pct": [0.01, -0.02],
+            "net_return_pct": [1.0, -2.0],
         }
     )
 
@@ -125,3 +125,84 @@ def test_build_ticker_drilldown_output_structure():
         "volatility_performance",
         "pattern_summary",
     }
+
+
+def _sample_df_with_alias(return_column: str) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB", "NCB", "NCB", "JMMB"],
+            "holding_window": [5, 5, 20, 20, 5],
+            return_column: [2.0, -1.0, 4.0, 1.0, 3.0],
+            "quality_tier": ["A", "B", "A", "C", "B"],
+            "volatility_bucket": ["low", "mid", "mid", "high", "mid"],
+        }
+    )
+
+
+def test_return_column_alias_resolution_supports_net_return():
+    df = _sample_df_with_alias("net_return")
+
+    signals = compute_signal_breakdown(df, "NCB")
+    holding = compute_holding_window_stats(df, "NCB")
+    distribution = compute_return_distribution(df, "NCB")
+    tier = compute_tier_performance(df, "NCB")
+    volatility = compute_volatility_performance(df, "NCB")
+
+    assert len(signals) == 4
+    assert holding["5D"]["count"] == 2
+    assert distribution == {"negative": 1, "small_positive": 2, "strong_positive": 1}
+    assert tier["A"]["count"] == 2
+    assert volatility["mid"]["count"] == 2
+
+
+def test_return_column_alias_resolution_supports_return():
+    df = _sample_df_with_alias("return")
+
+    signals = compute_signal_breakdown(df, "NCB")
+    holding = compute_holding_window_stats(df, "NCB")
+    distribution = compute_return_distribution(df, "NCB")
+    tier = compute_tier_performance(df, "NCB")
+    volatility = compute_volatility_performance(df, "NCB")
+
+    assert len(signals) == 4
+    assert holding["20D"]["count"] == 2
+    assert distribution == {"negative": 1, "small_positive": 2, "strong_positive": 1}
+    assert tier["C"]["count"] == 1
+    assert volatility["high"]["count"] == 1
+
+
+def test_return_distribution_uses_percentage_point_cutoffs_for_all_aliases():
+    expected = {"negative": 2, "small_positive": 2, "strong_positive": 2}
+    base = {
+        "instrument": ["NCB", "NCB", "NCB", "NCB", "NCB", "NCB"],
+        "values": [-2.0, 0.0, 0.5, 2.99, 3.0, 7.5],
+    }
+
+    for column in ["net_return_pct", "return_pct", "net_return", "return"]:
+        df = pd.DataFrame({"instrument": base["instrument"], column: base["values"]})
+        distribution = compute_return_distribution(df, "NCB")
+        assert distribution == expected
+
+
+def test_metrics_stay_empty_safe_when_no_supported_return_alias_exists():
+    df = pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB"],
+            "holding_window": [5, 20],
+            "quality_tier": ["A", "B"],
+            "volatility_bucket": ["low", "high"],
+            "gross_return": [1.2, -0.5],
+        }
+    )
+
+    signals = compute_signal_breakdown(df, "NCB")
+    holding = compute_holding_window_stats(df, "NCB")
+    distribution = compute_return_distribution(df, "NCB")
+    tier = compute_tier_performance(df, "NCB")
+    volatility = compute_volatility_performance(df, "NCB")
+
+    assert all("return_pct" not in row and "win_loss" not in row for row in signals)
+    assert holding == {}
+    assert distribution == {"negative": 0, "small_positive": 0, "strong_positive": 0}
+    assert tier == {}
+    assert volatility == {}


### PR DESCRIPTION
### Motivation
- Ensure the ticker drilldown works with different dataset schemas by supporting common return-column aliases so valid data is not ignored.  
- Correct return-distribution bucket thresholds so buckets operate on percentage-point values (e.g., 3.0) rather than fractional proportions (e.g., 0.03).  
- Preserve existing output structure and non-column-detection logic while keeping empty-safe behavior when no supported return column exists.

### Description
- Expanded `RETURN_COLUMNS` to `["net_return_pct", "return_pct", "net_return", "return"]` so the resolver checks aliases in priority order and selects the first available column.  
- Applied the alias-resolution via `_resolve_first_column`/`_resolve_return_column` consistently in `compute_signal_breakdown`, `compute_holding_window_stats`, `compute_return_distribution`, `compute_tier_performance`, and `compute_volatility_performance`.  
- Updated return-distribution cutoffs to percentage-point logic: `negative` = `<= 0`, `small_positive` = `0 < return < 3.0`, and `strong_positive` = `>= 3.0`.  
- Updated and added tests in `tests/test_ticker_drilldown.py` to cover alias resolution for `net_return` and `return`, validate distribution bucketing for all supported aliases, adjust sample fixtures to percentage-point values, and assert empty-safe behavior when no supported return field exists.

### Testing
- Ran the ticker-drilldown unit tests with `pytest -q tests/test_ticker_drilldown.py`, which completed successfully as `13 passed` (approx. `1.10s`).  
- All modified tests in `tests/test_ticker_drilldown.py` passed and confirm alias resolution and percentage-point distribution behavior.  
- No other automated tests were modified, and existing output structures and metrics logic remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2e10954b083229e7869d3aca6bc2a)