### PR TITLE
Surface dataset source and fallback warning; verify bundled JSE dataset with test

### DIFF
--- a/app.py
+++ b/app.py
@@ -108,8 +108,19 @@ def main() -> None:
     mode = st.radio("Mode", options=["Beginner", "Analyst"], horizontal=True, index=0)
     mode_token = mode.lower()
 
+    # TEMPORARY validation support: clear cached data once per browser session
+    # so bundled dataset changes are reflected immediately while validating ingestion.
+    if not st.session_state.get("_temp_dataset_cache_cleared", False):
+        st.cache_data.clear()
+        st.session_state["_temp_dataset_cache_cleared"] = True
+
     canonical_df, meta, issues = ingest_dataset("demo")
+    dataset_source_label = str(meta.get("dataset_source_label") or "unknown_dataset")
+    st.caption(f"Data source: {dataset_source_label}")
     st.caption("Using historical data from the Jamaican stock market.")
+
+    if dataset_source_label == "legacy_demo_dataset":
+        st.warning("Internal JSE dataset not found. Using fallback dataset.")
 
     if canonical_df.empty:
         st.warning("No rows were loaded from the data layer. Please verify the internal sample data file.")

--- a/app/data/ingest.py
+++ b/app/data/ingest.py
@@ -20,14 +20,16 @@ def ingest_dataset(
         raise ValueError("mode must be 'demo' or 'upload'.")
 
     if mode == "demo":
-        raw, _source_label = load_internal_dataset()
+        raw, source_label = load_internal_dataset()
         source = "demo"
     else:
         raw = load_upload(uploaded_file)
         source = "upload"
+        source_label = "uploaded_dataset"
 
     dataset_id = generate_dataset_id()
     canonical, _ = normalize_data(raw, source=source, dataset_id=dataset_id)
     issues = validate_canonical(canonical)
     meta = build_metadata(canonical, source=source, dataset_id=dataset_id)
+    meta["dataset_source_label"] = source_label
     return canonical, meta, issues

--- a/app/data/loaders.py
+++ b/app/data/loaders.py
@@ -9,8 +9,21 @@ import pandas as pd
 
 from .processor import normalize_jse_dataset
 
-INTERNAL_DATASET_PATH = Path(__file__).resolve().parents[2] / "data" / "internal" / "jse_dataset.csv"
-LEGACY_INTERNAL_DATASET_PATH = Path(__file__).resolve().parents[2] / "data" / "internal" / "jse_sample.csv"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INTERNAL_DATASET_PATH = REPO_ROOT / "data" / "internal" / "jse_dataset.csv"
+LEGACY_INTERNAL_DATASET_PATH = REPO_ROOT / "data" / "internal" / "jse_sample.csv"
+
+
+def _build_legacy_fallback_dataset() -> pd.DataFrame:
+    """Build a tiny emergency fallback dataset when no file-based fallback exists."""
+    return pd.DataFrame(
+        {
+            "date": ["2024-01-02", "2024-01-03", "2024-01-04"],
+            "symbol": ["DEMO", "DEMO", "DEMO"],
+            "close_price": [10.0, 10.2, 10.1],
+            "volume": [1000, 1200, 900],
+        }
+    )
 
 
 def load_internal_dataset() -> tuple[pd.DataFrame, str]:
@@ -18,11 +31,15 @@ def load_internal_dataset() -> tuple[pd.DataFrame, str]:
     if INTERNAL_DATASET_PATH.exists():
         dataset_path = INTERNAL_DATASET_PATH
         source_label = "internal_jse_dataset"
+        raw = pd.read_csv(dataset_path)
     else:
         dataset_path = LEGACY_INTERNAL_DATASET_PATH
         source_label = "legacy_demo_dataset"
+        if dataset_path.exists():
+            raw = pd.read_csv(dataset_path)
+        else:
+            raw = _build_legacy_fallback_dataset()
 
-    raw = pd.read_csv(dataset_path)
     normalized = normalize_jse_dataset(raw)
 
     # Backward compatibility: downstream app paths still expect `instrument`.

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -141,3 +141,13 @@ def test_internal_loader_prefers_bundled_jse_dataset(monkeypatch, tmp_path):
 
     assert calls == [bundled_path]
     assert source_label == "internal_jse_dataset"
+
+
+def test_internal_loader_uses_real_bundled_dataset_when_available():
+    assert INTERNAL_DATASET_PATH.as_posix().endswith("data/internal/jse_dataset.csv")
+    assert INTERNAL_DATASET_PATH.exists()
+
+    loaded, source_label = load_internal_dataset()
+
+    assert source_label == "internal_jse_dataset"
+    assert len(loaded) > 1000


### PR DESCRIPTION
### Motivation
- Make the active dataset source visible in the UI so it's clear whether the real bundled JSE dataset is being used.  
- Surface fallback behavior explicitly instead of being silent so users know when a demo dataset is active.  
- Add a non-destructive validation check and a short-lived cache clear to ensure Streamlit isn't showing stale data while validating the bundled dataset.  

### Description
- Add explicit path resolution and ordering in `app/data/loaders.py` so `data/internal/jse_dataset.csv` is the first choice, then `data/internal/jse_sample.csv`, then a tiny in-memory fallback; return a `source_label` of `internal_jse_dataset` or `legacy_demo_dataset`.  
- Propagate the loader `source_label` through ingestion metadata as `meta["dataset_source_label"]` in `app/data/ingest.py`, and mark uploads as `uploaded_dataset`.  
- Surface the dataset source in the UI (`st.caption(f"Data source: {dataset_source_label}")`) and display a clear Streamlit warning `Internal JSE dataset not found. Using fallback dataset.` when fallback is active in `app.py`.  
- Add a guarded one-time `st.cache_data.clear()` in `app.py` (temporary validation support) so cached dataset data is invalidated once per session while validating ingestion.  
- Add test `test_internal_loader_uses_real_bundled_dataset_when_available()` in `tests/test_ingestion.py` to assert the bundled path is used, the loader returns `internal_jse_dataset`, and the loaded dataset is substantially larger than a demo dataset (`len(loaded) > 1000`).  

### Testing
- Ran `pytest -q tests/test_ingestion.py`, which completed successfully with `8 passed` in ~0.94s.  
- The new test confirms `INTERNAL_DATASET_PATH` points to `data/internal/jse_dataset.csv`, the file exists, `load_internal_dataset()` returns `source_label == "internal_jse_dataset"`, and the real bundled dataset size is `> 1000` rows.  
- No application-level (manual) UI tests were run here; the change is limited to subtle UI captions/warnings and non-destructive loader logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db1a2fe4d88322ae66017d98706fd5)