### PR TITLE
Sprint 12 Step 4: mode-based tab access and final UX polish

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,11 +14,44 @@ from app.planner.allocation import generate_portfolio_allocation
 from app.planner.portfolio_ui import render_portfolio_plan
 from app.shell import build_analyst_dataset, coerce_trade_rows_from_ranked
 
+_BEGINNER_TABS = ["Portfolio", "Review", "Ticker Analysis"]
+_ANALYST_TABS = [*_BEGINNER_TABS, "Analyst Insights", "Data"]
+
 
 def _has_analyst_insight_content(trades_df: pd.DataFrame, *, analyst_mode: bool) -> bool:
     if not analyst_mode or trades_df.empty:
         return False
     return any(column in trades_df.columns for column in ("net_return_pct", "net_return", "return_pct", "return"))
+
+
+def _resolve_tabs_for_mode(mode: str) -> list[str]:
+    return _ANALYST_TABS if str(mode).lower() == "analyst" else _BEGINNER_TABS
+
+
+def _render_visual_polish(st_module) -> None:
+    st_module.markdown(
+        """
+        <style>
+        :root { --jse-accent: #7ea6ff; --jse-panel: #141b2a; --jse-border: #263248; --jse-muted: #aeb8cd; }
+        .jse-card {
+            background: linear-gradient(180deg, rgba(20, 27, 42, 0.92), rgba(17, 23, 36, 0.92));
+            border: 1px solid var(--jse-border);
+            border-radius: 14px;
+            padding: 1rem 1.1rem;
+            margin: 0.35rem 0 0.8rem 0;
+        }
+        .jse-eyebrow { color: var(--jse-accent); font-size: 0.82rem; letter-spacing: 0.03em; text-transform: uppercase; margin-bottom: 0.35rem; }
+        .jse-muted { color: var(--jse-muted); }
+        .jse-metric-grid { display: grid; grid-template-columns: repeat(4, minmax(90px, 1fr)); gap: 0.6rem; margin-top: 0.5rem; }
+        .jse-metric { border: 1px solid var(--jse-border); border-radius: 10px; padding: 0.55rem 0.65rem; background: rgba(24, 32, 49, 0.75); }
+        .jse-metric-label { color: var(--jse-muted); font-size: 0.74rem; }
+        .jse-metric-value { color: #eaf0ff; font-size: 1rem; font-weight: 600; }
+        .stTabs [data-baseweb="tab-list"] button [data-testid="stMarkdownContainer"] p { font-weight: 600; }
+        .stTabs [data-baseweb="tab-list"] button[aria-selected="true"] { border-bottom-color: var(--jse-accent) !important; }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
 
 
 def _render_data_status_summary(
@@ -69,6 +102,7 @@ def main() -> None:
         page_icon="📈",
         layout="wide",
     )
+    _render_visual_polish(st)
 
     st.title("JSE Market Lab")
     mode = st.radio("Mode", options=["Beginner", "Analyst"], horizontal=True, index=0)
@@ -103,11 +137,10 @@ def main() -> None:
     _render_first_run_header(st, mode=mode_token)
     render_embedded_insights(insights_payload, st_module=st)
 
-    portfolio_tab, review_tab, ticker_tab, insights_tab, data_tab = st.tabs(
-        ["Portfolio", "Review", "Ticker Analysis", "Analyst Insights", "Data"]
-    )
+    tabs = st.tabs(_resolve_tabs_for_mode(mode_token))
+    tab_map = {name: tab for name, tab in zip(_resolve_tabs_for_mode(mode_token), tabs)}
 
-    with portfolio_tab:
+    with tab_map["Portfolio"]:
         st.markdown("### Portfolio Plan")
         selected_capital = st.number_input(
             "Total capital",
@@ -129,7 +162,7 @@ def main() -> None:
                 show_header=False,
             )
 
-    with review_tab:
+    with tab_map["Review"]:
         st.markdown("### Review")
         if ranked_df.empty:
             st.info("Review unavailable: ranked outputs were not generated.")
@@ -144,7 +177,7 @@ def main() -> None:
                 show_header=False,
             )
 
-    with ticker_tab:
+    with tab_map["Ticker Analysis"]:
         st.markdown("### Ticker Analysis")
         if analyst_df.empty or "instrument" not in analyst_df.columns:
             st.info("Ticker Analysis is unavailable because no ticker rows are loaded.")
@@ -193,6 +226,18 @@ def main() -> None:
                             "Average Return": float(returns.mean()),
                         }
 
+                st.markdown(
+                    (
+                        '<div class="jse-metric-grid">'
+                        f'<div class="jse-metric"><div class="jse-metric-label">Signal Count</div><div class="jse-metric-value">{key_stats["Signal Count"]}</div></div>'
+                        f'<div class="jse-metric"><div class="jse-metric-label">Win Rate</div><div class="jse-metric-value">{key_stats["Win Rate"]:.1%}</div></div>'
+                        f'<div class="jse-metric"><div class="jse-metric-label">Median Return</div><div class="jse-metric-value">{key_stats["Median Return"]:.2%}</div></div>'
+                        f'<div class="jse-metric"><div class="jse-metric-label">Average Return</div><div class="jse-metric-value">{key_stats["Average Return"]:.2%}</div></div>'
+                        "</div>"
+                    ),
+                    unsafe_allow_html=True,
+                )
+
                 if mode_token == "analyst":
                     st.markdown("#### Key Stats")
                     st.dataframe(pd.DataFrame([key_stats]), use_container_width=True)
@@ -230,34 +275,42 @@ def main() -> None:
                 else:
                     st.dataframe(signal_df, use_container_width=True)
 
-    with insights_tab:
-        st.markdown("### Analyst Insights")
-        if _has_analyst_insight_content(analyst_df, analyst_mode=mode_token == "analyst"):
-            render_analyst_insights(analyst_df, st_module=st, analyst_mode=True)
-        else:
-            st.info("Analyst insights are not available for this dataset yet.")
+    if "Analyst Insights" in tab_map:
+        with tab_map["Analyst Insights"]:
+            st.markdown("### Analyst Insights")
+            if _has_analyst_insight_content(analyst_df, analyst_mode=mode_token == "analyst"):
+                render_analyst_insights(analyst_df, st_module=st, analyst_mode=True)
+            else:
+                st.info("Analyst insights are not available for this dataset yet.")
 
-    with data_tab:
-        st.markdown("### Data")
-        _render_data_status_summary(
-            st,
-            source=meta.get("source"),
-            row_count=int(len(canonical_df)),
-            issues=issues,
-            dataset_id=meta.get("dataset_id"),
-            analyst_mode=mode_token == "analyst",
-        )
-        st.markdown("#### Main Dashboard")
-        st.dataframe(canonical_df.head(50), use_container_width=True)
+    if "Data" in tab_map:
+        with tab_map["Data"]:
+            st.markdown("### Data")
+            _render_data_status_summary(
+                st,
+                source=meta.get("source"),
+                row_count=int(len(canonical_df)),
+                issues=issues,
+                dataset_id=meta.get("dataset_id"),
+                analyst_mode=mode_token == "analyst",
+            )
+            st.markdown("#### Main Dashboard")
+            st.dataframe(canonical_df.head(50), use_container_width=True)
 
 
 def _render_first_run_header(st_module, *, mode: str) -> None:
-    st_module.markdown("### JSE Market Lab")
+    mode_label = "Analyst" if str(mode).lower() == "analyst" else "Beginner"
     st_module.markdown(
-        "This dashboard helps you review stock opportunities on the Jamaican market using structured rules and risk checks."
-    )
-    st_module.markdown(
-        "It highlights stronger setups, explains the risks, and shows what to watch before making decisions."
+        (
+            '<div class="jse-card">'
+            '<div class="jse-eyebrow">First-Run Orientation</div>'
+            "<h3 style='margin:0 0 0.45rem 0;'>JSE Market Lab</h3>"
+            "<p style='margin:0 0 0.35rem 0;'>This dashboard helps you review stock opportunities on the Jamaican market using structured rules and risk checks.</p>"
+            "<p class='jse-muted' style='margin:0;'>It highlights stronger setups, explains key risks, and keeps your review flow focused for "
+            f"{mode_label} mode.</p>"
+            "</div>"
+        ),
+        unsafe_allow_html=True,
     )
     st_module.markdown("**How to read this**")
     st_module.markdown("- The system scans the market and ranks possible trades.")

--- a/app/insights/embedded.py
+++ b/app/insights/embedded.py
@@ -61,12 +61,20 @@ def generate_embedded_insights(
 
 
 def render_embedded_insights(insights: Mapping[str, Any], *, st_module=None) -> None:
-    """Render embedded insights as simple bullet lists."""
+    """Render embedded insights as card-style sections with concise bullets."""
     if st_module is None:
         import streamlit as st_module
 
-    st_module.markdown("#### Final Insight")
-    st_module.markdown("**What’s happening**")
+    st_module.markdown(
+        (
+            '<div class="jse-card"><div class="jse-eyebrow">Final Insight</div>'
+            "<h4 style='margin:0;'>Decision Context Snapshot</h4>"
+            "<p class='jse-muted' style='margin:0.3rem 0 0;'>A quick read on what is working, what needs attention, and where discipline matters most.</p></div>"
+        ),
+        unsafe_allow_html=True,
+    )
+
+    st_module.markdown("**What’s happening now**")
     for line in insights.get("what_is_happening", []):
         st_module.markdown(f"- {line}")
 
@@ -78,7 +86,7 @@ def render_embedded_insights(insights: Mapping[str, Any], *, st_module=None) -> 
     for line in insights.get("common_mistakes", []):
         st_module.markdown(f"- {line}")
 
-    st_module.markdown("**Why this matters**")
+    st_module.markdown("**Why this matters now**")
     st_module.markdown(str(insights.get("why_this_matters", "")))
 
 

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -117,7 +117,10 @@ def render_portfolio_plan(
     funded_trades, unfunded_trades = split_trades_by_funding(allocations)
 
     def _render_plan_section() -> None:
-        st_module.markdown("#### Portfolio Summary")
+        st_module.markdown(
+            '<div class="jse-card"><div class="jse-eyebrow">Portfolio Summary</div><p style="margin:0;" class="jse-muted">Funding view of current eligible setups and reserve coverage.</p></div>',
+            unsafe_allow_html=True,
+        )
         summary_df = pd.DataFrame(
             [
                 {
@@ -182,12 +185,9 @@ def render_portfolio_plan(
         )
 
     def _render_review_section() -> None:
-        st_module.markdown("#### Decision Review")
         st_module.markdown(
-            "This section shows how closely the selected trades followed the system rules."
-        )
-        st_module.markdown(
-            "It helps you spot where decisions stayed disciplined and where risk increased."
+            '<div class="jse-card"><div class="jse-eyebrow">Review Summary</div><p style="margin:0;">This section shows how closely selected trades followed system rules and where risk discipline changed.</p></div>',
+            unsafe_allow_html=True,
         )
         trades_df = pd.DataFrame(list(allocations))
         safe_signals_df = signals_df if signals_df is not None else pd.DataFrame()

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -31,9 +31,10 @@ class DummyTab:
 
 
 class DummyStreamlit:
-    def __init__(self):
+    def __init__(self, *, mode_choice="Analyst"):
         self.session_state = {}
         self.current_tab = None
+        self.mode_choice = mode_choice
         self.tabs_requested = []
         self.number_inputs = []
         self.markdowns = []
@@ -48,9 +49,11 @@ class DummyStreamlit:
         return None
 
     def radio(self, _label, options, **_kwargs):
-        return options[1]
+        if self.mode_choice in options:
+            return self.mode_choice
+        return options[0]
 
-    def markdown(self, text):
+    def markdown(self, text, **_kwargs):
         self.markdowns.append((self.current_tab, text))
 
     def caption(self, text):
@@ -125,6 +128,54 @@ def test_sprint12_tab_layout_and_capital_location(monkeypatch):
 
     assert dummy_st.tabs_requested[0] == ["Portfolio", "Review", "Ticker Analysis", "Analyst Insights", "Data"]
     assert dummy_st.number_inputs == [("Portfolio", "Total capital", "total_capital")]
+
+
+def test_beginner_mode_hides_analyst_and_data_tabs(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit(mode_choice="Beginner")
+
+    canonical_df = pd.DataFrame({"instrument": ["AAA"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo-v1"}, {"errors": [], "warnings": []}),
+    )
+    monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
+    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
+
+    app_main.main()
+
+    assert dummy_st.tabs_requested[0] == ["Portfolio", "Review", "Ticker Analysis"]
+    assert not any(tab == "Data" for tab, _ in dummy_st.dataframes)
+    assert not any(tab == "Analyst Insights" for tab, _ in dummy_st.info_messages)
+
+
+def test_analyst_mode_keeps_all_tabs_visible(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit(mode_choice="Analyst")
+
+    canonical_df = pd.DataFrame({"instrument": ["AAA"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo-v1"}, {"errors": [], "warnings": []}),
+    )
+    monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
+    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
+
+    app_main.main()
+
+    assert dummy_st.tabs_requested[0] == ["Portfolio", "Review", "Ticker Analysis", "Analyst Insights", "Data"]
 
 
 def test_review_excludes_data_status_and_data_tab_contains_raw_preview(monkeypatch):

--- a/tests/test_embedded_insights.py
+++ b/tests/test_embedded_insights.py
@@ -5,6 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
 from app.insights.embedded import generate_embedded_insights
+from app.insights.embedded import render_embedded_insights
 
 
 def test_embedded_insights_keep_short_sections():
@@ -34,3 +35,26 @@ def test_embedded_insights_keep_short_sections():
     assert len(payload["what_to_watch"]) <= 3
     assert 1 <= len(payload["common_mistakes"]) <= 2
     assert isinstance(payload["why_this_matters"], str)
+
+
+def test_render_embedded_insights_renders_card_and_sections():
+    class DummyStreamlit:
+        def __init__(self):
+            self.markdowns = []
+
+        def markdown(self, text, **_kwargs):
+            self.markdowns.append(text)
+
+    dummy_st = DummyStreamlit()
+    payload = {
+        "what_is_happening": ["Signal quality improved."],
+        "what_to_watch": ["Win rate dispersion widened."],
+        "common_mistakes": ["Ignoring reserve limits."],
+        "why_this_matters": "It frames risk before allocation.",
+    }
+
+    render_embedded_insights(payload, st_module=dummy_st)
+
+    assert any("Final Insight" in block for block in dummy_st.markdowns)
+    assert any("What’s happening now" in block for block in dummy_st.markdowns)
+    assert any("Why this matters now" in block for block in dummy_st.markdowns)

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -29,7 +29,7 @@ class DummyStreamlit:
     def caption(self, text):
         self.captions.append(text)
 
-    def markdown(self, _text):
+    def markdown(self, _text, **_kwargs):
         self.markdowns.append(_text)
         return None
 
@@ -83,7 +83,7 @@ def test_render_portfolio_plan_uses_why_column_and_no_primary_rule_column():
     assert unfunded_df.iloc[0]["Decision Status"] == "Not funded (limit reached)"
     assert "funds the strongest eligible setups first" in st.captions[0]
     assert st.tabs_requested == [["Plan", "Review"]]
-    assert any("followed the system rules" in line for line in st.markdowns)
+    assert any("followed system rules" in line for line in st.markdowns)
 
 
 def test_group_mistakes_for_display_combines_repeated_types():


### PR DESCRIPTION
### Motivation
- Restrict deeper technical surfaces to Analyst mode while keeping Beginner view focused and cleaner.
- Improve the app's visual presentation so it feels more polished and product-ready without touching core product logic.
- Preserve the dark theme direction and avoid flashy or brittle styling while improving readability and hierarchy.

### Description
- Introduced mode-driven tab lists and dynamic tab resolution in `app.py` (`_BEGINNER_TABS`, `_ANALYST_TABS`, `_resolve_tabs_for_mode`) and render tabs conditionally via a `tab_map` so hidden tabs are not rendered in Beginner mode.
- Added a lightweight visual polish layer in `app.py` with a single restrained accent, card styles, softened borders, spacing tweaks, and a small metric-card layout for ticker key stats (`_render_visual_polish`, HTML/CSS injected via `st.markdown`).
- Restyled first-run intro and final insight blocks into card-like containers and improved headings: `app.py` first-run header and `app/insights/embedded.py` final insight rendering were updated for clearer hierarchy and tone.
- Added lightweight card wrappers for Portfolio Summary and Review Summary in `app/planner/portfolio_ui.py` and kept all portfolio/review logic intact (no changes to allocation, ranking, review, or drilldown algorithms).
- Updated/added tests and test stubs to support the new behaviors and HTML-capable markdown kwargs (`tests/test_app_information_architecture.py`, `tests/test_embedded_insights.py`, `tests/test_portfolio_ui.py`).

### Testing
- Ran: `pytest -q tests/test_app_information_architecture.py tests/test_embedded_insights.py tests/test_portfolio_ui.py` and all targeted tests passed (12 passed).
- New/updated automated tests cover Beginner vs Analyst tab visibility, Analyst-only surfaces not rendered in Beginner mode, embedded insights rendering as a card, and that the portfolio UI still exposes the expected columns and captions; these tests succeeded.
- Confirmed no core signal, allocation, review, or drilldown behavior was modified; changes are presentation and architecture-only and validated by the existing test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf73076548322b54aab47de5b13d4)