### PR TITLE
Unify selected capital across Portfolio and Review paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,24 +40,27 @@ def main() -> None:
     analyst_df = build_analyst_dataset(canonical_df, ranked_df)
     trade_rows = coerce_trade_rows_from_ranked(ranked_df) if not ranked_df.empty else []
 
+    selected_capital = st.number_input(
+        "Total capital",
+        min_value=0.0,
+        value=100_000.0,
+        step=5_000.0,
+    )
+
+    if ranked_df.empty:
+        enriched_allocations: list[dict] = []
+    else:
+        allocation_payload = generate_portfolio_allocation(trade_rows, selected_capital)
+        base_allocations = allocation_payload.get("allocations", [])
+        enriched_allocations = [{**allocation, **row} for row, allocation in zip(trade_rows, base_allocations)]
+
     if trade_rows:
-        preview_allocation = generate_portfolio_allocation(trade_rows, 100_000.0)
-        preview_allocations = preview_allocation.get("allocations", [])
-        enriched_preview = [{**allocation, **row} for row, allocation in zip(trade_rows, preview_allocations)]
-        insights_payload = generate_embedded_insights(trade_rows, enriched_preview, mode=mode_token)
+        insights_payload = generate_embedded_insights(trade_rows, enriched_allocations, mode=mode_token)
     else:
         insights_payload = generate_embedded_insights([], [], mode=mode_token)
 
     _render_first_run_header(st, mode=mode_token)
     render_embedded_insights(insights_payload, st_module=st)
-
-    if ranked_df.empty:
-        allocations: list[dict] = []
-    else:
-        default_capital = 100_000.0
-        allocation_payload = generate_portfolio_allocation(trade_rows, default_capital)
-        base_allocations = allocation_payload.get("allocations", [])
-        allocations = [{**allocation, **row} for row, allocation in zip(trade_rows, base_allocations)]
 
     portfolio_tab, review_tab, insights_tab, ticker_tab = st.tabs(
         ["Portfolio", "Review", "Analyst Insights", "Ticker Analysis"]
@@ -65,23 +68,12 @@ def main() -> None:
 
     with portfolio_tab:
         st.markdown("### Portfolio Plan")
-        total_capital = st.number_input(
-            "Total capital",
-            min_value=0.0,
-            value=100_000.0,
-            step=5_000.0,
-        )
         if ranked_df.empty:
             st.info("Portfolio Plan unavailable: ranked outputs were not generated.")
         else:
-            allocation_payload = generate_portfolio_allocation(trade_rows, total_capital)
-            refreshed_allocations = allocation_payload.get("allocations", [])
-            enriched_allocations = [
-                {**allocation, **row} for row, allocation in zip(trade_rows, refreshed_allocations)
-            ]
             render_portfolio_plan(
                 enriched_allocations,
-                total_capital=total_capital,
+                total_capital=selected_capital,
                 st_module=st,
                 signals_df=ranked_df,
                 mode=mode_token,
@@ -106,8 +98,8 @@ def main() -> None:
             st.info("Review unavailable: ranked outputs were not generated.")
         else:
             render_portfolio_plan(
-                allocations,
-                total_capital=100_000.0,
+                enriched_allocations,
+                total_capital=selected_capital,
                 st_module=st,
                 signals_df=ranked_df,
                 mode=mode_token,


### PR DESCRIPTION
### Motivation
- Ensure the portfolio `Review` always reflects the exact portfolio shown in `Portfolio` by using a single source of truth for total capital rather than duplicated/hardcoded values.

### Description
- Add a single user input `selected_capital = st.number_input(...)` and compute `enriched_allocations` once using `generate_portfolio_allocation(trade_rows, selected_capital)` in `app.py`.
- Pass the same `enriched_allocations` and `selected_capital` into `render_portfolio_plan(...)` for both the `plan` and `review` sections so downstream review logic (discipline scoring, mistake detection) uses the identical allocation context.
- Remove hardcoded uses of `100_000.0` and the duplicate `st.number_input` in the portfolio tab; consolidate allocation preparation.
- Modified file: `app.py`.

### Testing
- Ran `python -m compileall app.py app` which succeeded.
- Ran `pytest -q` which produced 94 passing tests and 1 failing test; the failing test is `tests/test_planner_explanations.py::test_status_labels_match_new_mapping` and fails with `NameError: name 'text' is not defined`, which appears to be a pre-existing test issue unrelated to the capital unification changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daec29a7cc8322bfa937b3f75b01f3)