### PR TITLE
Harden demo artifact writes for read-only filesystems

### DIFF
--- a/app/demo/run_demo.py
+++ b/app/demo/run_demo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import errno
 from pathlib import Path
 
 import pandas as pd
@@ -56,6 +57,11 @@ def run_demo(language_mode: str = "plain") -> dict:
     except PermissionError as exc:
         # Continue when running in restricted environments where local writes are unavailable.
         logger.warning("Demo artifacts not written due to restricted filesystem permissions: %s", exc)
+    except OSError as exc:
+        if exc.errno == errno.EROFS:
+            logger.warning("Demo artifacts not written due to read-only filesystem: %s", exc)
+        else:
+            raise
 
     return {
         "ranked": ranked,

--- a/tests/test_demo_pipeline.py
+++ b/tests/test_demo_pipeline.py
@@ -1,3 +1,4 @@
+import errno
 import sys
 from pathlib import Path
 
@@ -67,9 +68,22 @@ def test_run_demo_logs_warning_when_artifact_writes_are_permission_restricted(ca
     assert "restricted filesystem permissions" in caplog.text
 
 
+def test_run_demo_logs_warning_when_artifact_writes_are_read_only_filesystem(caplog, monkeypatch):
+    def raise_read_only_os_error(*args, **kwargs):
+        raise OSError(errno.EROFS, "read-only filesystem")
+
+    monkeypatch.setattr(Path, "mkdir", raise_read_only_os_error)
+
+    with caplog.at_level("WARNING"):
+        result = run_demo_module.run_demo()
+
+    assert not result["ranked"].empty
+    assert "read-only filesystem" in caplog.text
+
+
 def test_run_demo_does_not_swallow_unexpected_os_errors(monkeypatch):
     def raise_unexpected_os_error(*args, **kwargs):
-        raise OSError("disk full")
+        raise OSError(errno.ENOSPC, "disk full")
 
     monkeypatch.setattr(Path, "mkdir", raise_unexpected_os_error)
 


### PR DESCRIPTION
### Motivation
- Prevent the demo run from failing in hosted or sandboxed environments that raise read-only filesystem errors while still surfacing real I/O failures.
- Keep the existing behavior of tolerating restricted writes but avoid swallowing unexpected `OSError` values.

### Description
- Added an `except OSError as exc` branch that logs a warning and continues only when `exc.errno == errno.EROFS`, and re-raises all other `OSError` values.
- Kept the existing `PermissionError` handling and logging message: `"Demo artifacts not written due to restricted filesystem permissions: %s"`.
- Added the read-only message: `"Demo artifacts not written due to read-only filesystem: %s"` and `import errno` in `app/demo/run_demo.py`.
- Updated `tests/test_demo_pipeline.py` to add a test for `OSError(errno.EROFS)` and tightened the unexpected `OSError` test to use `errno.ENOSPC` (disk full).

### Testing
- Ran `pytest -q tests/test_demo_pipeline.py` and all tests passed (`4 passed`).
- Tests added/updated: `test_run_demo_logs_warning_when_artifact_writes_are_permission_restricted`, `test_run_demo_logs_warning_when_artifact_writes_are_read_only_filesystem`, and `test_run_demo_does_not_swallow_unexpected_os_errors` (propagation verified).
- Verified the new exception handling in `run_demo()` logs the expected warnings for permission and read-only cases and re-raises non-EROFS `OSError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa6a289b08322827f85c48cd4e6d4)