### PR TITLE
Implement Sprint 11 decision review and discipline layer

### DIFF
--- a/app.py
+++ b/app.py
@@ -160,6 +160,7 @@ def main() -> None:
             enriched_allocations,
             total_capital=total_capital,
             st_module=st,
+            signals_df=ranked_df,
         )
 
 

--- a/app/planner/decision_review.py
+++ b/app/planner/decision_review.py
@@ -1,0 +1,299 @@
+"""Decision review utilities for post-allocation discipline checks."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pandas as pd
+
+
+def compute_trade_review(trades_df: pd.DataFrame, signals_df: pd.DataFrame) -> pd.DataFrame:
+    """Compute per-trade decision review fields in an empty-safe way."""
+    if trades_df is None or trades_df.empty:
+        return pd.DataFrame(
+            columns=[
+                "instrument",
+                "followed_rules",
+                "deviation_type",
+                "selected_rank",
+                "best_available_rank",
+                "quality_flag",
+                "liquidity_flag",
+            ]
+        )
+
+    signal_rank_lookup = _build_signal_rank_lookup(signals_df)
+
+    reviewed_rows: list[dict[str, Any]] = []
+    for idx, trade in trades_df.reset_index(drop=True).iterrows():
+        trade_map = trade.to_dict()
+        instrument = _as_text(trade_map.get("instrument"), fallback=f"row_{idx + 1}")
+
+        selected_rank = _int_or_none(trade_map.get("selection_rank"))
+        best_available_rank = signal_rank_lookup.get(instrument)
+
+        quality_ok = _quality_passes(trade_map)
+        liquidity_ok = _liquidity_passes(trade_map)
+        rank_ok = True
+        if selected_rank is not None and best_available_rank is not None:
+            rank_ok = selected_rank <= best_available_rank
+
+        followed_rules = bool(quality_ok and liquidity_ok and rank_ok)
+        deviation_type = _resolve_deviation_type(
+            followed_rules=followed_rules,
+            quality_ok=quality_ok,
+            liquidity_ok=liquidity_ok,
+            rank_ok=rank_ok,
+        )
+
+        reviewed_rows.append(
+            {
+                "instrument": instrument,
+                "followed_rules": followed_rules,
+                "deviation_type": deviation_type,
+                "selected_rank": selected_rank,
+                "best_available_rank": best_available_rank,
+                "quality_flag": "pass" if quality_ok else "fail",
+                "liquidity_flag": "pass" if liquidity_ok else "fail",
+            }
+        )
+
+    return pd.DataFrame(reviewed_rows)
+
+
+def detect_decision_mistakes(
+    trades_df: pd.DataFrame,
+    signals_df: pd.DataFrame,
+    allocation_df: pd.DataFrame,
+) -> list[dict[str, Any]]:
+    """Detect selection mistakes from trade, signal, and allocation context."""
+    if trades_df is None or trades_df.empty:
+        return []
+
+    review_df = compute_trade_review(trades_df, signals_df)
+    mistakes: list[dict[str, Any]] = []
+
+    for row in review_df.to_dict("records"):
+        instrument = row.get("instrument", "Trade")
+        selected_rank = row.get("selected_rank")
+        best_rank = row.get("best_available_rank")
+
+        if selected_rank is not None and best_rank is not None and selected_rank > best_rank:
+            mistakes.append(
+                {
+                    "type": "ignored_higher_rank",
+                    "message": (
+                        f"{instrument} was selected at rank #{selected_rank} while rank #{best_rank} "
+                        "was available."
+                    ),
+                    "impact": "Selection order drifted from top-ranked signals.",
+                }
+            )
+
+        if row.get("quality_flag") == "fail":
+            mistakes.append(
+                {
+                    "type": "low_quality_trade",
+                    "message": f"{instrument} did not meet the quality tier rule.",
+                    "impact": "Trade quality consistency dropped.",
+                }
+            )
+
+        if row.get("liquidity_flag") == "fail":
+            mistakes.append(
+                {
+                    "type": "liquidity_violation",
+                    "message": f"{instrument} failed the liquidity screen.",
+                    "impact": "Execution reliability may be weaker.",
+                }
+            )
+
+    allocation_safe = allocation_df if allocation_df is not None else pd.DataFrame()
+    if not allocation_safe.empty:
+        over_allocated = allocation_safe[
+            pd.to_numeric(allocation_safe.get("allocation_pct"), errors="coerce").fillna(0.0) > 0.70
+        ]
+        for _, row in over_allocated.iterrows():
+            instrument = _as_text(row.get("instrument"), fallback="Trade")
+            allocation_pct = float(pd.to_numeric(row.get("allocation_pct"), errors="coerce") or 0.0)
+            mistakes.append(
+                {
+                    "type": "over_allocation",
+                    "message": f"{instrument} received {allocation_pct:.0%}, above the 70% cap.",
+                    "impact": "Portfolio concentration became too high.",
+                }
+            )
+
+    merged_df = trades_df.copy()
+    if not allocation_safe.empty and "instrument" in merged_df.columns and "instrument" in allocation_safe.columns:
+        merged_df = merged_df.merge(
+            allocation_safe[["instrument", "allocation_pct"]],
+            on="instrument",
+            how="left",
+        )
+
+    cooldown_mask = _build_cooldown_mask(merged_df)
+    if cooldown_mask.any():
+        flagged = merged_df[cooldown_mask]
+        for _, row in flagged.iterrows():
+            instrument = _as_text(row.get("instrument"), fallback="Trade")
+            allocation_pct = float(pd.to_numeric(row.get("allocation_pct"), errors="coerce") or 0.0)
+            if allocation_pct > 0:
+                mistakes.append(
+                    {
+                        "type": "cooldown_violation",
+                        "message": f"{instrument} was funded while cooldown was active.",
+                        "impact": "Cooldown discipline was broken.",
+                    }
+                )
+
+    return mistakes
+
+
+def build_behavior_summary(trades_df: pd.DataFrame, review_df: pd.DataFrame) -> list[str]:
+    """Build 2-4 plain-language observations about trade selection behavior."""
+    trade_count = int(len(trades_df)) if trades_df is not None else 0
+    if review_df is None or review_df.empty or trade_count == 0:
+        return [
+            "No trade behavior to review yet.",
+            "Add a few completed selections to see a pattern summary.",
+        ]
+
+    total = max(int(len(review_df)), 1)
+    followed = int(pd.to_numeric(review_df["followed_rules"], errors="coerce").fillna(0).astype(int).sum())
+    rule_rate = followed / total
+
+    rank_misses = int((review_df["deviation_type"] == "rank_deviation").sum())
+    quality_fails = int((review_df["quality_flag"] == "fail").sum())
+    liquidity_fails = int((review_df["liquidity_flag"] == "fail").sum())
+
+    insights: list[str] = [
+        f"{followed} of {total} trades followed the selection rules ({rule_rate:.0%}).",
+        f"Rank order mismatches appeared on {rank_misses} trade(s).",
+    ]
+
+    if quality_fails > 0:
+        insights.append(f"{quality_fails} trade(s) were below the quality rule.")
+    else:
+        insights.append("All reviewed trades stayed within the quality rule.")
+
+    if liquidity_fails > 0:
+        insights.append(f"Liquidity checks failed on {liquidity_fails} trade(s).")
+    else:
+        insights.append("Liquidity checks stayed clean across reviewed trades.")
+
+    return insights[:4]
+
+
+def compute_discipline_score(review_df: pd.DataFrame) -> float:
+    """Compute discipline score on a 0-100 scale from review adherence."""
+    if review_df is None or review_df.empty:
+        return 0.0
+
+    total = max(int(len(review_df)), 1)
+    followed_rate = float(review_df["followed_rules"].fillna(False).astype(bool).mean())
+
+    rank_series = pd.Series([True] * total)
+    if "selected_rank" in review_df.columns and "best_available_rank" in review_df.columns:
+        rank_series = review_df.apply(
+            lambda row: _rank_passes(row.get("selected_rank"), row.get("best_available_rank")),
+            axis=1,
+        )
+    rank_rate = float(rank_series.astype(bool).mean())
+
+    quality_rate = float((review_df.get("quality_flag", pd.Series(["fail"] * total)) == "pass").mean())
+
+    score = (followed_rate * 0.5 + rank_rate * 0.25 + quality_rate * 0.25) * 100
+    return round(float(score), 1)
+
+
+def _build_signal_rank_lookup(signals_df: pd.DataFrame) -> dict[str, int]:
+    if signals_df is None or signals_df.empty or "instrument" not in signals_df.columns:
+        return {}
+
+    working = signals_df.copy()
+    if "rank" not in working.columns:
+        if "score_total" in working.columns:
+            working = working.sort_values("score_total", ascending=False).reset_index(drop=True)
+            working["rank"] = working.index + 1
+        else:
+            working = working.reset_index(drop=True)
+            working["rank"] = working.index + 1
+
+    lookup: dict[str, int] = {}
+    for _, row in working.iterrows():
+        instrument = _as_text(row.get("instrument"))
+        rank = _int_or_none(row.get("rank"))
+        if instrument and rank is not None and instrument not in lookup:
+            lookup[instrument] = rank
+    return lookup
+
+
+def _quality_passes(trade: Mapping[str, Any]) -> bool:
+    quality_tier = _as_text(trade.get("quality_tier")).upper()
+    return quality_tier != "C"
+
+
+def _liquidity_passes(trade: Mapping[str, Any]) -> bool:
+    value = trade.get("liquidity_pass")
+    if value is None:
+        return True
+    return bool(value)
+
+
+def _resolve_deviation_type(
+    *,
+    followed_rules: bool,
+    quality_ok: bool,
+    liquidity_ok: bool,
+    rank_ok: bool,
+) -> str | None:
+    if followed_rules:
+        return None
+    if not rank_ok:
+        return "rank_deviation"
+    if not quality_ok:
+        return "quality_deviation"
+    if not liquidity_ok:
+        return "liquidity_deviation"
+    return "rule_deviation"
+
+
+def _build_cooldown_mask(df: pd.DataFrame) -> pd.Series:
+    if df is None or df.empty:
+        return pd.Series(dtype=bool)
+
+    cooldown_active = pd.Series(False, index=df.index)
+    for column in ("cooldown_active", "cooldown_violation", "in_cooldown"):
+        if column in df.columns:
+            cooldown_active = cooldown_active | df[column].fillna(False).astype(bool)
+
+    if "days_since_exit" in df.columns:
+        days = pd.to_numeric(df["days_since_exit"], errors="coerce")
+        cooldown_active = cooldown_active | (days < 5)
+
+    return cooldown_active
+
+
+def _rank_passes(selected_rank: Any, best_available_rank: Any) -> bool:
+    selected = _int_or_none(selected_rank)
+    best = _int_or_none(best_available_rank)
+    if selected is None or best is None:
+        return True
+    return selected <= best
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_text(value: Any, fallback: str = "") -> str:
+    if value is None:
+        return fallback
+    token = str(value).strip()
+    return token or fallback

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -6,6 +6,12 @@ from typing import Any, Mapping, Sequence
 
 import pandas as pd
 
+from app.planner.decision_review import (
+    build_behavior_summary,
+    compute_discipline_score,
+    compute_trade_review,
+    detect_decision_mistakes,
+)
 from app.planner.explanations import (
     REASON_KEYS,
     classify_decision_status,
@@ -79,6 +85,9 @@ def render_portfolio_plan(
     allocations: Sequence[Mapping[str, Any]],
     total_capital: float,
     st_module=None,
+    *,
+    signals_df: pd.DataFrame | None = None,
+    show_review_table: bool = True,
 ) -> None:
     """Render portfolio summary, funded/unfunded tables, and constraints."""
     if st_module is None:
@@ -158,6 +167,40 @@ def render_portfolio_plan(
         "- Max funded trades: 3\n"
         "- Tier C and liquidity failures are not funded"
     )
+
+    st_module.markdown("#### Decision Review")
+    trades_df = pd.DataFrame(list(allocations))
+    safe_signals_df = signals_df if signals_df is not None else pd.DataFrame()
+    review_df = compute_trade_review(trades_df, safe_signals_df)
+    mistake_list = detect_decision_mistakes(
+        trades_df,
+        safe_signals_df,
+        trades_df,
+    )
+    discipline_score = compute_discipline_score(review_df)
+
+    st_module.write({"Discipline Score": discipline_score})
+
+    behavior_summary = build_behavior_summary(trades_df, review_df)
+    st_module.markdown("**Behavior Summary**")
+    for item in behavior_summary:
+        st_module.markdown(f"- {item}")
+
+    st_module.markdown("**Mistakes Detected**")
+    if mistake_list:
+        for mistake in mistake_list:
+            st_module.markdown(
+                f"- **{mistake['type']}**: {mistake['message']} Impact: {mistake['impact']}"
+            )
+    else:
+        st_module.markdown("- No clear decision mistakes were detected.")
+
+    if show_review_table:
+        st_module.markdown("**Trade Review Table**")
+        if review_df.empty:
+            st_module.info("No review rows available for this run.")
+        else:
+            st_module.dataframe(review_df, use_container_width=True)
 
 
 def _first_sentence(text: str) -> str:

--- a/tests/test_decision_review.py
+++ b/tests/test_decision_review.py
@@ -1,0 +1,192 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.planner.decision_review import (
+    build_behavior_summary,
+    compute_discipline_score,
+    compute_trade_review,
+    detect_decision_mistakes,
+)
+
+
+def _signals_df():
+    return pd.DataFrame(
+        [
+            {"instrument": "AAA", "rank": 1, "score_total": 0.95},
+            {"instrument": "BBB", "rank": 2, "score_total": 0.90},
+            {"instrument": "CCC", "rank": 3, "score_total": 0.85},
+        ]
+    )
+
+
+def test_compute_trade_review_returns_expected_columns_and_flags():
+    trades_df = pd.DataFrame(
+        [
+            {
+                "instrument": "AAA",
+                "selection_rank": 2,
+                "quality_tier": "A",
+                "liquidity_pass": True,
+            },
+            {
+                "instrument": "CCC",
+                "selection_rank": 3,
+                "quality_tier": "C",
+                "liquidity_pass": False,
+            },
+        ]
+    )
+
+    review_df = compute_trade_review(trades_df, _signals_df())
+
+    assert set(review_df.columns) == {
+        "instrument",
+        "followed_rules",
+        "deviation_type",
+        "selected_rank",
+        "best_available_rank",
+        "quality_flag",
+        "liquidity_flag",
+    }
+    assert review_df.iloc[0]["deviation_type"] == "rank_deviation"
+    assert review_df.iloc[1]["quality_flag"] == "fail"
+    assert review_df.iloc[1]["liquidity_flag"] == "fail"
+
+
+def test_detect_decision_mistakes_catches_each_mistake_type():
+    trades_df = pd.DataFrame(
+        [
+            {
+                "instrument": "AAA",
+                "selection_rank": 2,
+                "quality_tier": "A",
+                "liquidity_pass": True,
+                "cooldown_active": False,
+            },
+            {
+                "instrument": "BBB",
+                "selection_rank": 2,
+                "quality_tier": "C",
+                "liquidity_pass": False,
+                "cooldown_active": False,
+            },
+            {
+                "instrument": "CCC",
+                "selection_rank": 3,
+                "quality_tier": "A",
+                "liquidity_pass": True,
+                "cooldown_active": True,
+            },
+        ]
+    )
+    allocation_df = pd.DataFrame(
+        [
+            {"instrument": "AAA", "allocation_pct": 0.10},
+            {"instrument": "BBB", "allocation_pct": 0.80},
+            {"instrument": "CCC", "allocation_pct": 0.20},
+        ]
+    )
+
+    mistakes = detect_decision_mistakes(trades_df, _signals_df(), allocation_df)
+    mistake_types = {item["type"] for item in mistakes}
+
+    assert "ignored_higher_rank" in mistake_types
+    assert "low_quality_trade" in mistake_types
+    assert "liquidity_violation" in mistake_types
+    assert "over_allocation" in mistake_types
+    assert "cooldown_violation" in mistake_types
+
+
+def test_build_behavior_summary_generates_observational_bullets():
+    trades_df = pd.DataFrame(
+        [
+            {"instrument": "AAA"},
+            {"instrument": "BBB"},
+            {"instrument": "CCC"},
+        ]
+    )
+    review_df = pd.DataFrame(
+        [
+            {
+                "instrument": "AAA",
+                "followed_rules": True,
+                "deviation_type": None,
+                "quality_flag": "pass",
+                "liquidity_flag": "pass",
+            },
+            {
+                "instrument": "BBB",
+                "followed_rules": False,
+                "deviation_type": "rank_deviation",
+                "quality_flag": "pass",
+                "liquidity_flag": "pass",
+            },
+            {
+                "instrument": "CCC",
+                "followed_rules": False,
+                "deviation_type": "quality_deviation",
+                "quality_flag": "fail",
+                "liquidity_flag": "fail",
+            },
+        ]
+    )
+
+    summary = build_behavior_summary(trades_df, review_df)
+
+    assert 2 <= len(summary) <= 4
+    assert all(isinstance(item, str) for item in summary)
+    assert "followed the selection rules" in summary[0]
+
+
+def test_compute_discipline_score_uses_adherence_components():
+    review_df = pd.DataFrame(
+        [
+            {
+                "followed_rules": True,
+                "selected_rank": 1,
+                "best_available_rank": 1,
+                "quality_flag": "pass",
+            },
+            {
+                "followed_rules": False,
+                "selected_rank": 3,
+                "best_available_rank": 2,
+                "quality_flag": "pass",
+            },
+            {
+                "followed_rules": False,
+                "selected_rank": 4,
+                "best_available_rank": 2,
+                "quality_flag": "fail",
+            },
+            {
+                "followed_rules": True,
+                "selected_rank": 2,
+                "best_available_rank": 2,
+                "quality_flag": "pass",
+            },
+        ]
+    )
+
+    score = compute_discipline_score(review_df)
+
+    assert score == 56.2
+
+
+def test_empty_inputs_are_safe():
+    empty_df = pd.DataFrame()
+
+    review_df = compute_trade_review(empty_df, empty_df)
+    mistakes = detect_decision_mistakes(empty_df, empty_df, empty_df)
+    summary = build_behavior_summary(empty_df, empty_df)
+    score = compute_discipline_score(empty_df)
+
+    assert review_df.empty
+    assert mistakes == []
+    assert len(summary) >= 2
+    assert score == 0.0

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -12,6 +12,7 @@ class DummyStreamlit:
         self.dataframes = []
         self.info_messages = []
         self.captions = []
+        self.writes = []
 
     def subheader(self, _text):
         return None
@@ -27,6 +28,9 @@ class DummyStreamlit:
 
     def dataframe(self, df, use_container_width=False):
         self.dataframes.append((df.copy(), use_container_width))
+
+    def write(self, payload):
+        self.writes.append(payload)
 
 
 def test_render_portfolio_plan_uses_why_column_and_no_primary_rule_column():


### PR DESCRIPTION
### Motivation
- Add a post-decision evaluation layer to assess whether trades followed system rules, surface deviations, and highlight behavioral patterns. 
- Keep review logic empty-safe and observational, and avoid changing planner allocation/drilldown behavior. 

### Description
- Added new review module `app/planner/decision_review.py` implementing `compute_trade_review`, `detect_decision_mistakes`, `build_behavior_summary`, and `compute_discipline_score` for per-trade checks, mistake detection, plain-language behavior bullets, and a 0–100 discipline score. 
- Integrated a “Decision Review” UI section into `render_portfolio_plan` (in `app/planner/portfolio_ui.py`) that shows the discipline score, behavior summary bullets, mistake list, and an optional trade review table. 
- Wired the app shell (`app.py`) to pass ranked signals into the portfolio review so rank-context is available. 
- Added unit tests (`tests/test_decision_review.py`) and updated the Streamlit test double in `tests/test_portfolio_ui.py` to support the new UI output path. 

### Testing
- Ran automated tests: `pytest -q tests/test_decision_review.py tests/test_portfolio_ui.py tests/test_planner_allocation.py`, all tests succeeded with `18 passed`.
- All new unit tests for each mistake type, behavior summary, score calculation, and empty-input handling passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5ebc7cc408322b9efea2d45fecce9)