### PR TITLE
Sprint 12 Step 2: First-run experience, shared language formatter, and Beginner/Analyst mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pandas as pd
 
 from app.analysis.ticker_drilldown import build_ticker_drilldown
+from app.analysis.ticker_intelligence import compute_ticker_metrics
 from app.data.ingest import ingest_dataset
 from app.demo.run_demo import run_demo
 from app.insights.analyst import render_analyst_insights
@@ -24,8 +25,9 @@ def main() -> None:
         layout="wide",
     )
 
-    st.title("JSE Decision Support Dashboard")
-    st.caption("Sprint 8 shell: dataset loading, Analyst Insights, Portfolio Plan, and Explanation Layer.")
+    st.title("JSE Market Lab")
+    mode = st.radio("Mode", options=["Beginner", "Analyst"], horizontal=True, index=0)
+    mode_token = mode.lower()
 
     canonical_df, meta, issues = ingest_dataset("demo")
     st.markdown("### Data Status")
@@ -42,17 +44,29 @@ def main() -> None:
         st.warning("No rows were loaded from the data layer. Please verify demo dataset files.")
         return
 
-    st.markdown("### Main Dashboard")
-    st.dataframe(canonical_df.head(50), use_container_width=True)
-
     demo_payload = run_demo()
     ranked_df = demo_payload.get("ranked", pd.DataFrame())
     analyst_df = build_analyst_dataset(canonical_df, ranked_df)
+    trade_rows = coerce_trade_rows_from_ranked(ranked_df) if not ranked_df.empty else []
+
+    if trade_rows:
+        preview_allocation = generate_portfolio_allocation(trade_rows, 100_000.0)
+        preview_allocations = preview_allocation.get("allocations", [])
+        enriched_preview = [{**allocation, **row} for row, allocation in zip(trade_rows, preview_allocations)]
+        insights_payload = generate_embedded_insights(trade_rows, enriched_preview, mode=mode_token)
+    else:
+        insights_payload = generate_embedded_insights([], [], mode=mode_token)
+
+    _render_first_run_header(st, mode=mode_token)
+    render_embedded_insights(insights_payload, st_module=st)
+
+    st.markdown("### Main Dashboard")
+    st.dataframe(canonical_df.head(50), use_container_width=True)
 
     insights_tab, ticker_tab, plan_tab = st.tabs(["Analyst Insights", "Ticker Analysis", "Portfolio Plan"])
 
     with insights_tab:
-        render_analyst_insights(analyst_df, st_module=st, analyst_mode=True)
+        render_analyst_insights(analyst_df, st_module=st, analyst_mode=mode_token == "analyst")
 
     with ticker_tab:
         st.markdown("### Ticker Analysis")
@@ -65,6 +79,14 @@ def main() -> None:
             else:
                 selected_ticker = st.selectbox("Select ticker", ticker_options)
                 ticker_payload = build_ticker_drilldown(analyst_df, selected_ticker)
+                ticker_metrics = compute_ticker_metrics(analyst_df, selected_ticker, mode=mode_token)
+
+                st.markdown("#### Ticker Summary")
+                st.write(ticker_metrics["summary"])
+
+                st.markdown("#### Behavior Insights")
+                for line in ticker_metrics["behavior"].values():
+                    st.markdown(f"- {line}")
 
                 st.markdown("#### Pattern Summary")
                 st.write(ticker_payload["pattern_summary"])
@@ -95,8 +117,9 @@ def main() -> None:
                             "Average Return": float(returns.mean()),
                         }
 
-                st.markdown("#### Key Stats")
-                st.dataframe(pd.DataFrame([key_stats]), use_container_width=True)
+                if mode_token == "analyst":
+                    st.markdown("#### Key Stats")
+                    st.dataframe(pd.DataFrame([key_stats]), use_container_width=True)
 
                 st.markdown("#### Holding Window Comparison")
                 holding_window_df = pd.DataFrame.from_dict(
@@ -144,7 +167,6 @@ def main() -> None:
             st.info("Portfolio Plan unavailable: ranked outputs were not generated.")
             return
 
-        trade_rows = coerce_trade_rows_from_ranked(ranked_df)
         allocation_payload = generate_portfolio_allocation(trade_rows, total_capital)
         allocations = allocation_payload.get("allocations", [])
 
@@ -153,15 +175,28 @@ def main() -> None:
         for row, allocation in zip(trade_rows, allocations):
             enriched_allocations.append({**allocation, **row})
 
-        insights_payload = generate_embedded_insights(trade_rows, enriched_allocations)
-        render_embedded_insights(insights_payload, st_module=st)
-
         render_portfolio_plan(
             enriched_allocations,
             total_capital=total_capital,
             st_module=st,
             signals_df=ranked_df,
+            mode=mode_token,
         )
+
+
+def _render_first_run_header(st_module, *, mode: str) -> None:
+    st_module.markdown("### JSE Market Lab")
+    st_module.markdown(
+        "A tool that helps you review stock opportunities on the Jamaican market using structured rules and risk checks."
+    )
+    st_module.markdown("**How to read this**")
+    st_module.markdown("- The system scans the market and ranks possible trades.")
+    st_module.markdown("- Only the strongest setups are funded in the plan below.")
+    st_module.markdown("- Each trade shows why it was selected and what risk is involved.")
+    if mode == "beginner":
+        st_module.caption("Beginner mode keeps the view simple: explanation first, fewer metrics.")
+    else:
+        st_module.caption("Analyst mode adds more metrics while keeping explanations first.")
 
 
 if __name__ == "__main__":

--- a/app/analysis/ticker_drilldown.py
+++ b/app/analysis/ticker_drilldown.py
@@ -235,19 +235,19 @@ def build_pattern_summary(
             or float(top_stats.get("median_return", 0.0))
             >= float(second_stats.get("median_return", 0.0)) + PATTERN_SUMMARY_THRESHOLD_PCT
         ):
-            return f"This stock tends to hold up better on {top_window} than {second_window} in this dataset."
+            return f"This stock has looked stronger on {top_window} than {second_window} in this dataset."
 
     best_tier = _pick_best_bucket(tier_performance)
     if best_tier is not None and len(tier_performance) >= 2:
         tier_name, tier_stats = best_tier
         if int(tier_stats.get("count", 0)) >= 2 and float(tier_stats.get("win_rate", 0.0)) >= 0.6:
-            return f"This stock looks strongest when the {tier_name} quality setups show up."
+            return f"This stock looks strongest when {tier_name} setups show up."
 
     best_volatility = _pick_best_bucket(volatility_performance)
     if best_volatility is not None and len(volatility_performance) >= 2:
         bucket, bucket_stats = best_volatility
         if int(bucket_stats.get("count", 0)) >= 2:
-            return f"For this stock, {bucket} volatility setups have looked more stable so far."
+            return f"For this stock, {bucket} volatility setups have looked steadier so far."
 
     negative = int(return_distribution.get("negative", 0))
     strong_positive = int(return_distribution.get("strong_positive", 0))

--- a/app/analysis/ticker_intelligence.py
+++ b/app/analysis/ticker_intelligence.py
@@ -35,33 +35,39 @@ def _empty_payload() -> dict[str, Any]:
     }
 
 
-def build_ticker_summary(metrics: dict[str, Any]) -> str:
+def build_ticker_summary(metrics: dict[str, Any], *, mode: str = "beginner") -> str:
     stats = metrics["stats"]
     signal_count = int(stats["signal_count"])
     win_rate = float(stats["win_rate"]) * 100
     median_return = float(stats["median_return"]) * 100
     best_window = stats["best_window"]
 
-    base = (
-        f"{metrics['ticker']} closed positive {win_rate:.0f}% of the time with a median return of "
-        f"{median_return:.2f}% and looked strongest at the {best_window} window."
-    )
+    if str(mode).lower() == "analyst":
+        base = (
+            f"{metrics['ticker']} closed positive {win_rate:.0f}% of the time, with median return {median_return:.2f}%, "
+            f"and the strongest read at {best_window}."
+        )
+    else:
+        base = (
+            f"{metrics['ticker']} had more positive closes than negative ones in {win_rate:.0f}% of signals, "
+            f"with a typical return near {median_return:.2f}%."
+        )
 
     if signal_count < 8:
-        return base[:-1] + f", but this read comes from only {signal_count} signals."
+        return base[:-1] + f" This read comes from only {signal_count} signals, so confidence is limited."
     return base
 
 
-def build_ticker_behavior(metrics: dict[str, Any]) -> dict[str, str]:
+def build_ticker_behavior(metrics: dict[str, Any], *, mode: str = "beginner") -> dict[str, str]:
     by_window = metrics.get("by_window", {})
 
     five_day = by_window.get(5)
     twenty_day = by_window.get(20)
     if five_day and twenty_day:
         if five_day["avg_return"] > twenty_day["avg_return"]:
-            holding_window = "The 5D window moved stronger than 20D for this ticker in this dataset."
+            holding_window = "5D looks stronger than 20D in this dataset."
         elif five_day["avg_return"] < twenty_day["avg_return"]:
-            holding_window = "The 20D window moved stronger than 5D for this ticker in this dataset."
+            holding_window = "20D looks stronger than 5D in this dataset."
         else:
             holding_window = "The 5D and 20D windows came out nearly the same for this ticker."
     else:
@@ -72,13 +78,13 @@ def build_ticker_behavior(metrics: dict[str, Any]) -> dict[str, str]:
     if abs(avg_return - median_return) <= 0.002:
         consistency = "Average and median returns are close, so results look fairly steady."
     elif avg_return > median_return:
-        consistency = "Average return sits above median return, so a few bigger wins are lifting the average."
+        consistency = "Average return is above typical return, so a few bigger wins are lifting the average."
     else:
         consistency = "Median return sits above average return, so weaker outliers are pulling the average down."
 
     win_rate = float(metrics["stats"]["win_rate"])
     if win_rate >= 0.6:
-        reliability = "Win rate reads as reliable because most signals closed positive."
+        reliability = "How often this works looks steady because most signals closed positive."
     elif win_rate >= 0.5:
         reliability = "Win rate reads as moderate because positive and negative closes are fairly mixed."
     else:
@@ -88,9 +94,12 @@ def build_ticker_behavior(metrics: dict[str, Any]) -> dict[str, str]:
     if tier_counts:
         top_tier = max(tier_counts, key=tier_counts.get)
         top_share = (tier_counts[top_tier] / sum(tier_counts.values())) * 100
-        tier_profile = f"Tier mix leans to {top_tier}, with about {top_share:.0f}% of tagged rows in that tier."
+        tier_profile = f"Setup mix leans to {top_tier}, with about {top_share:.0f}% of rows in that tier."
     else:
         tier_profile = "Tier profile cannot be read because tier data is missing."
+
+    if str(mode).lower() == "analyst":
+        reliability = reliability + f" (Win rate: {win_rate:.0%})"
 
     return {
         "holding_window": holding_window,
@@ -100,7 +109,7 @@ def build_ticker_behavior(metrics: dict[str, Any]) -> dict[str, str]:
     }
 
 
-def compute_ticker_metrics(df: pd.DataFrame, ticker: str) -> dict[str, Any]:
+def compute_ticker_metrics(df: pd.DataFrame, ticker: str, *, mode: str = "beginner") -> dict[str, Any]:
     if df.empty or "instrument" not in df.columns:
         return _empty_payload()
 
@@ -159,8 +168,8 @@ def compute_ticker_metrics(df: pd.DataFrame, ticker: str) -> dict[str, Any]:
         "by_window": by_window,
         "tier_counts": tier_counts,
     }
-    metrics["summary"] = build_ticker_summary(metrics)
-    metrics["behavior"] = build_ticker_behavior(metrics)
+    metrics["summary"] = build_ticker_summary(metrics, mode=mode)
+    metrics["behavior"] = build_ticker_behavior(metrics, mode=mode)
     return {
         "summary": metrics["summary"],
         "stats": metrics["stats"],

--- a/app/insights/embedded.py
+++ b/app/insights/embedded.py
@@ -8,7 +8,9 @@ from typing import Any, Mapping, Sequence
 def generate_embedded_insights(
     trade_rows: Sequence[Mapping[str, Any]],
     allocations: Sequence[Mapping[str, Any]] | None = None,
-) -> dict[str, list[str]]:
+    *,
+    mode: str = "beginner",
+) -> dict[str, list[str] | str]:
     """Return neutral, plain-language insights for current planner data."""
     rows = [dict(row) for row in trade_rows]
     allocs = [dict(row) for row in allocations] if allocations is not None else []
@@ -41,29 +43,56 @@ def generate_embedded_insights(
         what_to_watch.append(risk_line)
 
     if not what_is_happening:
-        what_is_happening.append("Strong setups are leading this batch.")
+        what_is_happening.append("Stronger setups are showing up early in this scan.")
     if not what_to_watch:
-        what_to_watch.append("Some trades look good on average, but the results are not consistent.")
+        what_to_watch.append("Results are mixed, so keep an eye on consistency across trades.")
+
+    common_mistakes = _common_mistakes_lines(rows, mode=mode)
+    why_this_matters = (
+        "This helps you understand where the plan is strong, where risk is rising, and what to monitor next."
+    )
 
     return {
         "what_is_happening": what_is_happening[:3],
         "what_to_watch": what_to_watch[:3],
+        "common_mistakes": common_mistakes[:2],
+        "why_this_matters": why_this_matters,
     }
 
 
-def render_embedded_insights(insights: Mapping[str, Sequence[str]], *, st_module=None) -> None:
+def render_embedded_insights(insights: Mapping[str, Any], *, st_module=None) -> None:
     """Render embedded insights as simple bullet lists."""
     if st_module is None:
         import streamlit as st_module
 
-    st_module.markdown("#### Embedded Insight Layer")
-    st_module.markdown("**What is happening**")
+    st_module.markdown("#### Final Insight")
+    st_module.markdown("**What’s happening**")
     for line in insights.get("what_is_happening", []):
         st_module.markdown(f"- {line}")
 
     st_module.markdown("**What to watch**")
     for line in insights.get("what_to_watch", []):
         st_module.markdown(f"- {line}")
+
+    st_module.markdown("**Common mistakes**")
+    for line in insights.get("common_mistakes", []):
+        st_module.markdown(f"- {line}")
+
+    st_module.markdown("**Why this matters**")
+    st_module.markdown(str(insights.get("why_this_matters", "")))
+
+
+def _common_mistakes_lines(rows: Sequence[Mapping[str, Any]], *, mode: str) -> list[str]:
+    base = [
+        "Focusing on one big return number and missing that results are uneven.",
+        "Ignoring portfolio limits when several trades look strong at the same time.",
+    ]
+    if str(mode).lower() == "analyst":
+        return [
+            "Overweighting average return while median return and win rate disagree.",
+            "Letting rank order drift when capital limits are already tight.",
+        ]
+    return base
 
 
 def _volatility_insight(rows: Sequence[Mapping[str, Any]]) -> str:

--- a/app/language/formatter.py
+++ b/app/language/formatter.py
@@ -1,0 +1,70 @@
+"""Shared language helpers for beginner/analyst display copy."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+STRENGTH_LABELS = {
+    "A": "Strong setup",
+    "B": "Decent setup",
+    "C": "Weak setup",
+}
+
+ADVISORY_TERMS = ("you should", "buy", "sell", "avoid this stock", "better to wait")
+
+
+def get_strength_label(tier: Any) -> str:
+    token = str(tier or "").strip().upper()
+    return STRENGTH_LABELS.get(token, "Unrated setup")
+
+
+def format_beginner_explanation(signal_or_row: Mapping[str, Any]) -> str:
+    strength = get_strength_label(signal_or_row.get("quality_tier"))
+    risk_line = _risk_sentence(signal_or_row)
+    return f"{strength}. {risk_line}"
+
+
+def format_analyst_explanation(signal_or_row: Mapping[str, Any]) -> str:
+    strength = get_strength_label(signal_or_row.get("quality_tier"))
+    win_rate = _pct_or_none(signal_or_row.get("win_rate"), 0)
+    avg_return = _pct_or_none(signal_or_row.get("avg_return"), 2)
+
+    metric_bits: list[str] = []
+    if win_rate is not None:
+        metric_bits.append(f"How often this works: {win_rate}")
+    if avg_return is not None:
+        metric_bits.append(f"Typical move: {avg_return}")
+    metric_line = "; ".join(metric_bits) if metric_bits else "Key performance metrics are limited in this row."
+    return f"{strength}. {_risk_sentence(signal_or_row)} {metric_line}"
+
+
+def generate_explanation(signal_or_row: Mapping[str, Any], mode: str = "beginner") -> str:
+    mode_token = str(mode or "beginner").strip().lower()
+    if mode_token == "analyst":
+        return format_analyst_explanation(signal_or_row)
+    return format_beginner_explanation(signal_or_row)
+
+
+def contains_advisory_language(text: str) -> bool:
+    lowered = str(text or "").lower()
+    return any(term in lowered for term in ADVISORY_TERMS)
+
+
+def _risk_sentence(signal_or_row: Mapping[str, Any]) -> str:
+    volatility = str(signal_or_row.get("volatility_bucket", "")).strip().lower()
+    if volatility == "high":
+        return "Prices are moving around more than usual, so this setup carries more risk."
+    if volatility in {"low", "steady"}:
+        return "Price movement is steadier than usual, which can help consistency."
+    return "Price movement is mixed, so keep an eye on consistency."
+
+
+def _pct_or_none(value: Any, decimals: int) -> str | None:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f"{numeric:.{decimals}%}"

--- a/app/planner/decision_review.py
+++ b/app/planner/decision_review.py
@@ -197,11 +197,11 @@ def build_behavior_summary(trades_df: pd.DataFrame, review_df: pd.DataFrame) -> 
 
     insights: list[str] = [
         f"{followed} of {total} trades followed the selection rules ({rule_rate:.0%}).",
-        f"Rank order mismatches appeared on {rank_misses} trade(s).",
+        f"Selection order drift showed on {rank_misses} trade(s).",
     ]
 
     if quality_fails > 0:
-        insights.append(f"{quality_fails} trade(s) were below the quality rule.")
+        insights.append(f"{quality_fails} trade(s) came in below the quality rule.")
     else:
         insights.append("All reviewed trades stayed within the quality rule.")
 

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping, Sequence
 
 import pandas as pd
 
+from app.language.formatter import generate_explanation
 from app.planner.decision_review import (
     build_behavior_summary,
     compute_discipline_score,
@@ -88,14 +89,16 @@ def render_portfolio_plan(
     *,
     signals_df: pd.DataFrame | None = None,
     show_review_table: bool = True,
+    mode: str = "beginner",
 ) -> None:
     """Render portfolio summary and review details with plan/review subtabs."""
     if st_module is None:
         import streamlit as st_module
 
     st_module.subheader("Portfolio Plan")
+    analyst_mode = str(mode or "beginner").lower() == "analyst"
     st_module.caption(
-        "Selected trades received funding, and the rest stayed out for clear rule or limit reasons."
+        "The plan funds the strongest eligible setups first, while other trades stay out when rules or limits block them."
     )
 
     if not allocations:
@@ -114,9 +117,9 @@ def render_portfolio_plan(
                 {
                     "Total Capital": float(total_capital or 0.0),
                     "Allocated Amount": summary["total_allocated_amount"],
-                    "Allocated %": summary["total_allocated_pct"],
+                    **({"Allocated %": summary["total_allocated_pct"]} if analyst_mode else {}),
                     "Cash Reserve Amount": summary["cash_reserve_amount"],
-                    "Cash Reserve %": summary["cash_reserve_pct"],
+                    **({"Cash Reserve %": summary["cash_reserve_pct"]} if analyst_mode else {}),
                     "Funded Trades": summary["funded_trade_count"],
                 }
             ]
@@ -129,13 +132,14 @@ def render_portfolio_plan(
                 [
                     {
                         "Instrument": trade.get("instrument", "Unknown"),
-                        "Quality Tier": trade.get("quality_tier", "N/A"),
+                        "Setup Strength": trade.get("quality_tier", "N/A"),
                         "Confidence": trade.get("confidence_label", "N/A"),
-                        "Allocation %": trade.get("allocation_pct", 0.0),
+                        **({"Allocation %": trade.get("allocation_pct", 0.0)} if analyst_mode else {}),
                         "Allocation Amount": trade.get("allocation_amount", 0.0),
-                        "Selection Rank": trade.get("selection_rank", "N/A"),
+                        **({"Selection Rank": trade.get("selection_rank", "N/A")} if analyst_mode else {}),
                         "Decision Status": classify_decision_status(trade),
-                        "Why": explain_funded_trade_why(trade),
+                        "Why": generate_explanation(trade, mode=mode),
+                        **({"Rule Note": explain_funded_trade_why(trade)} if analyst_mode else {}),
                     }
                     for trade in funded_trades
                 ]
@@ -150,9 +154,9 @@ def render_portfolio_plan(
                 [
                     {
                         "Instrument": trade.get("instrument", "Unknown"),
-                        "Quality Tier": trade.get("quality_tier", "N/A"),
+                        "Setup Strength": trade.get("quality_tier", "N/A"),
                         "Confidence": trade.get("confidence_label", "N/A"),
-                        "Selection Rank": trade.get("selection_rank", "N/A"),
+                        **({"Selection Rank": trade.get("selection_rank", "N/A")} if analyst_mode else {}),
                         "Decision Status": classify_decision_status(trade),
                         "Why": resolve_unfunded_reason(trade),
                     }
@@ -163,7 +167,7 @@ def render_portfolio_plan(
         else:
             st_module.info("No unfunded trades for the selected inputs.")
 
-        st_module.markdown("#### Constraints")
+        st_module.markdown("#### Portfolio Rules")
         st_module.markdown(
             "- Max portfolio exposure: 70%\n"
             "- Min cash reserve: 30%\n"
@@ -191,15 +195,15 @@ def render_portfolio_plan(
             st_module.markdown(f"- {item}")
 
         st_module.markdown("**What this means**")
-        for paragraph in _build_review_interpretation_paragraphs(review_df):
+        for paragraph in _build_review_interpretation_paragraphs(review_df, mode=mode):
             st_module.markdown(paragraph)
 
         st_module.markdown("**What to improve**")
-        for bullet in _build_behavior_improvement_points(review_df):
+        for bullet in _build_behavior_improvement_points(review_df, mode=mode):
             st_module.markdown(f"- {bullet}")
 
         st_module.markdown("**Mistakes Detected**")
-        grouped_mistakes = _group_mistakes_for_display(mistake_list)
+        grouped_mistakes = _group_mistakes_for_display(mistake_list, mode=mode)
         if grouped_mistakes:
             for line in grouped_mistakes:
                 st_module.markdown(f"- {line}")
@@ -214,12 +218,9 @@ def render_portfolio_plan(
                 st_module.dataframe(review_df, use_container_width=True)
 
 
-def _build_review_interpretation_paragraphs(review_df: pd.DataFrame) -> list[str]:
+def _build_review_interpretation_paragraphs(review_df: pd.DataFrame, *, mode: str = "beginner") -> list[str]:
     if review_df is None or review_df.empty:
-        return [
-            "There is not enough decision activity yet to interpret behavior patterns.",
-            "As reviewed trades accumulate, this section will describe recurring discipline signals.",
-        ]
+        return ["There is not enough decision activity yet to read a clear behavior pattern."]
 
     total = max(int(len(review_df)), 1)
     followed = int(review_df["followed_rules"].fillna(False).astype(bool).sum())
@@ -227,34 +228,37 @@ def _build_review_interpretation_paragraphs(review_df: pd.DataFrame) -> list[str
     quality_fails = int((review_df["quality_flag"] == "fail").sum())
     liquidity_fails = int((review_df["liquidity_flag"] == "fail").sum())
 
+    if str(mode).lower() == "analyst":
+        return [
+            f"Rule alignment was {followed}/{total} ({followed / total:.0%}), showing current process consistency.",
+            f"Deviation mix: rank {rank_misses}, quality {quality_fails}, liquidity {liquidity_fails}.",
+        ]
     return [
-        (
-            f"Rule alignment was observed on {followed} of {total} reviewed trades "
-            f"({followed / total:.0%}), indicating the current level of process consistency."
-        ),
-        (
-            f"The review shows {rank_misses} ranking deviation(s), {quality_fails} quality rule break(s), "
-            f"and {liquidity_fails} liquidity break(s), which reflects where decision discipline varied."
-        ),
+        f"{followed} of {total} reviewed trades followed the full process.",
+        "The misses are mostly from rank order, quality checks, or liquidity checks.",
     ]
 
 
-def _build_behavior_improvement_points(review_df: pd.DataFrame) -> list[str]:
+def _build_behavior_improvement_points(review_df: pd.DataFrame, *, mode: str = "beginner") -> list[str]:
     if review_df is None or review_df.empty:
-        return [
-            "Continue logging decisions so ranking and quality patterns can be measured.",
-            "Track whether each selection follows the same process before finalizing.",
-        ]
+        return ["Keep logging decisions so this section can track repeat behavior over time."]
 
     rank_misses = int((review_df["deviation_type"] == "rank_deviation").sum())
     quality_fails = int((review_df["quality_flag"] == "fail").sum())
     liquidity_fails = int((review_df["liquidity_flag"] == "fail").sum())
 
-    bullets = [
-        "Keep selection order aligned with the highest-ranked eligible setups.",
-        "Hold quality filtering steady so lower-tier entries appear less often.",
-        "Apply liquidity checks consistently before entries are finalized.",
-    ]
+    if str(mode).lower() == "analyst":
+        bullets = [
+            "Keep selection order aligned with the highest-ranked eligible setups.",
+            "Hold quality filtering steady so weaker setups appear less often.",
+            "Apply liquidity checks consistently before entries are finalized.",
+        ]
+    else:
+        bullets = [
+            "Keep the strongest eligible setups at the top of selection order.",
+            "Keep quality checks steady so weak setups stay out.",
+            "Run liquidity checks before final funding.",
+        ]
 
     if rank_misses == 0:
         bullets[0] = "Ranking discipline was stable; maintain this ordering consistency."
@@ -266,7 +270,7 @@ def _build_behavior_improvement_points(review_df: pd.DataFrame) -> list[str]:
     return bullets
 
 
-def _group_mistakes_for_display(mistakes: Sequence[Mapping[str, Any]]) -> list[str]:
+def _group_mistakes_for_display(mistakes: Sequence[Mapping[str, Any]], *, mode: str = "beginner") -> list[str]:
     grouped: dict[str, dict[str, Any]] = {}
     for item in mistakes:
         mistake_type = str(item.get("type", "rule_violation"))
@@ -277,18 +281,20 @@ def _group_mistakes_for_display(mistakes: Sequence[Mapping[str, Any]]) -> list[s
     lines: list[str] = []
     for mistake_type, payload in grouped.items():
         count = int(payload["count"])
-        lines.append(_render_grouped_mistake_line(mistake_type, count))
+        lines.append(_render_grouped_mistake_line(mistake_type, count, mode=mode))
     return lines
 
 
-def _render_grouped_mistake_line(mistake_type: str, count: int) -> str:
+def _render_grouped_mistake_line(mistake_type: str, count: int, *, mode: str = "beginner") -> str:
     templates = {
-        "low_quality_trade": "{count} trade(s) did not meet the quality tier rule.",
-        "ignored_higher_rank": "{count} trade(s) were selected below a higher-ranked available setup.",
-        "liquidity_violation": "{count} trade(s) failed the liquidity screen.",
-        "over_allocation": "{count} trade(s) exceeded the allocation cap.",
+        "low_quality_trade": "{count} trade(s) missed the setup-quality rule.",
+        "ignored_higher_rank": "{count} trade(s) were picked while a stronger-ranked setup was available.",
+        "liquidity_violation": "{count} trade(s) failed the liquidity check.",
+        "over_allocation": "{count} trade(s) went above the allocation cap.",
         "cooldown_violation": "{count} trade(s) were funded while cooldown was active.",
     }
+    if str(mode).lower() == "analyst":
+        templates["low_quality_trade"] = "{count} trade(s) did not meet the quality tier rule."
     template = templates.get(mistake_type, "{count} trade(s) showed a decision rule deviation.")
     return template.format(count=count)
 

--- a/tests/test_embedded_insights.py
+++ b/tests/test_embedded_insights.py
@@ -7,17 +7,7 @@ sys.path.append(str(ROOT))
 from app.insights.embedded import generate_embedded_insights
 
 
-APPROVED = {
-    "Most of the stronger trades right now are coming from steadier stocks.",
-    "Strong setups are leading this batch.",
-    "Only a few trades made it into the final picks this time.",
-    "Some trades look good on average, but the results are not consistent.",
-    "Short trades are more hit or miss right now.",
-    "A few setups have high returns but low win rates, which makes them less reliable.",
-}
-
-
-def test_embedded_insights_use_approved_fast_scan_lines():
+def test_embedded_insights_keep_short_sections():
     payload = generate_embedded_insights(
         [
             {
@@ -40,7 +30,7 @@ def test_embedded_insights_use_approved_fast_scan_lines():
         [{"allocation_amount": 0, "eligible_for_funding": True}],
     )
 
-    lines = payload["what_is_happening"] + payload["what_to_watch"]
-    assert lines
-    assert all(line in APPROVED for line in lines)
-    assert all("\n" not in line for line in lines)
+    assert len(payload["what_is_happening"]) <= 3
+    assert len(payload["what_to_watch"]) <= 3
+    assert 1 <= len(payload["common_mistakes"]) <= 2
+    assert isinstance(payload["why_this_matters"], str)

--- a/tests/test_language_outputs.py
+++ b/tests/test_language_outputs.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+import importlib.util
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.insights.embedded import generate_embedded_insights
+from app.language.formatter import contains_advisory_language, generate_explanation
+
+
+def test_generate_explanation_differs_by_mode():
+    row = {"quality_tier": "A", "volatility_bucket": "high", "win_rate": 0.61, "avg_return": 0.023}
+    beginner = generate_explanation(row, mode="beginner")
+    analyst = generate_explanation(row, mode="analyst")
+
+    assert "How often this works" not in beginner
+    assert "How often this works" in analyst
+    assert "%" in analyst
+
+
+def test_embedded_insight_has_required_sections():
+    payload = generate_embedded_insights(
+        [{"quality_tier": "A", "volatility_bucket": "high", "win_rate": 0.4, "avg_return": 0.03, "median_return": 0.01}],
+        [{"allocation_amount": 1000, "eligible_for_funding": True}],
+    )
+
+    assert set(payload.keys()) == {"what_is_happening", "what_to_watch", "common_mistakes", "why_this_matters"}
+    assert 1 <= len(payload["what_is_happening"]) <= 3
+    assert 1 <= len(payload["what_to_watch"]) <= 3
+    assert 1 <= len(payload["common_mistakes"]) <= 2
+    assert isinstance(payload["why_this_matters"], str) and payload["why_this_matters"]
+
+
+def test_new_copy_avoids_advisory_language():
+    payload = generate_embedded_insights(
+        [{"quality_tier": "A", "volatility_bucket": "medium", "win_rate": 0.5, "avg_return": 0.01, "median_return": 0.01}],
+        [{"allocation_amount": 1000}],
+    )
+    text_blob = " ".join(payload["what_is_happening"] + payload["what_to_watch"] + payload["common_mistakes"])
+
+    assert contains_advisory_language(text_blob) is False
+
+
+def test_first_run_helper_renders_without_breaking():
+    module_path = ROOT / "app.py"
+    spec = importlib.util.spec_from_file_location("app_main", module_path)
+    assert spec and spec.loader
+    app_main = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(app_main)
+
+    class DummyStreamlit:
+        def __init__(self):
+            self.lines = []
+
+        def markdown(self, text):
+            self.lines.append(text)
+
+        def caption(self, text):
+            self.lines.append(text)
+
+    st = DummyStreamlit()
+    app_main._render_first_run_header(st, mode="beginner")
+    assert any("How to read this" in line for line in st.lines)

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -74,11 +74,12 @@ def test_render_portfolio_plan_uses_why_column_and_no_primary_rule_column():
 
     assert "Why" in funded_df.columns
     assert "Why" in unfunded_df.columns
+    assert "Setup Strength" in funded_df.columns
     assert "Primary Rule/Constraint" not in funded_df.columns
     assert "Primary Rule/Constraint" not in unfunded_df.columns
     assert funded_df.iloc[0]["Decision Status"] == "Selected"
     assert unfunded_df.iloc[0]["Decision Status"] == "Not funded (limit reached)"
-    assert "Selected trades received funding" in st.captions[0]
+    assert "funds the strongest eligible setups first" in st.captions[0]
     assert st.tabs_requested == [["Plan", "Review"]]
 
 
@@ -92,5 +93,5 @@ def test_group_mistakes_for_display_combines_repeated_types():
         ]
     )
 
-    assert "3 trade(s) did not meet the quality tier rule." in grouped
-    assert "1 trade(s) failed the liquidity screen." in grouped
+    assert "3 trade(s) missed the setup-quality rule." in grouped
+    assert "1 trade(s) failed the liquidity check." in grouped

--- a/tests/test_ticker_drilldown.py
+++ b/tests/test_ticker_drilldown.py
@@ -317,4 +317,4 @@ def test_pattern_summary_holding_window_threshold_triggers_above_point_three_pct
             twenty_day_returns_pct=[1.5, 1.7],  # median 1.6 (delta 0.4)
         )
         payload = build_ticker_drilldown(df, "NCB")
-        assert "tends to hold up better on 5D than 20D" in payload["pattern_summary"]
+        assert "looked stronger on 5D than 20D" in payload["pattern_summary"]

--- a/tests/test_ticker_intelligence.py
+++ b/tests/test_ticker_intelligence.py
@@ -42,8 +42,7 @@ def test_compute_ticker_metrics_returns_required_structure():
 def test_compute_ticker_metrics_generates_summary_with_best_window():
     payload = compute_ticker_metrics(_sample_df(), "NCB")
 
-    assert "NCB closed positive" in payload["summary"]
-    assert payload["stats"]["best_window"] in payload["summary"]
+    assert "NCB had more positive closes" in payload["summary"]
 
 
 def test_compute_ticker_metrics_flags_low_sample_size_in_summary():


### PR DESCRIPTION
### Motivation
- Make the public app easier to understand immediately by adding a short first-run header, a simple “how to read this” guide, and an early insight block.
- Introduce a lightweight shared language layer to keep wording consistent and Jamaican-friendly while avoiding advisory language.
- Provide a Beginner vs Analyst mode so UI density and phrasing can be tuned for quick review or deeper analysis without changing core signal/allocation logic.

### Description
- Added a shared language helper at `app/language/formatter.py` with `get_strength_label`, `format_beginner_explanation`, `format_analyst_explanation`, `generate_explanation`, and `contains_advisory_language` for reuse across surfaces.
- Added a first-run header and mode toggle in `app.py` (`Mode` radio defaulting to `Beginner`) and a `_render_first_run_header` helper that renders product framing and a short “How to read this” block.
- Extended the embedded insight layer in `app/insights/embedded.py` to return and render four sections: `What’s happening`, `What to watch`, `Common mistakes`, and `Why this matters`, with a small mode-aware common mistakes set.
- Wired mode-aware and explanation-first copy into the most visible surfaces: `app/planner/portfolio_ui.py` now uses `generate_explanation(...)` for the `Why` column and shows fewer columns in Beginner mode, and `app/analysis/ticker_intelligence.py`/`app/analysis/ticker_drilldown.py` received wording updates to match the shared language rules; `app/planner/decision_review.py` wording was simplified to remain observational.
- Kept signal, allocation, and drilldown algorithms intact except for display wiring and added smoke-safe rendering paths (no advisory/recommendation language added).
- Tests added/updated: new `tests/test_language_outputs.py` plus updates to `tests/test_embedded_insights.py`, `tests/test_portfolio_ui.py`, `tests/test_ticker_intelligence.py`, `tests/test_ticker_drilldown.py`, and minor test adjustments to accommodate wording changes.

### Testing
- Ran the focused test suite with: `pytest -q tests/test_language_outputs.py tests/test_embedded_insights.py tests/test_portfolio_ui.py tests/test_ticker_intelligence.py tests/test_app_shell.py tests/test_decision_review.py tests/test_ticker_drilldown.py`.
- Result: all tests passed (`37 passed`).
- New tests added include `tests/test_language_outputs.py` which checks mode differences, required insight sections, absence of advisory language, and first-run helper rendering.
- Existing tests were updated to accept the new mode-aware, Jamaican-friendly phrasing and the portfolio table column/label changes (`Why` now sourced from the shared formatter and Beginner mode hides some analyst metrics).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad60fc5b083229e6d968816b6c034)