### PR TITLE
Fix allocation_pct edge cases & preserve cooldown checks in decision_review

### DIFF
--- a/app/planner/decision_review.py
+++ b/app/planner/decision_review.py
@@ -109,10 +109,9 @@ def detect_decision_mistakes(
             )
 
     allocation_safe = allocation_df if allocation_df is not None else pd.DataFrame()
-    if not allocation_safe.empty:
-        over_allocated = allocation_safe[
-            pd.to_numeric(allocation_safe.get("allocation_pct"), errors="coerce").fillna(0.0) > 0.70
-        ]
+    allocation_pct_series = _coerce_allocation_pct_series(allocation_safe)
+    if not allocation_safe.empty and allocation_pct_series is not None:
+        over_allocated = allocation_safe[allocation_pct_series > 0.70]
         for _, row in over_allocated.iterrows():
             instrument = _as_text(row.get("instrument"), fallback="Trade")
             allocation_pct = float(pd.to_numeric(row.get("allocation_pct"), errors="coerce") or 0.0)
@@ -126,11 +125,13 @@ def detect_decision_mistakes(
 
     merged_df = trades_df.copy()
     if not allocation_safe.empty and "instrument" in merged_df.columns and "instrument" in allocation_safe.columns:
-        merged_df = merged_df.merge(
-            allocation_safe[["instrument", "allocation_pct"]],
-            on="instrument",
-            how="left",
-        )
+        if "allocation_pct" not in merged_df.columns and "allocation_pct" in allocation_safe.columns:
+            merged_df = merged_df.merge(
+                allocation_safe[["instrument", "allocation_pct"]],
+                on="instrument",
+                how="left",
+            )
+    merged_df = _normalize_allocation_pct_column(merged_df)
 
     cooldown_mask = _build_cooldown_mask(merged_df)
     if cooldown_mask.any():
@@ -148,6 +149,33 @@ def detect_decision_mistakes(
                 )
 
     return mistakes
+
+
+def _coerce_allocation_pct_series(df: pd.DataFrame) -> pd.Series | None:
+    if df is None or df.empty:
+        return None
+    if "allocation_pct" not in df.columns:
+        return None
+    return pd.to_numeric(df["allocation_pct"], errors="coerce").fillna(0.0)
+
+
+def _normalize_allocation_pct_column(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return df
+
+    if "allocation_pct" in df.columns:
+        return df
+
+    candidates = [col for col in ("allocation_pct_x", "allocation_pct_y") if col in df.columns]
+    if not candidates:
+        return df
+
+    normalized = pd.to_numeric(df[candidates[0]], errors="coerce")
+    for col in candidates[1:]:
+        normalized = normalized.combine_first(pd.to_numeric(df[col], errors="coerce"))
+    df = df.copy()
+    df["allocation_pct"] = normalized
+    return df
 
 
 def build_behavior_summary(trades_df: pd.DataFrame, review_df: pd.DataFrame) -> list[str]:

--- a/tests/test_decision_review.py
+++ b/tests/test_decision_review.py
@@ -190,3 +190,43 @@ def test_empty_inputs_are_safe():
     assert mistakes == []
     assert len(summary) >= 2
     assert score == 0.0
+
+
+def test_detect_decision_mistakes_handles_missing_allocation_pct_column():
+    trades_df = pd.DataFrame(
+        [
+            {
+                "instrument": "AAA",
+                "selection_rank": 1,
+                "quality_tier": "A",
+                "liquidity_pass": True,
+                "cooldown_active": False,
+            }
+        ]
+    )
+    allocation_df = pd.DataFrame([{"instrument": "AAA"}])
+
+    mistakes = detect_decision_mistakes(trades_df, _signals_df(), allocation_df)
+
+    assert isinstance(mistakes, list)
+    assert all(item["type"] != "over_allocation" for item in mistakes)
+
+
+def test_detect_decision_mistakes_keeps_cooldown_check_when_trades_are_allocation_context():
+    trades_df = pd.DataFrame(
+        [
+            {
+                "instrument": "AAA",
+                "selection_rank": 1,
+                "quality_tier": "A",
+                "liquidity_pass": True,
+                "cooldown_active": True,
+                "allocation_pct": 0.25,
+            }
+        ]
+    )
+
+    mistakes = detect_decision_mistakes(trades_df, _signals_df(), trades_df)
+    mistake_types = {item["type"] for item in mistakes}
+
+    assert "cooldown_violation" in mistake_types


### PR DESCRIPTION
### Motivation
- Prevent a crash when a non-empty `allocation_df` lacks the `allocation_pct` column while keeping empty-safe behavior.  
- Ensure cooldown funding checks still detect violations when `trades_df` is reused as the allocation context and avoid duplicate `allocation_pct` column confusion after merges.

### Description
- Gate over-allocation detection on a coerced numeric series produced by `_coerce_allocation_pct_series` so checks are skipped when `allocation_pct` is absent rather than calling `.fillna(...)` on a scalar.  
- Avoid merging `allocation_df` allocation percentages into `trades_df` when `trades_df` already contains `allocation_pct` to prevent `_x/_y` duplication.  
- Add `_normalize_allocation_pct_column` to canonicalize `allocation_pct` from `allocation_pct_x`/`allocation_pct_y` if they exist so downstream cooldown logic reads a single `allocation_pct`.  
- Add two targeted tests to cover the regression cases without changing existing behavior: `test_detect_decision_mistakes_handles_missing_allocation_pct_column` and `test_detect_decision_mistakes_keeps_cooldown_check_when_trades_are_allocation_context`.

### Testing
- Ran the decision review test module with `pytest -q tests/test_decision_review.py`.  
- Result: `7 passed in 1.09s`.  
- Tests include the original mistake-detection suite plus the two new regression tests verifying (1) non-empty allocation frames missing `allocation_pct` do not crash and (2) cooldown violations are still detected when the same DataFrame is used for trades and allocations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5efe489d48322bcb644f1a62d160c)