### PR TITLE
Support return column aliases and percentage-point normalization in ticker drilldown

### DIFF
--- a/app/analysis/ticker_drilldown.py
+++ b/app/analysis/ticker_drilldown.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 TICKER_COLUMNS = ["ticker", "instrument"]
-RETURN_COLUMNS = ["net_return_pct", "return_pct"]
+RETURN_COLUMNS = ["net_return_pct", "net_return", "return_pct", "return"]
 TIER_COLUMNS = ["quality_tier", "tier"]
 
 
@@ -25,6 +25,12 @@ def _resolve_ticker_column(df: pd.DataFrame) -> str | None:
 
 def _resolve_return_column(df: pd.DataFrame) -> str | None:
     return _resolve_first_column(df, RETURN_COLUMNS)
+
+
+def _normalize_returns_to_percentage_points(returns: pd.Series, return_column: str) -> pd.Series:
+    if return_column in {"net_return", "return"}:
+        return returns * 100.0
+    return returns
 
 
 def _resolve_tier_column(df: pd.DataFrame) -> str | None:
@@ -137,9 +143,11 @@ def compute_return_distribution(df: pd.DataFrame, ticker: str) -> dict[str, int]
     if returns.empty:
         return distribution
 
-    distribution["negative"] = int((returns <= 0).sum())
-    distribution["small_positive"] = int(((returns > 0) & (returns < 0.03)).sum())
-    distribution["strong_positive"] = int((returns >= 0.03).sum())
+    normalized_returns = _normalize_returns_to_percentage_points(returns, return_column)
+
+    distribution["negative"] = int((normalized_returns <= 0).sum())
+    distribution["small_positive"] = int(((normalized_returns > 0) & (normalized_returns < 3.0)).sum())
+    distribution["strong_positive"] = int((normalized_returns >= 3.0).sum())
     return distribution
 
 

--- a/tests/test_ticker_drilldown.py
+++ b/tests/test_ticker_drilldown.py
@@ -31,7 +31,7 @@ def _sample_df() -> pd.DataFrame:
                 ]
             ),
             "holding_window": [5, 5, 20, 20, 5, 5],
-            "net_return_pct": [0.02, -0.01, 0.04, 0.01, 0.00, 0.03],
+            "net_return_pct": [2.0, -1.0, 4.0, 1.0, 0.0, 3.0],
             "quality_tier": ["A", "B", "A", "C", "A", "B"],
             "volatility_bucket": ["low", "mid", "mid", "high", "low", "mid"],
         }
@@ -67,7 +67,7 @@ def test_compute_tier_performance_groups_by_quality_tier():
 
     assert set(tier_stats.keys()) == {"A", "B", "C"}
     assert tier_stats["A"]["count"] == 3
-    assert round(tier_stats["C"]["avg_return"], 2) == 0.01
+    assert round(tier_stats["C"]["avg_return"], 2) == 1.0
 
 
 def test_compute_volatility_performance_groups_by_bucket():
@@ -82,7 +82,7 @@ def test_build_ticker_drilldown_low_sample_summary():
         {
             "instrument": ["AAA", "AAA"],
             "holding_window": [5, 20],
-            "net_return_pct": [0.01, -0.02],
+            "net_return_pct": [1.0, -2.0],
         }
     )
 
@@ -125,3 +125,103 @@ def test_build_ticker_drilldown_output_structure():
         "volatility_performance",
         "pattern_summary",
     }
+
+
+def _sample_df_with_alias(return_column: str) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB", "NCB", "NCB", "JMMB"],
+            "holding_window": [5, 5, 20, 20, 5],
+            return_column: [0.02, -0.01, 0.04, 0.01, 0.03],
+            "quality_tier": ["A", "B", "A", "C", "B"],
+            "volatility_bucket": ["low", "mid", "mid", "high", "mid"],
+        }
+    )
+
+
+def test_return_column_alias_resolution_supports_net_return():
+    df = _sample_df_with_alias("net_return")
+
+    signals = compute_signal_breakdown(df, "NCB")
+    holding = compute_holding_window_stats(df, "NCB")
+    distribution = compute_return_distribution(df, "NCB")
+    tier = compute_tier_performance(df, "NCB")
+    volatility = compute_volatility_performance(df, "NCB")
+
+    assert len(signals) == 4
+    assert holding["5D"]["count"] == 2
+    assert distribution == {"negative": 1, "small_positive": 2, "strong_positive": 1}
+    assert tier["A"]["count"] == 2
+    assert volatility["mid"]["count"] == 2
+
+
+def test_return_column_alias_resolution_supports_return():
+    df = _sample_df_with_alias("return")
+
+    signals = compute_signal_breakdown(df, "NCB")
+    holding = compute_holding_window_stats(df, "NCB")
+    distribution = compute_return_distribution(df, "NCB")
+    tier = compute_tier_performance(df, "NCB")
+    volatility = compute_volatility_performance(df, "NCB")
+
+    assert len(signals) == 4
+    assert holding["20D"]["count"] == 2
+    assert distribution == {"negative": 1, "small_positive": 2, "strong_positive": 1}
+    assert tier["C"]["count"] == 1
+    assert volatility["high"]["count"] == 1
+
+
+def test_return_distribution_uses_percentage_point_cutoffs_for_all_aliases():
+    pct_expected = {"negative": 2, "small_positive": 2, "strong_positive": 2}
+    pct_values = [-2.0, 0.0, 0.5, 2.99, 3.0, 7.5]
+
+    for column in ["net_return_pct", "return_pct"]:
+        df = pd.DataFrame({"instrument": ["NCB"] * 6, column: pct_values})
+        distribution = compute_return_distribution(df, "NCB")
+        assert distribution == pct_expected
+
+    fractional_expected = {"negative": 2, "small_positive": 2, "strong_positive": 2}
+    fractional_values = [-0.02, 0.0, 0.005, 0.0299, 0.03, 0.075]
+
+    for column in ["net_return", "return"]:
+        df = pd.DataFrame({"instrument": ["NCB"] * 6, column: fractional_values})
+        distribution = compute_return_distribution(df, "NCB")
+        assert distribution == fractional_expected
+
+
+def test_return_column_priority_prefers_net_return_before_return_pct():
+    df = pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB", "NCB", "NCB"],
+            "net_return": [0.01, -0.01, 0.05, 0.02],
+            "return_pct": [100.0, 100.0, 100.0, 100.0],
+        }
+    )
+
+    distribution = compute_return_distribution(df, "NCB")
+
+    assert distribution == {"negative": 1, "small_positive": 2, "strong_positive": 1}
+
+
+def test_metrics_stay_empty_safe_when_no_supported_return_alias_exists():
+    df = pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB"],
+            "holding_window": [5, 20],
+            "quality_tier": ["A", "B"],
+            "volatility_bucket": ["low", "high"],
+            "gross_return": [1.2, -0.5],
+        }
+    )
+
+    signals = compute_signal_breakdown(df, "NCB")
+    holding = compute_holding_window_stats(df, "NCB")
+    distribution = compute_return_distribution(df, "NCB")
+    tier = compute_tier_performance(df, "NCB")
+    volatility = compute_volatility_performance(df, "NCB")
+
+    assert all("return_pct" not in row and "win_loss" not in row for row in signals)
+    assert holding == {}
+    assert distribution == {"negative": 0, "small_positive": 0, "strong_positive": 0}
+    assert tier == {}
+    assert volatility == {}


### PR DESCRIPTION
### Motivation
- Make the ticker drilldown functions accept common return column aliases (`net_return`, `return`, `net_return_pct`, `return_pct`) so metrics work across datasets with different naming conventions.
- Ensure return bucketing and summary metrics use consistent percentage-point cutoffs regardless of whether returns are stored as fractions or already as percentage points.

### Description
- Added additional return column aliases to `RETURN_COLUMNS` to include `net_return` and `return`.
- Implemented `_normalize_returns_to_percentage_points` to convert fractional return columns (`net_return`, `return`) into percentage points for consistent thresholding.
- Updated `compute_return_distribution` to normalize returns and apply percentage-point cutoffs (`3.0` for strong positive) when building buckets.
- Adjusted tests in `tests/test_ticker_drilldown.py` and added new tests to validate alias resolution, normalization behavior, and priority ordering of return column selection.

### Testing
- Ran `pytest tests/test_ticker_drilldown.py` which executes the unit tests for the ticker drilldown module and the new alias/normalization cases; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2e10954b083229e7869d3aca6bc2a)