### PR TITLE
Sprint 12 Step 3 polish: trust layer, beginner wording, and review clarity

### DIFF
--- a/app.py
+++ b/app.py
@@ -187,12 +187,16 @@ def main() -> None:
 def _render_first_run_header(st_module, *, mode: str) -> None:
     st_module.markdown("### JSE Market Lab")
     st_module.markdown(
-        "A tool that helps you review stock opportunities on the Jamaican market using structured rules and risk checks."
+        "This dashboard helps you review stock opportunities on the Jamaican market using structured rules and risk checks."
+    )
+    st_module.markdown(
+        "It highlights stronger setups, explains the risks, and shows what to watch before making decisions."
     )
     st_module.markdown("**How to read this**")
     st_module.markdown("- The system scans the market and ranks possible trades.")
-    st_module.markdown("- Only the strongest setups are funded in the plan below.")
-    st_module.markdown("- Each trade shows why it was selected and what risk is involved.")
+    st_module.markdown("- Only the stronger setups are selected in the plan below.")
+    st_module.markdown("- Each trade explains why it was chosen and what risk is involved.")
+    st_module.caption("Based on historical data. Results can vary, so risk still matters.")
     if mode == "beginner":
         st_module.caption("Beginner mode keeps the view simple: explanation first, fewer metrics.")
     else:

--- a/app/analysis/ticker_intelligence.py
+++ b/app/analysis/ticker_intelligence.py
@@ -48,8 +48,14 @@ def build_ticker_summary(metrics: dict[str, Any], *, mode: str = "beginner") -> 
             f"and the strongest read at {best_window}."
         )
     else:
+        if win_rate >= 60:
+            setup_read = "This setup has worked well in the past."
+        elif win_rate >= 50:
+            setup_read = "This setup has worked about half the time."
+        else:
+            setup_read = "This setup has been less consistent."
         base = (
-            f"{metrics['ticker']} had more positive closes than negative ones in {win_rate:.0f}% of signals, "
+            f"{setup_read} {metrics['ticker']} closed positive in {win_rate:.0f}% of signals, "
             f"with a typical return near {median_return:.2f}%."
         )
 

--- a/app/insights/embedded.py
+++ b/app/insights/embedded.py
@@ -49,7 +49,7 @@ def generate_embedded_insights(
 
     common_mistakes = _common_mistakes_lines(rows, mode=mode)
     why_this_matters = (
-        "This helps you understand where the plan is strong, where risk is rising, and what to monitor next."
+        "Based on historical data, this helps you understand where the plan is strong, where risk is rising, and what to monitor next. Use it as a decision-support tool, not a guarantee."
     )
 
     return {

--- a/app/planner/decision_review.py
+++ b/app/planner/decision_review.py
@@ -208,7 +208,7 @@ def build_behavior_summary(trades_df: pd.DataFrame, review_df: pd.DataFrame) -> 
     if liquidity_fails > 0:
         insights.append(f"Liquidity checks failed on {liquidity_fails} trade(s).")
     else:
-        insights.append("Liquidity checks stayed clean across reviewed trades.")
+        insights.append("There was enough trading activity across the selected trades.")
 
     return insights[:4]
 

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -177,6 +177,12 @@ def render_portfolio_plan(
 
     with review_tab:
         st_module.markdown("#### Decision Review")
+        st_module.markdown(
+            "This section shows how closely the selected trades followed the system rules."
+        )
+        st_module.markdown(
+            "It helps you spot where decisions stayed disciplined and where risk increased."
+        )
         trades_df = pd.DataFrame(list(allocations))
         safe_signals_df = signals_df if signals_df is not None else pd.DataFrame()
         review_df = compute_trade_review(trades_df, safe_signals_df)
@@ -230,12 +236,12 @@ def _build_review_interpretation_paragraphs(review_df: pd.DataFrame, *, mode: st
 
     if str(mode).lower() == "analyst":
         return [
-            f"Rule alignment was {followed}/{total} ({followed / total:.0%}), showing current process consistency.",
+            f"Rule alignment came in at {followed}/{total} ({followed / total:.0%}), based on the current review set.",
             f"Deviation mix: rank {rank_misses}, quality {quality_fails}, liquidity {liquidity_fails}.",
         ]
     return [
-        f"{followed} of {total} reviewed trades followed the full process.",
-        "The misses are mostly from rank order, quality checks, or liquidity checks.",
+        f"{followed} of {total} reviewed trades followed the full process rules.",
+        "Where rules were missed, the gaps came from rank order, quality checks, or liquidity checks.",
     ]
 
 
@@ -250,13 +256,13 @@ def _build_behavior_improvement_points(review_df: pd.DataFrame, *, mode: str = "
     if str(mode).lower() == "analyst":
         bullets = [
             "Keep selection order aligned with the highest-ranked eligible setups.",
-            "Hold quality filtering steady so weaker setups appear less often.",
-            "Apply liquidity checks consistently before entries are finalized.",
+            "Keep quality filtering steady so weaker setups appear less often.",
+            "Apply liquidity checks before entries are finalized.",
         ]
     else:
         bullets = [
             "Keep the strongest eligible setups at the top of selection order.",
-            "Keep quality checks steady so weak setups stay out.",
+            "Keep quality checks steady so weaker setups stay out.",
             "Run liquidity checks before final funding.",
         ]
 

--- a/tests/test_decision_review.py
+++ b/tests/test_decision_review.py
@@ -143,6 +143,25 @@ def test_build_behavior_summary_generates_observational_bullets():
     assert "followed the selection rules" in summary[0]
 
 
+def test_build_behavior_summary_uses_clear_liquidity_wording_when_clean():
+    trades_df = pd.DataFrame([{"instrument": "AAA"}])
+    review_df = pd.DataFrame(
+        [
+            {
+                "instrument": "AAA",
+                "followed_rules": True,
+                "deviation_type": None,
+                "quality_flag": "pass",
+                "liquidity_flag": "pass",
+            }
+        ]
+    )
+
+    summary = build_behavior_summary(trades_df, review_df)
+
+    assert "There was enough trading activity across the selected trades." in summary
+
+
 def test_compute_discipline_score_uses_adherence_components():
     review_df = pd.DataFrame(
         [

--- a/tests/test_language_outputs.py
+++ b/tests/test_language_outputs.py
@@ -62,3 +62,16 @@ def test_first_run_helper_renders_without_breaking():
     st = DummyStreamlit()
     app_main._render_first_run_header(st, mode="beginner")
     assert any("How to read this" in line for line in st.lines)
+    assert any("Based on historical data." in line for line in st.lines)
+    assert any("risk still matters" in line.lower() for line in st.lines)
+
+
+def test_embedded_why_this_matters_includes_trust_layer_without_advisory_terms():
+    payload = generate_embedded_insights(
+        [{"quality_tier": "A", "volatility_bucket": "medium", "win_rate": 0.52, "avg_return": 0.01, "median_return": 0.01}],
+        [{"allocation_amount": 1500, "eligible_for_funding": True}],
+    )
+
+    assert "Based on historical data" in payload["why_this_matters"]
+    assert "decision-support tool, not a guarantee" in payload["why_this_matters"]
+    assert contains_advisory_language(payload["why_this_matters"]) is False

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -13,6 +13,7 @@ class DummyStreamlit:
         self.info_messages = []
         self.captions = []
         self.writes = []
+        self.markdowns = []
         self.tabs_requested = []
 
     class _DummyTab:
@@ -29,6 +30,7 @@ class DummyStreamlit:
         self.captions.append(text)
 
     def markdown(self, _text):
+        self.markdowns.append(_text)
         return None
 
     def info(self, text):
@@ -81,6 +83,7 @@ def test_render_portfolio_plan_uses_why_column_and_no_primary_rule_column():
     assert unfunded_df.iloc[0]["Decision Status"] == "Not funded (limit reached)"
     assert "funds the strongest eligible setups first" in st.captions[0]
     assert st.tabs_requested == [["Plan", "Review"]]
+    assert any("followed the system rules" in line for line in st.markdowns)
 
 
 def test_group_mistakes_for_display_combines_repeated_types():

--- a/tests/test_ticker_intelligence.py
+++ b/tests/test_ticker_intelligence.py
@@ -42,7 +42,23 @@ def test_compute_ticker_metrics_returns_required_structure():
 def test_compute_ticker_metrics_generates_summary_with_best_window():
     payload = compute_ticker_metrics(_sample_df(), "NCB")
 
-    assert "NCB had more positive closes" in payload["summary"]
+    assert "This setup has worked well in the past." in payload["summary"]
+    assert "closed positive in 62% of signals" in payload["summary"]
+
+
+def test_compute_ticker_metrics_uses_neutral_beginner_wording_for_weak_win_rate():
+    df = pd.DataFrame(
+        {
+            "instrument": ["TEST"] * 6,
+            "holding_window": [5, 5, 5, 20, 20, 20],
+            "net_return_pct": [-0.02, -0.01, 0.01, -0.03, 0.01, -0.01],
+        }
+    )
+
+    payload = compute_ticker_metrics(df, "TEST", mode="beginner")
+
+    assert "This setup has been less consistent." in payload["summary"]
+    assert "closed positive in 33% of signals" in payload["summary"]
 
 
 def test_compute_ticker_metrics_flags_low_sample_size_in_summary():


### PR DESCRIPTION
### Motivation
- Improve first-run clarity and surface trust signals so the app reads as a calm, decision‑support tool for new users. 
- Remove unintentionally positive beginner phrasing that can mislead when win rates are weak. 
- Tighten Review and Portfolio wording for clearer, more natural observations without changing core logic.

### Description
- Updated the first-run header in `app.py` to clearer framing and added a compact trust caption (`Based on historical data. Results can vary, so risk still matters.`). 
- Reworked beginner ticker summary wording in `app/analysis/ticker_intelligence.py` to use conditional/neutral language by win‑rate band (`>=60%`, `>=50%`, `<50%`) while retaining factual percent metrics. 
- Added a short purpose intro to the Review tab and softened interpretation/improvement bullets in `app/planner/portfolio_ui.py`. 
- Rephrased liquidity behavior copy in `app/planner/decision_review.py` to read more natural Jamaican-friendly English. 
- Introduced a lightweight trust sentence in embedded insights (`app/insights/embedded.py`): `Use it as a decision-support tool, not a guarantee.` 
- Expanded unit tests to cover beginner-mode neutral wording, presence of trust copy, Review intro rendering, and the liquidity wording change (`tests/test_ticker_intelligence.py`, `tests/test_language_outputs.py`, `tests/test_portfolio_ui.py`, `tests/test_decision_review.py`).

### Testing
- Ran subset of focused tests with success: `pytest -q tests/test_ticker_intelligence.py tests/test_language_outputs.py tests/test_portfolio_ui.py tests/test_decision_review.py` — all tests passed (`20 passed`).
- Verified first-run helper loading via app shell tests: `pytest -q tests/test_app_shell.py` — all tests passed (`2 passed`).
- Updated/added tests assert no advisory language was introduced and confirm new trust‑layer copy is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae1fef6508322a211f581d4297db3)