### PR TITLE
Refine Sprint 11 Decision Review UX in Portfolio Plan

### DIFF
--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -89,7 +89,7 @@ def render_portfolio_plan(
     signals_df: pd.DataFrame | None = None,
     show_review_table: bool = True,
 ) -> None:
-    """Render portfolio summary, funded/unfunded tables, and constraints."""
+    """Render portfolio summary and review details with plan/review subtabs."""
     if st_module is None:
         import streamlit as st_module
 
@@ -105,102 +105,192 @@ def render_portfolio_plan(
     summary = build_portfolio_summary(allocations, total_capital)
     funded_trades, unfunded_trades = split_trades_by_funding(allocations)
 
-    st_module.markdown("#### Portfolio Summary")
-    summary_df = pd.DataFrame(
-        [
-            {
-                "Total Capital": float(total_capital or 0.0),
-                "Allocated Amount": summary["total_allocated_amount"],
-                "Allocated %": summary["total_allocated_pct"],
-                "Cash Reserve Amount": summary["cash_reserve_amount"],
-                "Cash Reserve %": summary["cash_reserve_pct"],
-                "Funded Trades": summary["funded_trade_count"],
-            }
-        ]
-    )
-    st_module.dataframe(summary_df, use_container_width=True)
+    plan_tab, review_tab = st_module.tabs(["Plan", "Review"])
 
-    st_module.markdown("#### Funded Trades")
-    if funded_trades:
-        funded_df = pd.DataFrame(
+    with plan_tab:
+        st_module.markdown("#### Portfolio Summary")
+        summary_df = pd.DataFrame(
             [
                 {
-                    "Instrument": trade.get("instrument", "Unknown"),
-                    "Quality Tier": trade.get("quality_tier", "N/A"),
-                    "Confidence": trade.get("confidence_label", "N/A"),
-                    "Allocation %": trade.get("allocation_pct", 0.0),
-                    "Allocation Amount": trade.get("allocation_amount", 0.0),
-                    "Selection Rank": trade.get("selection_rank", "N/A"),
-                    "Decision Status": classify_decision_status(trade),
-                    "Why": explain_funded_trade_why(trade),
+                    "Total Capital": float(total_capital or 0.0),
+                    "Allocated Amount": summary["total_allocated_amount"],
+                    "Allocated %": summary["total_allocated_pct"],
+                    "Cash Reserve Amount": summary["cash_reserve_amount"],
+                    "Cash Reserve %": summary["cash_reserve_pct"],
+                    "Funded Trades": summary["funded_trade_count"],
                 }
-                for trade in funded_trades
             ]
         )
-        st_module.dataframe(funded_df, use_container_width=True)
-    else:
-        st_module.info("No funded trades for the selected inputs.")
+        st_module.dataframe(summary_df, use_container_width=True)
 
-    st_module.markdown("#### Unfunded Trades")
-    if unfunded_trades:
-        unfunded_df = pd.DataFrame(
-            [
-                {
-                    "Instrument": trade.get("instrument", "Unknown"),
-                    "Quality Tier": trade.get("quality_tier", "N/A"),
-                    "Confidence": trade.get("confidence_label", "N/A"),
-                    "Selection Rank": trade.get("selection_rank", "N/A"),
-                    "Decision Status": classify_decision_status(trade),
-                    "Why": resolve_unfunded_reason(trade),
-                }
-                for trade in unfunded_trades
-            ]
-        )
-        st_module.dataframe(unfunded_df, use_container_width=True)
-    else:
-        st_module.info("No unfunded trades for the selected inputs.")
-
-    st_module.markdown("#### Constraints")
-    st_module.markdown(
-        "- Max portfolio exposure: 70%\n"
-        "- Min cash reserve: 30%\n"
-        "- Max funded trades: 3\n"
-        "- Tier C and liquidity failures are not funded"
-    )
-
-    st_module.markdown("#### Decision Review")
-    trades_df = pd.DataFrame(list(allocations))
-    safe_signals_df = signals_df if signals_df is not None else pd.DataFrame()
-    review_df = compute_trade_review(trades_df, safe_signals_df)
-    mistake_list = detect_decision_mistakes(
-        trades_df,
-        safe_signals_df,
-        trades_df,
-    )
-    discipline_score = compute_discipline_score(review_df)
-
-    st_module.write({"Discipline Score": discipline_score})
-
-    behavior_summary = build_behavior_summary(trades_df, review_df)
-    st_module.markdown("**Behavior Summary**")
-    for item in behavior_summary:
-        st_module.markdown(f"- {item}")
-
-    st_module.markdown("**Mistakes Detected**")
-    if mistake_list:
-        for mistake in mistake_list:
-            st_module.markdown(
-                f"- **{mistake['type']}**: {mistake['message']} Impact: {mistake['impact']}"
+        st_module.markdown("#### Funded Trades")
+        if funded_trades:
+            funded_df = pd.DataFrame(
+                [
+                    {
+                        "Instrument": trade.get("instrument", "Unknown"),
+                        "Quality Tier": trade.get("quality_tier", "N/A"),
+                        "Confidence": trade.get("confidence_label", "N/A"),
+                        "Allocation %": trade.get("allocation_pct", 0.0),
+                        "Allocation Amount": trade.get("allocation_amount", 0.0),
+                        "Selection Rank": trade.get("selection_rank", "N/A"),
+                        "Decision Status": classify_decision_status(trade),
+                        "Why": explain_funded_trade_why(trade),
+                    }
+                    for trade in funded_trades
+                ]
             )
-    else:
-        st_module.markdown("- No clear decision mistakes were detected.")
-
-    if show_review_table:
-        st_module.markdown("**Trade Review Table**")
-        if review_df.empty:
-            st_module.info("No review rows available for this run.")
+            st_module.dataframe(funded_df, use_container_width=True)
         else:
-            st_module.dataframe(review_df, use_container_width=True)
+            st_module.info("No funded trades for the selected inputs.")
+
+        st_module.markdown("#### Unfunded Trades")
+        if unfunded_trades:
+            unfunded_df = pd.DataFrame(
+                [
+                    {
+                        "Instrument": trade.get("instrument", "Unknown"),
+                        "Quality Tier": trade.get("quality_tier", "N/A"),
+                        "Confidence": trade.get("confidence_label", "N/A"),
+                        "Selection Rank": trade.get("selection_rank", "N/A"),
+                        "Decision Status": classify_decision_status(trade),
+                        "Why": resolve_unfunded_reason(trade),
+                    }
+                    for trade in unfunded_trades
+                ]
+            )
+            st_module.dataframe(unfunded_df, use_container_width=True)
+        else:
+            st_module.info("No unfunded trades for the selected inputs.")
+
+        st_module.markdown("#### Constraints")
+        st_module.markdown(
+            "- Max portfolio exposure: 70%\n"
+            "- Min cash reserve: 30%\n"
+            "- Max funded trades: 3\n"
+            "- Tier C and liquidity failures are not funded"
+        )
+
+    with review_tab:
+        st_module.markdown("#### Decision Review")
+        trades_df = pd.DataFrame(list(allocations))
+        safe_signals_df = signals_df if signals_df is not None else pd.DataFrame()
+        review_df = compute_trade_review(trades_df, safe_signals_df)
+        mistake_list = detect_decision_mistakes(
+            trades_df,
+            safe_signals_df,
+            trades_df,
+        )
+        discipline_score = compute_discipline_score(review_df)
+
+        st_module.write({"Discipline Score": discipline_score})
+
+        behavior_summary = build_behavior_summary(trades_df, review_df)
+        st_module.markdown("**Behavior Summary**")
+        for item in behavior_summary:
+            st_module.markdown(f"- {item}")
+
+        st_module.markdown("**What this means**")
+        for paragraph in _build_review_interpretation_paragraphs(review_df):
+            st_module.markdown(paragraph)
+
+        st_module.markdown("**What to improve**")
+        for bullet in _build_behavior_improvement_points(review_df):
+            st_module.markdown(f"- {bullet}")
+
+        st_module.markdown("**Mistakes Detected**")
+        grouped_mistakes = _group_mistakes_for_display(mistake_list)
+        if grouped_mistakes:
+            for line in grouped_mistakes:
+                st_module.markdown(f"- {line}")
+        else:
+            st_module.markdown("- No clear decision mistakes were detected.")
+
+        if show_review_table:
+            st_module.markdown("**Trade Review Table**")
+            if review_df.empty:
+                st_module.info("No review rows available for this run.")
+            else:
+                st_module.dataframe(review_df, use_container_width=True)
+
+
+def _build_review_interpretation_paragraphs(review_df: pd.DataFrame) -> list[str]:
+    if review_df is None or review_df.empty:
+        return [
+            "There is not enough decision activity yet to interpret behavior patterns.",
+            "As reviewed trades accumulate, this section will describe recurring discipline signals.",
+        ]
+
+    total = max(int(len(review_df)), 1)
+    followed = int(review_df["followed_rules"].fillna(False).astype(bool).sum())
+    rank_misses = int((review_df["deviation_type"] == "rank_deviation").sum())
+    quality_fails = int((review_df["quality_flag"] == "fail").sum())
+    liquidity_fails = int((review_df["liquidity_flag"] == "fail").sum())
+
+    return [
+        (
+            f"Rule alignment was observed on {followed} of {total} reviewed trades "
+            f"({followed / total:.0%}), indicating the current level of process consistency."
+        ),
+        (
+            f"The review shows {rank_misses} ranking deviation(s), {quality_fails} quality rule break(s), "
+            f"and {liquidity_fails} liquidity break(s), which reflects where decision discipline varied."
+        ),
+    ]
+
+
+def _build_behavior_improvement_points(review_df: pd.DataFrame) -> list[str]:
+    if review_df is None or review_df.empty:
+        return [
+            "Continue logging decisions so ranking and quality patterns can be measured.",
+            "Track whether each selection follows the same process before finalizing.",
+        ]
+
+    rank_misses = int((review_df["deviation_type"] == "rank_deviation").sum())
+    quality_fails = int((review_df["quality_flag"] == "fail").sum())
+    liquidity_fails = int((review_df["liquidity_flag"] == "fail").sum())
+
+    bullets = [
+        "Keep selection order aligned with the highest-ranked eligible setups.",
+        "Hold quality filtering steady so lower-tier entries appear less often.",
+        "Apply liquidity checks consistently before entries are finalized.",
+    ]
+
+    if rank_misses == 0:
+        bullets[0] = "Ranking discipline was stable; maintain this ordering consistency."
+    if quality_fails == 0:
+        bullets[1] = "Quality discipline was stable; maintain current quality filtering consistency."
+    if liquidity_fails == 0:
+        bullets[2] = "Liquidity screening was stable; maintain current execution-quality checks."
+
+    return bullets
+
+
+def _group_mistakes_for_display(mistakes: Sequence[Mapping[str, Any]]) -> list[str]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for item in mistakes:
+        mistake_type = str(item.get("type", "rule_violation"))
+        if mistake_type not in grouped:
+            grouped[mistake_type] = {"count": 0}
+        grouped[mistake_type]["count"] += 1
+
+    lines: list[str] = []
+    for mistake_type, payload in grouped.items():
+        count = int(payload["count"])
+        lines.append(_render_grouped_mistake_line(mistake_type, count))
+    return lines
+
+
+def _render_grouped_mistake_line(mistake_type: str, count: int) -> str:
+    templates = {
+        "low_quality_trade": "{count} trade(s) did not meet the quality tier rule.",
+        "ignored_higher_rank": "{count} trade(s) were selected below a higher-ranked available setup.",
+        "liquidity_violation": "{count} trade(s) failed the liquidity screen.",
+        "over_allocation": "{count} trade(s) exceeded the allocation cap.",
+        "cooldown_violation": "{count} trade(s) were funded while cooldown was active.",
+    }
+    template = templates.get(mistake_type, "{count} trade(s) showed a decision rule deviation.")
+    return template.format(count=count)
 
 
 def _first_sentence(text: str) -> str:

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -4,7 +4,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-from app.planner.portfolio_ui import render_portfolio_plan
+from app.planner.portfolio_ui import _group_mistakes_for_display, render_portfolio_plan
 
 
 class DummyStreamlit:
@@ -13,6 +13,14 @@ class DummyStreamlit:
         self.info_messages = []
         self.captions = []
         self.writes = []
+        self.tabs_requested = []
+
+    class _DummyTab:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
 
     def subheader(self, _text):
         return None
@@ -31,6 +39,10 @@ class DummyStreamlit:
 
     def write(self, payload):
         self.writes.append(payload)
+
+    def tabs(self, names):
+        self.tabs_requested.append(list(names))
+        return [self._DummyTab(), self._DummyTab()]
 
 
 def test_render_portfolio_plan_uses_why_column_and_no_primary_rule_column():
@@ -67,3 +79,18 @@ def test_render_portfolio_plan_uses_why_column_and_no_primary_rule_column():
     assert funded_df.iloc[0]["Decision Status"] == "Selected"
     assert unfunded_df.iloc[0]["Decision Status"] == "Not funded (limit reached)"
     assert "Selected trades received funding" in st.captions[0]
+    assert st.tabs_requested == [["Plan", "Review"]]
+
+
+def test_group_mistakes_for_display_combines_repeated_types():
+    grouped = _group_mistakes_for_display(
+        [
+            {"type": "low_quality_trade", "message": "a"},
+            {"type": "low_quality_trade", "message": "b"},
+            {"type": "low_quality_trade", "message": "c"},
+            {"type": "liquidity_violation", "message": "d"},
+        ]
+    )
+
+    assert "3 trade(s) did not meet the quality tier rule." in grouped
+    assert "1 trade(s) failed the liquidity screen." in grouped


### PR DESCRIPTION
### Motivation
- Move the Decision Review UX into a dedicated subtab so the portfolio view remains focused on plan details and the review content is scoped separately.
- Add an interpretation layer below the existing Behavior Summary so users get neutral, observational context and concise improvement points.
- Improve mistake presentation by aggregating repeated mistake types into simple count-based lines for readability while preserving a non-advisory tone.

### Description
- Introduced `Plan` and `Review` subtabs via `st.tabs(["Plan", "Review"])` and moved existing portfolio summary / funded/unfunded tables into the `Plan` tab in `render_portfolio_plan`.
- Moved Decision Review rendering into the `Review` tab and added interpretation helpers: `_build_review_interpretation_paragraphs(review_df)` and `_build_behavior_improvement_points(review_df)` to generate the new "What this means" and "What to improve" sections.
- Added mistake grouping utilities `_group_mistakes_for_display(mistakes)` and `_render_grouped_mistake_line(mistake_type, count)` to aggregate repeated mistake types into readable lines (e.g., "3 trade(s) did not meet the quality tier rule.").
- Updated `tests/test_portfolio_ui.py` to simulate Streamlit tabs, validate the `Plan/Review` tab creation, and add `test_group_mistakes_for_display_combines_repeated_types()` to verify grouped mistake output.

### Testing
- Ran `pytest -q tests/test_portfolio_ui.py tests/test_decision_review.py`, and all tests passed: `9 passed`.
- Unit tests verify: `render_portfolio_plan` still renders `Why` columns and decision status, tabs are requested as `["Plan","Review"]`, and grouped mistake lines are produced by `_group_mistakes_for_display`.
- No UI/visual tests were run beyond the Streamlit-mocking unit tests referenced above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da880421c483228b7240c454331db1)