### PR TITLE
Sprint 12: Move Total Capital to Portfolio, add Data tab, and improve Data/Insights UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,41 @@ from app.planner.portfolio_ui import render_portfolio_plan
 from app.shell import build_analyst_dataset, coerce_trade_rows_from_ranked
 
 
+def _has_analyst_insight_content(trades_df: pd.DataFrame, *, analyst_mode: bool) -> bool:
+    if not analyst_mode or trades_df.empty:
+        return False
+    return any(column in trades_df.columns for column in ("net_return_pct", "net_return", "return_pct", "return"))
+
+
+def _render_data_status_summary(
+    st_module,
+    *,
+    source: str | None,
+    row_count: int,
+    issues: list[str],
+    dataset_id: str | None,
+    analyst_mode: bool,
+) -> None:
+    st_module.markdown("#### Data Status")
+    status_col, quality_col = st_module.columns(2)
+    with status_col:
+        st_module.markdown(f"**Source:** {source or 'Unknown'}")
+        st_module.markdown(f"**Rows loaded:** {row_count}")
+        st_module.markdown(f"**Errors:** {0 if row_count > 0 else 1}")
+    with quality_col:
+        warning_count = len(issues)
+        st_module.markdown(f"**Warnings:** {warning_count}")
+        if analyst_mode:
+            st_module.markdown(f"**Dataset ID:** {dataset_id or 'N/A'}")
+
+    if issues:
+        st_module.markdown("**Warning details**")
+        for issue in issues:
+            st_module.markdown(f"- {issue}")
+    elif row_count > 0:
+        st_module.caption("No ingestion warnings were reported for this dataset.")
+
+
 def main() -> None:
     """Run the Streamlit shell with Analyst Insights and Portfolio Plan sections."""
     import streamlit as st
@@ -40,12 +75,8 @@ def main() -> None:
     analyst_df = build_analyst_dataset(canonical_df, ranked_df)
     trade_rows = coerce_trade_rows_from_ranked(ranked_df) if not ranked_df.empty else []
 
-    selected_capital = st.number_input(
-        "Total capital",
-        min_value=0.0,
-        value=100_000.0,
-        step=5_000.0,
-    )
+    default_capital = 100_000.0
+    selected_capital = float(st.session_state.get("total_capital", default_capital))
 
     if ranked_df.empty:
         enriched_allocations: list[dict] = []
@@ -62,12 +93,19 @@ def main() -> None:
     _render_first_run_header(st, mode=mode_token)
     render_embedded_insights(insights_payload, st_module=st)
 
-    portfolio_tab, review_tab, insights_tab, ticker_tab = st.tabs(
-        ["Portfolio", "Review", "Analyst Insights", "Ticker Analysis"]
+    portfolio_tab, review_tab, ticker_tab, insights_tab, data_tab = st.tabs(
+        ["Portfolio", "Review", "Ticker Analysis", "Analyst Insights", "Data"]
     )
 
     with portfolio_tab:
         st.markdown("### Portfolio Plan")
+        selected_capital = st.number_input(
+            "Total capital",
+            min_value=0.0,
+            value=selected_capital,
+            step=5_000.0,
+            key="total_capital",
+        )
         if ranked_df.empty:
             st.info("Portfolio Plan unavailable: ranked outputs were not generated.")
         else:
@@ -83,17 +121,6 @@ def main() -> None:
 
     with review_tab:
         st.markdown("### Review")
-        st.markdown("#### Data Status")
-        st.write(
-            {
-                "dataset_id": meta.get("dataset_id"),
-                "source": meta.get("source"),
-                "row_count": int(len(canonical_df)),
-                "validation_issues": issues,
-            }
-        )
-        st.markdown("#### Main Dashboard")
-        st.dataframe(canonical_df.head(50), use_container_width=True)
         if ranked_df.empty:
             st.info("Review unavailable: ranked outputs were not generated.")
         else:
@@ -106,9 +133,6 @@ def main() -> None:
                 section="review",
                 show_header=False,
             )
-
-    with insights_tab:
-        render_analyst_insights(analyst_df, st_module=st, analyst_mode=mode_token == "analyst")
 
     with ticker_tab:
         st.markdown("### Ticker Analysis")
@@ -195,6 +219,26 @@ def main() -> None:
                     st.info("No signal history is available for this ticker yet.")
                 else:
                     st.dataframe(signal_df, use_container_width=True)
+
+    with insights_tab:
+        st.markdown("### Analyst Insights")
+        if _has_analyst_insight_content(analyst_df, analyst_mode=mode_token == "analyst"):
+            render_analyst_insights(analyst_df, st_module=st, analyst_mode=True)
+        else:
+            st.info("Analyst insights are not available for this dataset yet.")
+
+    with data_tab:
+        st.markdown("### Data")
+        _render_data_status_summary(
+            st,
+            source=meta.get("source"),
+            row_count=int(len(canonical_df)),
+            issues=issues,
+            dataset_id=meta.get("dataset_id"),
+            analyst_mode=mode_token == "analyst",
+        )
+        st.markdown("#### Main Dashboard")
+        st.dataframe(canonical_df.head(50), use_container_width=True)
 
 
 def _render_first_run_header(st_module, *, mode: str) -> None:

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -1,0 +1,181 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+
+class DummyColumn:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyTab:
+    def __init__(self, st_module, name):
+        self._st = st_module
+        self._name = name
+
+    def __enter__(self):
+        self._st.current_tab = self._name
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._st.current_tab = None
+        return False
+
+
+class DummyStreamlit:
+    def __init__(self):
+        self.session_state = {}
+        self.current_tab = None
+        self.tabs_requested = []
+        self.number_inputs = []
+        self.markdowns = []
+        self.info_messages = []
+        self.dataframes = []
+        self.captions = []
+
+    def set_page_config(self, **_kwargs):
+        return None
+
+    def title(self, _text):
+        return None
+
+    def radio(self, _label, options, **_kwargs):
+        return options[1]
+
+    def markdown(self, text):
+        self.markdowns.append((self.current_tab, text))
+
+    def caption(self, text):
+        self.captions.append((self.current_tab, text))
+
+    def info(self, text):
+        self.info_messages.append((self.current_tab, text))
+
+    def write(self, _payload):
+        return None
+
+    def number_input(self, label, value=0.0, key=None, **_kwargs):
+        self.number_inputs.append((self.current_tab, label, key))
+        if key is not None:
+            self.session_state[key] = value
+        return value
+
+    def tabs(self, names):
+        self.tabs_requested.append(list(names))
+        return [DummyTab(self, name) for name in names]
+
+    def dataframe(self, df, **_kwargs):
+        self.dataframes.append((self.current_tab, df.copy()))
+
+    def selectbox(self, _label, options):
+        return options[0]
+
+    def columns(self, count):
+        return [DummyColumn() for _ in range(count)]
+
+    def subheader(self, _text):
+        return None
+
+
+def _load_app_module():
+    spec = importlib.util.spec_from_file_location("app_main", ROOT / "app.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sprint12_tab_layout_and_capital_location(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit()
+
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["AAA"],
+            "date": pd.to_datetime(["2024-01-01"]),
+            "close": [10.0],
+        }
+    )
+    ranked_df = pd.DataFrame({"instrument": ["AAA"], "selection_rank": [1], "tier": ["A"]})
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(app_main, "ingest_dataset", lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo-v1"}, []))
+    monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": ranked_df})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [{"instrument": "AAA"}])
+    monkeypatch.setattr(app_main, "generate_portfolio_allocation", lambda _rows, _capital: {"allocations": [{"allocation_amount": 5000, "allocation_pct": 0.05}]})
+    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
+    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(app_main, "render_portfolio_plan", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(app_main, "render_analyst_insights", lambda *_args, **_kwargs: None)
+
+    app_main.main()
+
+    assert dummy_st.tabs_requested[0] == ["Portfolio", "Review", "Ticker Analysis", "Analyst Insights", "Data"]
+    assert dummy_st.number_inputs == [("Portfolio", "Total capital", "total_capital")]
+
+
+def test_review_excludes_data_status_and_data_tab_contains_raw_preview(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit()
+
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["AAA", "BBB"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "close": [10.0, 11.0],
+        }
+    )
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(app_main, "ingest_dataset", lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "dataset-42"}, ["Missing volume for BBB"]))
+    monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
+    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
+
+    app_main.main()
+
+    review_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Review"]
+    assert "#### Data Status" not in review_markdowns
+    assert "#### Main Dashboard" not in review_markdowns
+
+    data_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Data"]
+    assert "#### Data Status" in data_markdowns
+    assert "#### Main Dashboard" in data_markdowns
+    assert any(tab == "Data" and len(df) == 2 for tab, df in dummy_st.dataframes)
+
+
+def test_analyst_insights_empty_state_when_no_content(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit()
+
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["AAA"],
+            "date": pd.to_datetime(["2024-01-01"]),
+            "close": [10.0],
+        }
+    )
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(app_main, "ingest_dataset", lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo"}, []))
+    monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
+    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
+
+    app_main.main()
+
+    insight_messages = [text for tab, text in dummy_st.info_messages if tab == "Analyst Insights"]
+    assert "Analyst insights are not available for this dataset yet." in insight_messages


### PR DESCRIPTION
### Motivation
- Fix misplaced UI elements and reduce backend/debug-style output by moving the Total capital control into the Portfolio area and separating technical dataset views into their own tab. 
- Make the Review tab focused on portfolio review content rather than raw data previews or ingestion JSON. 
- Replace raw JSON Data Status with a readable product-style summary and ensure Analyst Insights never renders an empty tab. 
- Preserve existing allocation/signal logic and Beginner vs Analyst mode behavior while improving information architecture.

### Description
- Moved the `Total capital` control out of the top-level area and into the Portfolio tab while keeping a single source of truth in `st.session_state['total_capital']` and reading it as the default at startup. 
- Reordered top-level tabs to: `Portfolio`, `Review`, `Ticker Analysis`, `Analyst Insights`, `Data`, and removed Data Status and the Main Dashboard preview from the Review tab. 
- Added a new `Data` tab and implemented `_render_data_status_summary` to present a readable summary card including `Source`, `Rows loaded`, `Errors`, `Warnings`, and `Dataset ID` (shown only in Analyst mode), plus warning details when present. 
- Added `_has_analyst_insight_content` and a clean empty-state message `"Analyst insights are not available for this dataset yet."` so the Analyst Insights tab is never blank. 
- Kept all core signal, allocation, and cost logic unchanged and avoided duplicate renders.

### Testing
- Added `tests/test_app_information_architecture.py` covering: capital control only appearing in Portfolio, Review no longer including Data Status/Main Dashboard, Data tab containing Data Status and raw preview, and Analyst Insights empty-state behavior. 
- Ran `pytest -q tests/test_app_information_architecture.py` which passed with `3 passed`. 
- Ran `pytest -q tests/test_portfolio_ui.py tests/test_analyst_insights.py` which passed with `12 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daef7995608322ba61e92360b56c90)