### PR TITLE
Fix Streamlit duplicate rendering and flatten dashboard tabs

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,15 +30,6 @@ def main() -> None:
     mode_token = mode.lower()
 
     canonical_df, meta, issues = ingest_dataset("demo")
-    st.markdown("### Data Status")
-    st.write(
-        {
-            "dataset_id": meta.get("dataset_id"),
-            "source": meta.get("source"),
-            "row_count": int(len(canonical_df)),
-            "validation_issues": issues,
-        }
-    )
 
     if canonical_df.empty:
         st.warning("No rows were loaded from the data layer. Please verify demo dataset files.")
@@ -60,10 +51,69 @@ def main() -> None:
     _render_first_run_header(st, mode=mode_token)
     render_embedded_insights(insights_payload, st_module=st)
 
-    st.markdown("### Main Dashboard")
-    st.dataframe(canonical_df.head(50), use_container_width=True)
+    if ranked_df.empty:
+        allocations: list[dict] = []
+    else:
+        default_capital = 100_000.0
+        allocation_payload = generate_portfolio_allocation(trade_rows, default_capital)
+        base_allocations = allocation_payload.get("allocations", [])
+        allocations = [{**allocation, **row} for row, allocation in zip(trade_rows, base_allocations)]
 
-    insights_tab, ticker_tab, plan_tab = st.tabs(["Analyst Insights", "Ticker Analysis", "Portfolio Plan"])
+    portfolio_tab, review_tab, insights_tab, ticker_tab = st.tabs(
+        ["Portfolio", "Review", "Analyst Insights", "Ticker Analysis"]
+    )
+
+    with portfolio_tab:
+        st.markdown("### Portfolio Plan")
+        total_capital = st.number_input(
+            "Total capital",
+            min_value=0.0,
+            value=100_000.0,
+            step=5_000.0,
+        )
+        if ranked_df.empty:
+            st.info("Portfolio Plan unavailable: ranked outputs were not generated.")
+        else:
+            allocation_payload = generate_portfolio_allocation(trade_rows, total_capital)
+            refreshed_allocations = allocation_payload.get("allocations", [])
+            enriched_allocations = [
+                {**allocation, **row} for row, allocation in zip(trade_rows, refreshed_allocations)
+            ]
+            render_portfolio_plan(
+                enriched_allocations,
+                total_capital=total_capital,
+                st_module=st,
+                signals_df=ranked_df,
+                mode=mode_token,
+                section="plan",
+                show_header=False,
+            )
+
+    with review_tab:
+        st.markdown("### Review")
+        st.markdown("#### Data Status")
+        st.write(
+            {
+                "dataset_id": meta.get("dataset_id"),
+                "source": meta.get("source"),
+                "row_count": int(len(canonical_df)),
+                "validation_issues": issues,
+            }
+        )
+        st.markdown("#### Main Dashboard")
+        st.dataframe(canonical_df.head(50), use_container_width=True)
+        if ranked_df.empty:
+            st.info("Review unavailable: ranked outputs were not generated.")
+        else:
+            render_portfolio_plan(
+                allocations,
+                total_capital=100_000.0,
+                st_module=st,
+                signals_df=ranked_df,
+                mode=mode_token,
+                section="review",
+                show_header=False,
+            )
 
     with insights_tab:
         render_analyst_insights(analyst_df, st_module=st, analyst_mode=mode_token == "analyst")
@@ -153,35 +203,6 @@ def main() -> None:
                     st.info("No signal history is available for this ticker yet.")
                 else:
                     st.dataframe(signal_df, use_container_width=True)
-
-    with plan_tab:
-        st.markdown("### Portfolio Plan")
-        total_capital = st.number_input(
-            "Total capital",
-            min_value=0.0,
-            value=100_000.0,
-            step=5_000.0,
-        )
-
-        if ranked_df.empty:
-            st.info("Portfolio Plan unavailable: ranked outputs were not generated.")
-            return
-
-        allocation_payload = generate_portfolio_allocation(trade_rows, total_capital)
-        allocations = allocation_payload.get("allocations", [])
-
-        # Attach lightweight context fields used by portfolio UI reason labels.
-        enriched_allocations = []
-        for row, allocation in zip(trade_rows, allocations):
-            enriched_allocations.append({**allocation, **row})
-
-        render_portfolio_plan(
-            enriched_allocations,
-            total_capital=total_capital,
-            st_module=st,
-            signals_df=ranked_df,
-            mode=mode_token,
-        )
 
 
 def _render_first_run_header(st_module, *, mode: str) -> None:

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -90,16 +90,24 @@ def render_portfolio_plan(
     signals_df: pd.DataFrame | None = None,
     show_review_table: bool = True,
     mode: str = "beginner",
+    section: str = "both",
+    show_header: bool = True,
 ) -> None:
-    """Render portfolio summary and review details with plan/review subtabs."""
+    """Render portfolio summary/review details in one section or both."""
     if st_module is None:
         import streamlit as st_module
 
-    st_module.subheader("Portfolio Plan")
+    normalized_section = str(section or "both").strip().lower()
+    if normalized_section not in {"plan", "review", "both"}:
+        normalized_section = "both"
+
+    if show_header:
+        st_module.subheader("Portfolio Plan")
     analyst_mode = str(mode or "beginner").lower() == "analyst"
-    st_module.caption(
-        "The plan funds the strongest eligible setups first, while other trades stay out when rules or limits block them."
-    )
+    if show_header and normalized_section in {"plan", "both"}:
+        st_module.caption(
+            "The plan funds the strongest eligible setups first, while other trades stay out when rules or limits block them."
+        )
 
     if not allocations:
         st_module.info("Portfolio Plan unavailable: no allocation outputs were provided.")
@@ -108,9 +116,7 @@ def render_portfolio_plan(
     summary = build_portfolio_summary(allocations, total_capital)
     funded_trades, unfunded_trades = split_trades_by_funding(allocations)
 
-    plan_tab, review_tab = st_module.tabs(["Plan", "Review"])
-
-    with plan_tab:
+    def _render_plan_section() -> None:
         st_module.markdown("#### Portfolio Summary")
         summary_df = pd.DataFrame(
             [
@@ -175,7 +181,7 @@ def render_portfolio_plan(
             "- Tier C and liquidity failures are not funded"
         )
 
-    with review_tab:
+    def _render_review_section() -> None:
         st_module.markdown("#### Decision Review")
         st_module.markdown(
             "This section shows how closely the selected trades followed the system rules."
@@ -222,6 +228,19 @@ def render_portfolio_plan(
                 st_module.info("No review rows available for this run.")
             else:
                 st_module.dataframe(review_df, use_container_width=True)
+
+    if normalized_section == "plan":
+        _render_plan_section()
+        return
+    if normalized_section == "review":
+        _render_review_section()
+        return
+
+    plan_tab, review_tab = st_module.tabs(["Plan", "Review"])
+    with plan_tab:
+        _render_plan_section()
+    with review_tab:
+        _render_review_section()
 
 
 def _build_review_interpretation_paragraphs(review_df: pd.DataFrame, *, mode: str = "beginner") -> list[str]:


### PR DESCRIPTION
### Motivation
- Prevent duplicated UI blocks and nested tabs that caused repeated headers and corrupted layout on rerun by centralizing top-level rendering flow. 
- Ensure the dashboard follows a single top-level order: mode toggle, first-run header, embedded insight block, then main tabs, so users see each section exactly once.

### Description
- Reworked `app.py` to render the first-run header and embedded insights once at top level and introduced top-level tabs `Portfolio`, `Review`, `Analyst Insights`, and `Ticker Analysis` to avoid nested tabs and duplicated content. 
- Moved the previous top-level `Data Status`/`Main Dashboard` output into a dedicated `Review` tab and removed duplicate root-level writes. 
- Extended `render_portfolio_plan` in `app/planner/portfolio_ui.py` with new parameters `section` (`"plan" | "review" | "both"`) and `show_header` to allow callers to render only the plan or review section (or both) and to suppress duplicate headers, while preserving backward-compatible `both` behavior. 
- Centralized the mode toggle to a single `mode_token` at app entry and passed it into downstream renderers via `mode` so mode-driven rendering is controlled from one place. 

### Testing
- Ran `pytest -q tests/test_portfolio_ui.py tests/test_embedded_insights.py tests/test_app_shell.py` and all tests passed. 
- Test results: `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae7f3d60c8322a1000057451223fd)