### PR TITLE
Fix Sprint 12 Data Status issue parsing and metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,28 +26,38 @@ def _render_data_status_summary(
     *,
     source: str | None,
     row_count: int,
-    issues: list[str],
+    issues: dict[str, list[str]] | None,
     dataset_id: str | None,
     analyst_mode: bool,
 ) -> None:
+    issues = issues or {}
+    errors = issues.get("errors", [])
+    warnings = issues.get("warnings", [])
+
     st_module.markdown("#### Data Status")
     status_col, quality_col = st_module.columns(2)
     with status_col:
         st_module.markdown(f"**Source:** {source or 'Unknown'}")
         st_module.markdown(f"**Rows loaded:** {row_count}")
-        st_module.markdown(f"**Errors:** {0 if row_count > 0 else 1}")
+        st_module.markdown(f"**Errors:** {len(errors)}")
     with quality_col:
-        warning_count = len(issues)
-        st_module.markdown(f"**Warnings:** {warning_count}")
+        st_module.markdown(f"**Warnings:** {len(warnings)}")
         if analyst_mode:
             st_module.markdown(f"**Dataset ID:** {dataset_id or 'N/A'}")
 
-    if issues:
+    if warnings:
         st_module.markdown("**Warning details**")
-        for issue in issues:
-            st_module.markdown(f"- {issue}")
-    elif row_count > 0:
+        for warning in warnings:
+            st_module.markdown(f"- {warning}")
+    else:
         st_module.caption("No ingestion warnings were reported for this dataset.")
+
+    if errors:
+        st_module.markdown("**Error details**")
+        for error in errors:
+            st_module.markdown(f"- {error}")
+    else:
+        st_module.caption("No ingestion errors were reported for this dataset.")
 
 
 def main() -> None:

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -107,7 +107,11 @@ def test_sprint12_tab_layout_and_capital_location(monkeypatch):
     ranked_df = pd.DataFrame({"instrument": ["AAA"], "selection_rank": [1], "tier": ["A"]})
 
     monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
-    monkeypatch.setattr(app_main, "ingest_dataset", lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo-v1"}, []))
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo-v1"}, {"errors": [], "warnings": []}),
+    )
     monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": ranked_df})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [{"instrument": "AAA"}])
@@ -136,7 +140,15 @@ def test_review_excludes_data_status_and_data_tab_contains_raw_preview(monkeypat
     )
 
     monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
-    monkeypatch.setattr(app_main, "ingest_dataset", lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "dataset-42"}, ["Missing volume for BBB"]))
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (
+            canonical_df,
+            {"source": "demo", "dataset_id": "dataset-42"},
+            {"errors": [], "warnings": ["Missing volume for BBB"]},
+        ),
+    )
     monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
@@ -168,7 +180,11 @@ def test_analyst_insights_empty_state_when_no_content(monkeypatch):
     )
 
     monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
-    monkeypatch.setattr(app_main, "ingest_dataset", lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo"}, []))
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo"}, {"errors": [], "warnings": []}),
+    )
     monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
@@ -179,3 +195,79 @@ def test_analyst_insights_empty_state_when_no_content(monkeypatch):
 
     insight_messages = [text for tab, text in dummy_st.info_messages if tab == "Analyst Insights"]
     assert "Analyst insights are not available for this dataset yet." in insight_messages
+
+
+def test_data_status_uses_warning_bucket_for_counts_and_details():
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit()
+
+    app_main._render_data_status_summary(
+        dummy_st,
+        source="demo",
+        row_count=12,
+        issues={"errors": [], "warnings": ["Missing volume for BBB"]},
+        dataset_id="dataset-42",
+        analyst_mode=False,
+    )
+
+    markdowns = [text for _, text in dummy_st.markdowns]
+    captions = [text for _, text in dummy_st.captions]
+
+    assert "**Errors:** 0" in markdowns
+    assert "**Warnings:** 1" in markdowns
+    assert "**Warning details**" in markdowns
+    assert "- Missing volume for BBB" in markdowns
+    assert "**Error details**" not in markdowns
+    assert "No ingestion errors were reported for this dataset." in captions
+
+
+def test_data_status_uses_error_bucket_for_counts_and_details():
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit()
+
+    app_main._render_data_status_summary(
+        dummy_st,
+        source="upload",
+        row_count=8,
+        issues={"errors": ["Missing required column: close"], "warnings": []},
+        dataset_id="dataset-100",
+        analyst_mode=False,
+    )
+
+    markdowns = [text for _, text in dummy_st.markdowns]
+    captions = [text for _, text in dummy_st.captions]
+
+    assert "**Errors:** 1" in markdowns
+    assert "**Warnings:** 0" in markdowns
+    assert "**Error details**" in markdowns
+    assert "- Missing required column: close" in markdowns
+    assert "**Warning details**" not in markdowns
+    assert "No ingestion warnings were reported for this dataset." in captions
+
+
+def test_data_status_uses_both_buckets_without_top_level_keys():
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit()
+
+    app_main._render_data_status_summary(
+        dummy_st,
+        source="upload",
+        row_count=5,
+        issues={
+            "errors": ["Price parse failed on row 3"],
+            "warnings": ["Ticker normalized: BRG -> BRG.JM"],
+        },
+        dataset_id="dataset-200",
+        analyst_mode=True,
+    )
+
+    markdowns = [text for _, text in dummy_st.markdowns]
+
+    assert "**Errors:** 1" in markdowns
+    assert "**Warnings:** 1" in markdowns
+    assert "**Warning details**" in markdowns
+    assert "- Ticker normalized: BRG -> BRG.JM" in markdowns
+    assert "**Error details**" in markdowns
+    assert "- Price parse failed on row 3" in markdowns
+    assert "- errors" not in markdowns
+    assert "- warnings" not in markdowns


### PR DESCRIPTION
### Motivation
- The Data Status summary treated the ingestion `issues` return value as a flat iterable and derived Errors from `row_count`, which produced incorrect counts and rendered raw keys instead of message text.
- The intent is to ensure counts and detail rendering reflect actual validation buckets (`errors` / `warnings`) while preserving the existing Data tab layout and UX.

### Description
- Files updated: `app.py` and `tests/test_app_information_architecture.py`.
- Parse `issues` as a dict with explicit buckets by adding `issues = issues or {}`, `errors = issues.get("errors", [])`, and `warnings = issues.get("warnings", [])`, and stop iterating the top-level object.
- Data Status counts changed so `Errors` uses `len(errors)` and `Warnings` uses `len(warnings)`, while `Rows loaded` remains independent and unchanged.
- Render separate detail sections `Warning details` and `Error details`, each showing bullet lines from the corresponding bucket, and show clean empty-state captions when a bucket is empty.
- Tests updated and added: existing ingest mocks converted to dict-shaped issues and new tests added for warning-only, error-only, and mixed issues rendering and counts.

### Testing
- Updated/added tests in `tests/test_app_information_architecture.py` validate warning-only, error-only, and both-buckets scenarios and the use of bucket contents for counts and rendered lines.
- Command run: `pytest -q tests/test_app_information_architecture.py` and result: `6 passed`.
- The changes were committed locally with message `Fix Data Status issues bucket parsing and counts` and the modified files were `M app.py` and `M tests/test_app_information_architecture.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf3f526b88322b875b2854da24299)