### PR TITLE
Preserve `instrument` alias in internal JSE loader (instrument = ticker)

### DIFF
--- a/app/data/loaders.py
+++ b/app/data/loaders.py
@@ -17,7 +17,12 @@ def load_internal_dataset() -> pd.DataFrame:
     """Load and normalize the bundled internal JSE dataset from disk."""
     dataset_path = INTERNAL_DATASET_PATH if INTERNAL_DATASET_PATH.exists() else LEGACY_INTERNAL_DATASET_PATH
     raw = pd.read_csv(dataset_path)
-    return normalize_jse_dataset(raw)
+    normalized = normalize_jse_dataset(raw)
+
+    # Backward compatibility: downstream app paths still expect `instrument`.
+    # Keep `ticker` from the normalized dataset while exposing a mirrored alias.
+    normalized["instrument"] = normalized["ticker"]
+    return normalized
 
 
 def load_upload(uploaded_file: Optional[IO]) -> pd.DataFrame:

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -8,7 +8,9 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
 from app.data.metadata import build_metadata
+from app.data.loaders import INTERNAL_DATASET_PATH, load_internal_dataset
 from app.data.normalize import detect_format, normalize_data
+from app.data.ingest import ingest_dataset
 from app.data.validate import validate_canonical
 
 
@@ -71,3 +73,69 @@ def test_adj_close_accepted_when_close_missing():
     normalized, fmt = normalize_data(df, source="demo", dataset_id="test")
     assert fmt == "long"
     assert normalized["close"].tolist() == [1.0, 2.0]
+
+
+def test_internal_loader_returns_ticker_and_instrument_columns(monkeypatch):
+    sample_raw = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02"],
+            "symbol": ["AAA", "AAA"],
+            "close_price": [10.0, 10.5],
+            "volume": [1000, 1200],
+        }
+    )
+    monkeypatch.setattr("app.data.loaders.pd.read_csv", lambda *_args, **_kwargs: sample_raw)
+
+    loaded = load_internal_dataset()
+
+    assert "ticker" in loaded.columns
+    assert "instrument" in loaded.columns
+    pd.testing.assert_series_equal(
+        loaded["instrument"],
+        loaded["ticker"],
+        check_names=False,
+    )
+
+
+def test_demo_ingestion_path_accepts_internal_loader_compatibility_contract(monkeypatch):
+    sample_raw = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02"],
+            "symbol": ["AAA", "AAA"],
+            "close_price": [10.0, 10.5],
+            "volume": [1000, 1200],
+        }
+    )
+    monkeypatch.setattr("app.data.loaders.pd.read_csv", lambda *_args, **_kwargs: sample_raw)
+
+    canonical, meta, issues = ingest_dataset("demo")
+
+    assert not canonical.empty
+    assert "instrument" in canonical.columns
+    assert meta["source"] == "demo"
+    assert "errors" in issues and "warnings" in issues
+
+
+def test_internal_loader_prefers_bundled_jse_dataset(monkeypatch, tmp_path):
+    calls = []
+    sample_raw = pd.DataFrame(
+        {
+            "date": ["2024-01-01"],
+            "symbol": ["AAA"],
+            "close_price": [10.0],
+            "volume": [1000],
+        }
+    )
+
+    bundled_path = tmp_path / "jse_dataset.csv"
+    legacy_path = tmp_path / "jse_sample.csv"
+    bundled_path.write_text("date,symbol,close_price,volume\n")
+    legacy_path.write_text("date,symbol,close_price,volume\n")
+
+    monkeypatch.setattr("app.data.loaders.pd.read_csv", lambda path: calls.append(path) or sample_raw)
+    monkeypatch.setattr("app.data.loaders.INTERNAL_DATASET_PATH", bundled_path)
+    monkeypatch.setattr("app.data.loaders.LEGACY_INTERNAL_DATASET_PATH", legacy_path)
+
+    _ = load_internal_dataset()
+
+    assert calls == [bundled_path]


### PR DESCRIPTION
### Motivation
- The bundled JSE loader previously returned a normalized dataframe with `ticker` only, which breaks older app code and causes `KeyError` where `instrument` is still expected.
- Keep the normalization logic focused and add a loader-level compatibility shim so the dashboard and other downstream code continue to work without changing signal/analysis logic.

### Description
- Updated `app/data/loaders.py` so `load_internal_dataset()` returns the normalized dataframe augmented with `instrument` by setting `normalized["instrument"] = normalized["ticker"]` while preserving the original `ticker` column.
- Left `app/data/processor.py::normalize_jse_dataset()` unchanged so normalization still yields `date`, `ticker`, `close`, and `volume` only.
- Added/updated tests in `tests/test_ingestion.py` to assert the loader returns both `ticker` and `instrument`, that `instrument == ticker`, that the demo ingestion path accepts the compatibility contract, and that the loader prefers the bundled `data/internal/jse_dataset.csv` when present.
- Files updated: `app/data/loaders.py`, `tests/test_ingestion.py`.

### Testing
- Ran `pytest -q tests/test_ingestion.py tests/test_app_information_architecture.py` and all tests passed (`15 passed`).
- Unit tests added include `test_internal_loader_returns_ticker_and_instrument_columns`, `test_demo_ingestion_path_accepts_internal_loader_compatibility_contract`, and `test_internal_loader_prefers_bundled_jse_dataset`, and they succeeded in the CI-local run.
- Confirmed the dashboard ingestion path calls `ingest_dataset("demo")` which uses `load_internal_dataset()` and the loader prefers the bundled `data/internal/jse_dataset.csv` when present, maintaining backward compatibility for downstream code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db118b84bc83229a7f5d96f58a2e91)