### PR TITLE
Harden demo artifact writes for restricted filesystems

### DIFF
--- a/app/demo/run_demo.py
+++ b/app/demo/run_demo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pandas as pd
@@ -13,6 +14,9 @@ from app.demo.language import get_explanatory_copy
 from app.events.earnings import tag_earnings_phase
 from app.events.phase_metrics import compute_phase_metrics
 from app.ranking.engine import rank_instruments
+
+
+logger = logging.getLogger(__name__)
 
 
 def run_demo(language_mode: str = "plain") -> dict:
@@ -49,9 +53,9 @@ def run_demo(language_mode: str = "plain") -> dict:
         phase_metrics.to_csv(artifacts_dir / "phase_metrics.csv", index=False)
         meta_payload = {"meta": meta, "issues": issues}
         (artifacts_dir / "meta.json").write_text(json.dumps(meta_payload, indent=2))
-    except OSError:
+    except PermissionError as exc:
         # Continue when running in restricted environments where local writes are unavailable.
-        pass
+        logger.warning("Demo artifacts not written due to restricted filesystem permissions: %s", exc)
 
     return {
         "ranked": ranked,

--- a/tests/test_demo_pipeline.py
+++ b/tests/test_demo_pipeline.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
@@ -14,6 +15,7 @@ from app.demo.generate_prices import generate_demo_prices
 from app.events.earnings import tag_earnings_phase
 from app.events.phase_metrics import compute_phase_metrics
 from app.ranking.engine import rank_instruments
+from app.demo import run_demo as run_demo_module
 
 
 def test_demo_pipeline_outputs():
@@ -50,3 +52,26 @@ def test_demo_pipeline_outputs():
         "net_return_pct",
     )
     assert {"insufficient_history", "n"}.issubset(phase_metrics.columns)
+
+
+def test_run_demo_logs_warning_when_artifact_writes_are_permission_restricted(caplog, monkeypatch):
+    def raise_permission_error(*args, **kwargs):
+        raise PermissionError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "mkdir", raise_permission_error)
+
+    with caplog.at_level("WARNING"):
+        result = run_demo_module.run_demo()
+
+    assert not result["ranked"].empty
+    assert "restricted filesystem permissions" in caplog.text
+
+
+def test_run_demo_does_not_swallow_unexpected_os_errors(monkeypatch):
+    def raise_unexpected_os_error(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "mkdir", raise_unexpected_os_error)
+
+    with pytest.raises(OSError, match="disk full"):
+        run_demo_module.run_demo()


### PR DESCRIPTION
### Motivation
- Prevent silent swallowing of all `OSError` on demo artifact writes so real filesystem failures (e.g., disk-full) surface while preserving resilience in hosted, restricted environments.
- Provide a lightweight visible signal when demo artifact writes are intentionally skipped due to permission restrictions.

### Description
- Narrowed exception handling in `app/demo/run_demo.py` so the artifact-write block now catches only `PermissionError` and no longer swallows all `OSError`.
- Added a module logger (`logger = logging.getLogger(__name__)`) and emit a lightweight warning on permission-restricted write skips: `logger.warning("Demo artifacts not written due to restricted filesystem permissions: %s", exc)`.
- Added focused tests in `tests/test_demo_pipeline.py` to validate restricted-write behavior and to assert that unexpected `OSError` is propagated rather than swallowed.
- Files changed: `app/demo/run_demo.py`, `tests/test_demo_pipeline.py`.

### Testing
- Ran the focused test file: `pytest -q tests/test_demo_pipeline.py` which passed (3 passed).
- Tests added: `test_run_demo_logs_warning_when_artifact_writes_are_permission_restricted` (monkeypatch `Path.mkdir` -> `PermissionError`, asserts warning via `caplog`) and `test_run_demo_does_not_swallow_unexpected_os_errors` (monkeypatch `Path.mkdir` -> `OSError('disk full')`, asserts the `OSError` is raised).
- Result: `3 passed` for the invoked test run.

Details (concise references):
- Exact exception handling now used: `except PermissionError as exc:` (no broader `OSError` catch around artifact writes).
- Write-failure signaling: uses `logger.warning(...)` with the permission error text; app continues without crashing when permissions are restricted.
- Key diff excerpts: replaced `except OSError:` + `pass` with `except PermissionError as exc:` + `logger.warning(...)`, and added `import logging` + `logger = logging.getLogger(__name__)`, and two tests in `tests/test_demo_pipeline.py` to cover the behaviors.
- Remaining deployment risks: partial/partial-write semantics (mid-write I/O failures may still produce corrupt/partial files), warning visibility depends on runtime logging configuration, and no atomic-write or retry semantics were added (intentionally out of scope).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa4c84d708322b3e1b5be07d856f8)