### PR TITLE
Normalize return aliases (net_return / return / *_pct) and use percentage-point thresholds in ticker drilldown

### DIFF
--- a/app/analysis/ticker_drilldown.py
+++ b/app/analysis/ticker_drilldown.py
@@ -8,8 +8,10 @@ import pandas as pd
 
 
 TICKER_COLUMNS = ["ticker", "instrument"]
-RETURN_COLUMNS = ["net_return_pct", "return_pct"]
+RETURN_COLUMNS = ["net_return_pct", "net_return", "return_pct", "return"]
 TIER_COLUMNS = ["quality_tier", "tier"]
+NORMALIZED_RETURN_COLUMN = "_normalized_return_pct"
+PATTERN_SUMMARY_THRESHOLD_PCT = 0.3
 
 
 def _resolve_first_column(df: pd.DataFrame, candidates: list[str]) -> str | None:
@@ -25,6 +27,19 @@ def _resolve_ticker_column(df: pd.DataFrame) -> str | None:
 
 def _resolve_return_column(df: pd.DataFrame) -> str | None:
     return _resolve_first_column(df, RETURN_COLUMNS)
+
+
+def _normalize_returns_to_percentage_points(returns: pd.Series, return_column: str) -> pd.Series:
+    if return_column in {"net_return", "return"}:
+        return returns * 100.0
+    return returns
+
+
+def _attach_normalized_returns(df: pd.DataFrame, return_column: str) -> pd.DataFrame:
+    scoped = df.copy()
+    returns = pd.to_numeric(scoped[return_column], errors="coerce")
+    scoped[NORMALIZED_RETURN_COLUMN] = _normalize_returns_to_percentage_points(returns, return_column)
+    return scoped
 
 
 def _resolve_tier_column(df: pd.DataFrame) -> str | None:
@@ -78,6 +93,8 @@ def compute_signal_breakdown(df: pd.DataFrame, ticker: str) -> list[dict[str, An
         return []
 
     return_column = _resolve_return_column(scoped)
+    if return_column is not None:
+        scoped = _attach_normalized_returns(scoped, return_column)
     tier_column = _resolve_tier_column(scoped)
 
     if "date" in scoped.columns:
@@ -96,7 +113,7 @@ def compute_signal_breakdown(df: pd.DataFrame, ticker: str) -> list[dict[str, An
             signal["holding_window"] = _format_holding_window(row.get("holding_window"))
 
         if return_column is not None:
-            return_value = pd.to_numeric(row.get(return_column), errors="coerce")
+            return_value = pd.to_numeric(row.get(NORMALIZED_RETURN_COLUMN), errors="coerce")
             if not pd.isna(return_value):
                 return_float = float(return_value)
                 signal["return_pct"] = return_float
@@ -118,10 +135,11 @@ def compute_holding_window_stats(df: pd.DataFrame, ticker: str) -> dict[str, dic
     return_column = _resolve_return_column(scoped)
     if scoped.empty or return_column is None or "holding_window" not in scoped.columns:
         return {}
+    scoped = _attach_normalized_returns(scoped, return_column)
 
     stats: dict[str, dict[str, float | int]] = {}
     for window, group in scoped.groupby("holding_window", dropna=True):
-        stats[_format_holding_window(window)] = _build_group_stats(group, return_column)
+        stats[_format_holding_window(window)] = _build_group_stats(group, NORMALIZED_RETURN_COLUMN)
 
     return stats
 
@@ -133,13 +151,14 @@ def compute_return_distribution(df: pd.DataFrame, ticker: str) -> dict[str, int]
     if scoped.empty or return_column is None:
         return distribution
 
-    returns = pd.to_numeric(scoped[return_column], errors="coerce").dropna()
+    scoped = _attach_normalized_returns(scoped, return_column)
+    returns = pd.to_numeric(scoped[NORMALIZED_RETURN_COLUMN], errors="coerce").dropna()
     if returns.empty:
         return distribution
 
     distribution["negative"] = int((returns <= 0).sum())
-    distribution["small_positive"] = int(((returns > 0) & (returns < 0.03)).sum())
-    distribution["strong_positive"] = int((returns >= 0.03).sum())
+    distribution["small_positive"] = int(((returns > 0) & (returns < 3.0)).sum())
+    distribution["strong_positive"] = int((returns >= 3.0).sum())
     return distribution
 
 
@@ -149,10 +168,11 @@ def compute_tier_performance(df: pd.DataFrame, ticker: str) -> dict[str, dict[st
     tier_column = _resolve_tier_column(scoped)
     if scoped.empty or return_column is None or tier_column is None:
         return {}
+    scoped = _attach_normalized_returns(scoped, return_column)
 
     stats: dict[str, dict[str, float | int]] = {}
     for tier, group in scoped.groupby(tier_column, dropna=True):
-        stats[str(tier)] = _build_group_stats(group, return_column)
+        stats[str(tier)] = _build_group_stats(group, NORMALIZED_RETURN_COLUMN)
 
     return stats
 
@@ -162,10 +182,11 @@ def compute_volatility_performance(df: pd.DataFrame, ticker: str) -> dict[str, d
     return_column = _resolve_return_column(scoped)
     if scoped.empty or return_column is None or "volatility_bucket" not in scoped.columns:
         return {}
+    scoped = _attach_normalized_returns(scoped, return_column)
 
     stats: dict[str, dict[str, float | int]] = {}
     for bucket, group in scoped.groupby("volatility_bucket", dropna=True):
-        stats[str(bucket)] = _build_group_stats(group, return_column)
+        stats[str(bucket)] = _build_group_stats(group, NORMALIZED_RETURN_COLUMN)
 
     return stats
 
@@ -212,7 +233,7 @@ def build_pattern_summary(
         if (
             float(top_stats.get("win_rate", 0.0)) >= float(second_stats.get("win_rate", 0.0)) + 0.1
             or float(top_stats.get("median_return", 0.0))
-            >= float(second_stats.get("median_return", 0.0)) + 0.003
+            >= float(second_stats.get("median_return", 0.0)) + PATTERN_SUMMARY_THRESHOLD_PCT
         ):
             return f"This stock tends to hold up better on {top_window} than {second_window} in this dataset."
 

--- a/tests/test_ticker_drilldown.py
+++ b/tests/test_ticker_drilldown.py
@@ -31,7 +31,7 @@ def _sample_df() -> pd.DataFrame:
                 ]
             ),
             "holding_window": [5, 5, 20, 20, 5, 5],
-            "net_return_pct": [0.02, -0.01, 0.04, 0.01, 0.00, 0.03],
+            "net_return_pct": [2.0, -1.0, 4.0, 1.0, 0.0, 3.0],
             "quality_tier": ["A", "B", "A", "C", "A", "B"],
             "volatility_bucket": ["low", "mid", "mid", "high", "low", "mid"],
         }
@@ -67,7 +67,7 @@ def test_compute_tier_performance_groups_by_quality_tier():
 
     assert set(tier_stats.keys()) == {"A", "B", "C"}
     assert tier_stats["A"]["count"] == 3
-    assert round(tier_stats["C"]["avg_return"], 2) == 0.01
+    assert round(tier_stats["C"]["avg_return"], 2) == 1.0
 
 
 def test_compute_volatility_performance_groups_by_bucket():
@@ -82,7 +82,7 @@ def test_build_ticker_drilldown_low_sample_summary():
         {
             "instrument": ["AAA", "AAA"],
             "holding_window": [5, 20],
-            "net_return_pct": [0.01, -0.02],
+            "net_return_pct": [1.0, -2.0],
         }
     )
 
@@ -125,3 +125,196 @@ def test_build_ticker_drilldown_output_structure():
         "volatility_performance",
         "pattern_summary",
     }
+
+
+def _sample_df_with_alias(return_column: str) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB", "NCB", "NCB", "JMMB"],
+            "holding_window": [5, 5, 20, 20, 5],
+            return_column: [0.02, -0.01, 0.04, 0.01, 0.03],
+            "quality_tier": ["A", "B", "A", "C", "B"],
+            "volatility_bucket": ["low", "mid", "mid", "high", "mid"],
+        }
+    )
+
+
+def test_return_column_alias_resolution_supports_net_return():
+    df = _sample_df_with_alias("net_return")
+
+    signals = compute_signal_breakdown(df, "NCB")
+    holding = compute_holding_window_stats(df, "NCB")
+    distribution = compute_return_distribution(df, "NCB")
+    tier = compute_tier_performance(df, "NCB")
+    volatility = compute_volatility_performance(df, "NCB")
+
+    assert len(signals) == 4
+    assert holding["5D"]["count"] == 2
+    assert distribution == {"negative": 1, "small_positive": 2, "strong_positive": 1}
+    assert tier["A"]["count"] == 2
+    assert volatility["mid"]["count"] == 2
+
+
+def test_return_column_alias_resolution_supports_return():
+    df = _sample_df_with_alias("return")
+
+    signals = compute_signal_breakdown(df, "NCB")
+    holding = compute_holding_window_stats(df, "NCB")
+    distribution = compute_return_distribution(df, "NCB")
+    tier = compute_tier_performance(df, "NCB")
+    volatility = compute_volatility_performance(df, "NCB")
+
+    assert len(signals) == 4
+    assert holding["20D"]["count"] == 2
+    assert distribution == {"negative": 1, "small_positive": 2, "strong_positive": 1}
+    assert tier["C"]["count"] == 1
+    assert volatility["high"]["count"] == 1
+
+
+def test_return_distribution_uses_percentage_point_cutoffs_for_all_aliases():
+    pct_expected = {"negative": 2, "small_positive": 2, "strong_positive": 2}
+    pct_values = [-2.0, 0.0, 0.5, 2.99, 3.0, 7.5]
+
+    for column in ["net_return_pct", "return_pct"]:
+        df = pd.DataFrame({"instrument": ["NCB"] * 6, column: pct_values})
+        distribution = compute_return_distribution(df, "NCB")
+        assert distribution == pct_expected
+
+    fractional_expected = {"negative": 2, "small_positive": 2, "strong_positive": 2}
+    fractional_values = [-0.02, 0.0, 0.005, 0.0299, 0.03, 0.075]
+
+    for column in ["net_return", "return"]:
+        df = pd.DataFrame({"instrument": ["NCB"] * 6, column: fractional_values})
+        distribution = compute_return_distribution(df, "NCB")
+        assert distribution == fractional_expected
+
+
+def test_return_column_priority_prefers_net_return_before_return_pct():
+    df = pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB", "NCB", "NCB"],
+            "net_return": [0.01, -0.01, 0.05, 0.02],
+            "return_pct": [100.0, 100.0, 100.0, 100.0],
+        }
+    )
+
+    distribution = compute_return_distribution(df, "NCB")
+
+    assert distribution == {"negative": 1, "small_positive": 2, "strong_positive": 1}
+
+
+def test_metrics_stay_empty_safe_when_no_supported_return_alias_exists():
+    df = pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB"],
+            "holding_window": [5, 20],
+            "quality_tier": ["A", "B"],
+            "volatility_bucket": ["low", "high"],
+            "gross_return": [1.2, -0.5],
+        }
+    )
+
+    signals = compute_signal_breakdown(df, "NCB")
+    holding = compute_holding_window_stats(df, "NCB")
+    distribution = compute_return_distribution(df, "NCB")
+    tier = compute_tier_performance(df, "NCB")
+    volatility = compute_volatility_performance(df, "NCB")
+
+    assert all("return_pct" not in row and "win_loss" not in row for row in signals)
+    assert holding == {}
+    assert distribution == {"negative": 0, "small_positive": 0, "strong_positive": 0}
+    assert tier == {}
+    assert volatility == {}
+
+
+def _equivalent_alias_df(return_column: str) -> pd.DataFrame:
+    percent_point_returns = [2.5, -1.0, 3.5, 1.0]
+    returns = (
+        [value / 100.0 for value in percent_point_returns]
+        if return_column in {"net_return", "return"}
+        else percent_point_returns
+    )
+    return pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB", "NCB", "NCB"],
+            "holding_window": [5, 5, 20, 20],
+            "quality_tier": ["A", "B", "A", "C"],
+            "volatility_bucket": ["low", "mid", "mid", "high"],
+            return_column: returns,
+        }
+    )
+
+
+def test_drilldown_outputs_are_schema_consistent_across_return_aliases():
+    aliases = ["net_return_pct", "net_return", "return_pct", "return"]
+    payloads = {alias: build_ticker_drilldown(_equivalent_alias_df(alias), "NCB") for alias in aliases}
+
+    def _rounded_stats(stats: dict[str, dict[str, float | int]]) -> dict[str, dict[str, float | int]]:
+        rounded: dict[str, dict[str, float | int]] = {}
+        for bucket, values in stats.items():
+            rounded[bucket] = {
+                key: (round(float(value), 8) if isinstance(value, float) else value) for key, value in values.items()
+            }
+        return rounded
+
+    baseline = payloads["net_return_pct"]
+    for alias in aliases[1:]:
+        assert len(payloads[alias]["signals"]) == len(baseline["signals"])
+        for candidate_signal, baseline_signal in zip(payloads[alias]["signals"], baseline["signals"], strict=True):
+            assert candidate_signal.keys() == baseline_signal.keys()
+            for key in candidate_signal:
+                if key == "return_pct":
+                    assert round(float(candidate_signal[key]), 8) == round(float(baseline_signal[key]), 8)
+                else:
+                    assert candidate_signal[key] == baseline_signal[key]
+        assert _rounded_stats(payloads[alias]["holding_window_stats"]) == _rounded_stats(baseline["holding_window_stats"])
+        assert payloads[alias]["return_distribution"] == baseline["return_distribution"]
+        assert _rounded_stats(payloads[alias]["tier_performance"]) == _rounded_stats(baseline["tier_performance"])
+        assert _rounded_stats(payloads[alias]["volatility_performance"]) == _rounded_stats(
+            baseline["volatility_performance"]
+        )
+        assert payloads[alias]["pattern_summary"] == baseline["pattern_summary"]
+
+
+def _pattern_window_df(return_column: str, five_day_returns_pct: list[float], twenty_day_returns_pct: list[float]) -> pd.DataFrame:
+    all_returns_pct = five_day_returns_pct + twenty_day_returns_pct
+    returns = (
+        [value / 100.0 for value in all_returns_pct]
+        if return_column in {"net_return", "return"}
+        else all_returns_pct
+    )
+    return pd.DataFrame(
+        {
+            "instrument": ["NCB", "NCB", "NCB", "NCB"],
+            "holding_window": [5, 5, 20, 20],
+            "quality_tier": ["A", "A", "A", "A"],
+            "volatility_bucket": ["mid", "mid", "mid", "mid"],
+            return_column: returns,
+        }
+    )
+
+
+def test_pattern_summary_holding_window_threshold_does_not_trigger_below_point_three_pct():
+    aliases = ["net_return_pct", "return_pct", "net_return", "return"]
+
+    for alias in aliases:
+        df = _pattern_window_df(
+            return_column=alias,
+            five_day_returns_pct=[1.0, 3.0],   # median 2.0
+            twenty_day_returns_pct=[1.8, 1.8],  # median 1.8 (delta 0.2)
+        )
+        payload = build_ticker_drilldown(df, "NCB")
+        assert "tends to hold up better on" not in payload["pattern_summary"]
+
+
+def test_pattern_summary_holding_window_threshold_triggers_above_point_three_pct():
+    aliases = ["net_return_pct", "return_pct", "net_return", "return"]
+
+    for alias in aliases:
+        df = _pattern_window_df(
+            return_column=alias,
+            five_day_returns_pct=[1.0, 3.0],   # median 2.0
+            twenty_day_returns_pct=[1.5, 1.7],  # median 1.6 (delta 0.4)
+        )
+        payload = build_ticker_drilldown(df, "NCB")
+        assert "tends to hold up better on 5D than 20D" in payload["pattern_summary"]


### PR DESCRIPTION
### Motivation

- Ensure the ticker drilldown analysis accepts multiple return column aliases (`net_return_pct`, `return_pct`, `net_return`, `return`) and computes metrics consistently regardless of whether returns are expressed as fractional values or percentage points.
- Make pattern-detection thresholds operate in percentage points to avoid subtle mismatches between fractional and percent representations.

### Description

- Added return alias resolution and normalization by introducing `NORMALIZED_RETURN_COLUMN`, `_normalize_returns_to_percentage_points`, and `_attach_normalized_returns`, and updated metric computations to use the normalized column where appropriate.
- Extended `RETURN_COLUMNS` to include `net_return` and `return` and ensured `compute_*` functions (`compute_signal_breakdown`, `compute_holding_window_stats`, `compute_return_distribution`, `compute_tier_performance`, `compute_volatility_performance`, and `build_ticker_drilldown` usages) attach and use normalized returns when a supported return column exists.
- Updated distribution cutoffs to operate on percentage points (small positive < 3.0, strong positive >= 3.0) and changed the pattern-summary median delta threshold to `PATTERN_SUMMARY_THRESHOLD_PCT = 0.3` for clarity and consistency.
- Added and updated comprehensive tests in `tests/test_ticker_drilldown.py` to cover alias support, normalization behavior, cutoff semantics, priority of aliases, schema consistency across aliases, and the pattern-summary threshold behavior.

### Testing

- Ran the ticker drilldown test module with `pytest tests/test_ticker_drilldown.py` and the updated test suite executed all new and existing assertions successfully.
- Verified that alias-resolution, normalization, distribution bucketing, grouping stats, and pattern-summary threshold tests all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2e10954b083229e7869d3aca6bc2a)