### PR TITLE
Fix internal dataset flow: use bundled JSE dataset everywhere, restore loader API, remove cache-clear hack

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 import pandas as pd
 
 from app.analysis.ticker_drilldown import build_ticker_drilldown
@@ -44,6 +46,23 @@ def _extract_ticker_options(df: pd.DataFrame) -> list[str]:
     tickers = df[ticker_column].dropna().astype(str).str.strip()
     tickers = tickers[tickers != ""]
     return sorted(tickers.unique())
+
+
+def _run_demo_with_active_dataset(
+    *,
+    canonical_df: pd.DataFrame,
+    meta: dict,
+    issues: dict,
+) -> dict:
+    """Run demo pipeline while preferring the active app dataset when supported."""
+    run_demo_signature = inspect.signature(run_demo)
+    supports_context_injection = all(
+        param_name in run_demo_signature.parameters
+        for param_name in ("canonical_df", "meta", "issues")
+    )
+    if supports_context_injection:
+        return run_demo(canonical_df=canonical_df, meta=meta, issues=issues)
+    return run_demo()
 
 
 def _render_visual_polish(st_module) -> None:
@@ -138,10 +157,11 @@ def main() -> None:
         st.warning("No rows were loaded from the data layer. Please verify the internal sample data file.")
         return
 
-    try:
-        demo_payload = run_demo(canonical_df=canonical_df, meta=meta, issues=issues)
-    except TypeError:
-        demo_payload = run_demo()
+    demo_payload = _run_demo_with_active_dataset(
+        canonical_df=canonical_df,
+        meta=meta,
+        issues=issues,
+    )
     ranked_df = demo_payload.get("ranked", pd.DataFrame())
     analyst_df = build_analyst_dataset(canonical_df, ranked_df)
     trade_rows = coerce_trade_rows_from_ranked(ranked_df) if not ranked_df.empty else []

--- a/app.py
+++ b/app.py
@@ -28,6 +28,24 @@ def _resolve_tabs_for_mode(mode: str) -> list[str]:
     return _ANALYST_TABS if str(mode).lower() == "analyst" else _BEGINNER_TABS
 
 
+def _extract_ticker_options(df: pd.DataFrame) -> list[str]:
+    """Build sorted ticker options from the active canonical dataset."""
+    if df.empty:
+        return []
+
+    ticker_column = None
+    for candidate in ("instrument", "ticker"):
+        if candidate in df.columns:
+            ticker_column = candidate
+            break
+    if ticker_column is None:
+        return []
+
+    tickers = df[ticker_column].dropna().astype(str).str.strip()
+    tickers = tickers[tickers != ""]
+    return sorted(tickers.unique())
+
+
 def _render_visual_polish(st_module) -> None:
     st_module.markdown(
         """
@@ -108,12 +126,6 @@ def main() -> None:
     mode = st.radio("Mode", options=["Beginner", "Analyst"], horizontal=True, index=0)
     mode_token = mode.lower()
 
-    # TEMPORARY validation support: clear cached data once per browser session
-    # so bundled dataset changes are reflected immediately while validating ingestion.
-    if not st.session_state.get("_temp_dataset_cache_cleared", False):
-        st.cache_data.clear()
-        st.session_state["_temp_dataset_cache_cleared"] = True
-
     canonical_df, meta, issues = ingest_dataset("demo")
     dataset_source_label = str(meta.get("dataset_source_label") or "unknown_dataset")
     st.caption(f"Data source: {dataset_source_label}")
@@ -126,7 +138,10 @@ def main() -> None:
         st.warning("No rows were loaded from the data layer. Please verify the internal sample data file.")
         return
 
-    demo_payload = run_demo()
+    try:
+        demo_payload = run_demo(canonical_df=canonical_df, meta=meta, issues=issues)
+    except TypeError:
+        demo_payload = run_demo()
     ranked_df = demo_payload.get("ranked", pd.DataFrame())
     analyst_df = build_analyst_dataset(canonical_df, ranked_df)
     trade_rows = coerce_trade_rows_from_ranked(ranked_df) if not ranked_df.empty else []
@@ -191,30 +206,36 @@ def main() -> None:
 
     with tab_map["Ticker Analysis"]:
         st.markdown("### Ticker Analysis")
-        if analyst_df.empty or "instrument" not in analyst_df.columns:
+        ticker_options = _extract_ticker_options(canonical_df)
+        if not ticker_options:
             st.info("Ticker Analysis is unavailable because no ticker rows are loaded.")
         else:
-            ticker_options = sorted(analyst_df["instrument"].dropna().astype(str).unique())
-            if not ticker_options:
-                st.info("Ticker Analysis is unavailable because no tickers are available.")
+            selected_ticker = st.selectbox("Select ticker", ticker_options)
+            ticker_payload = build_ticker_drilldown(analyst_df, selected_ticker)
+            ticker_metrics = compute_ticker_metrics(analyst_df, selected_ticker, mode=mode_token)
+
+            st.markdown("#### Ticker Summary")
+            st.write(ticker_metrics["summary"])
+
+            st.markdown("#### Behavior Insights")
+            for line in ticker_metrics["behavior"].values():
+                st.markdown(f"- {line}")
+
+            st.markdown("#### Pattern Summary")
+            st.write(ticker_payload["pattern_summary"])
+
+            signal_df = pd.DataFrame(ticker_payload["signals"])
+            signal_count = int(len(signal_df))
+            if signal_df.empty or "return_pct" not in signal_df.columns:
+                key_stats = {
+                    "Signal Count": signal_count,
+                    "Win Rate": 0.0,
+                    "Median Return": 0.0,
+                    "Average Return": 0.0,
+                }
             else:
-                selected_ticker = st.selectbox("Select ticker", ticker_options)
-                ticker_payload = build_ticker_drilldown(analyst_df, selected_ticker)
-                ticker_metrics = compute_ticker_metrics(analyst_df, selected_ticker, mode=mode_token)
-
-                st.markdown("#### Ticker Summary")
-                st.write(ticker_metrics["summary"])
-
-                st.markdown("#### Behavior Insights")
-                for line in ticker_metrics["behavior"].values():
-                    st.markdown(f"- {line}")
-
-                st.markdown("#### Pattern Summary")
-                st.write(ticker_payload["pattern_summary"])
-
-                signal_df = pd.DataFrame(ticker_payload["signals"])
-                signal_count = int(len(signal_df))
-                if signal_df.empty or "return_pct" not in signal_df.columns:
+                returns = pd.to_numeric(signal_df["return_pct"], errors="coerce").dropna()
+                if returns.empty:
                     key_stats = {
                         "Signal Count": signal_count,
                         "Win Rate": 0.0,
@@ -222,70 +243,61 @@ def main() -> None:
                         "Average Return": 0.0,
                     }
                 else:
-                    returns = pd.to_numeric(signal_df["return_pct"], errors="coerce").dropna()
-                    if returns.empty:
-                        key_stats = {
-                            "Signal Count": signal_count,
-                            "Win Rate": 0.0,
-                            "Median Return": 0.0,
-                            "Average Return": 0.0,
-                        }
-                    else:
-                        key_stats = {
-                            "Signal Count": signal_count,
-                            "Win Rate": float((returns > 0).mean()),
-                            "Median Return": float(returns.median()),
-                            "Average Return": float(returns.mean()),
-                        }
+                    key_stats = {
+                        "Signal Count": signal_count,
+                        "Win Rate": float((returns > 0).mean()),
+                        "Median Return": float(returns.median()),
+                        "Average Return": float(returns.mean()),
+                    }
 
-                st.markdown(
-                    (
-                        '<div class="jse-metric-grid">'
-                        f'<div class="jse-metric"><div class="jse-metric-label">Signal Count</div><div class="jse-metric-value">{key_stats["Signal Count"]}</div></div>'
-                        f'<div class="jse-metric"><div class="jse-metric-label">Win Rate</div><div class="jse-metric-value">{key_stats["Win Rate"]:.1%}</div></div>'
-                        f'<div class="jse-metric"><div class="jse-metric-label">Median Return</div><div class="jse-metric-value">{key_stats["Median Return"]:.2%}</div></div>'
-                        f'<div class="jse-metric"><div class="jse-metric-label">Average Return</div><div class="jse-metric-value">{key_stats["Average Return"]:.2%}</div></div>'
-                        "</div>"
-                    ),
-                    unsafe_allow_html=True,
-                )
+            st.markdown(
+                (
+                    '<div class="jse-metric-grid">'
+                    f'<div class="jse-metric"><div class="jse-metric-label">Signal Count</div><div class="jse-metric-value">{key_stats["Signal Count"]}</div></div>'
+                    f'<div class="jse-metric"><div class="jse-metric-label">Win Rate</div><div class="jse-metric-value">{key_stats["Win Rate"]:.1%}</div></div>'
+                    f'<div class="jse-metric"><div class="jse-metric-label">Median Return</div><div class="jse-metric-value">{key_stats["Median Return"]:.2%}</div></div>'
+                    f'<div class="jse-metric"><div class="jse-metric-label">Average Return</div><div class="jse-metric-value">{key_stats["Average Return"]:.2%}</div></div>'
+                    "</div>"
+                ),
+                unsafe_allow_html=True,
+            )
 
-                if mode_token == "analyst":
-                    st.markdown("#### Key Stats")
-                    st.dataframe(pd.DataFrame([key_stats]), use_container_width=True)
+            if mode_token == "analyst":
+                st.markdown("#### Key Stats")
+                st.dataframe(pd.DataFrame([key_stats]), use_container_width=True)
 
-                st.markdown("#### Holding Window Comparison")
-                holding_window_df = pd.DataFrame.from_dict(
-                    ticker_payload["holding_window_stats"], orient="index"
-                )
-                if holding_window_df.empty:
-                    st.info("No holding window data is ready for this ticker yet.")
-                else:
-                    st.dataframe(holding_window_df.reset_index().rename(columns={"index": "holding_window"}), use_container_width=True)
+            st.markdown("#### Holding Window Comparison")
+            holding_window_df = pd.DataFrame.from_dict(
+                ticker_payload["holding_window_stats"], orient="index"
+            )
+            if holding_window_df.empty:
+                st.info("No holding window data is ready for this ticker yet.")
+            else:
+                st.dataframe(holding_window_df.reset_index().rename(columns={"index": "holding_window"}), use_container_width=True)
 
-                st.markdown("#### Tier Performance")
-                tier_df = pd.DataFrame.from_dict(ticker_payload["tier_performance"], orient="index")
-                if tier_df.empty:
-                    st.info("No tier breakdown is ready for this ticker yet.")
-                else:
-                    st.dataframe(tier_df.reset_index().rename(columns={"index": "quality_tier"}), use_container_width=True)
+            st.markdown("#### Tier Performance")
+            tier_df = pd.DataFrame.from_dict(ticker_payload["tier_performance"], orient="index")
+            if tier_df.empty:
+                st.info("No tier breakdown is ready for this ticker yet.")
+            else:
+                st.dataframe(tier_df.reset_index().rename(columns={"index": "quality_tier"}), use_container_width=True)
 
-                st.markdown("#### Volatility Performance")
-                volatility_df = pd.DataFrame.from_dict(ticker_payload["volatility_performance"], orient="index")
-                if volatility_df.empty:
-                    st.info("No volatility breakdown is ready for this ticker yet.")
-                else:
-                    st.dataframe(volatility_df.reset_index().rename(columns={"index": "volatility_bucket"}), use_container_width=True)
+            st.markdown("#### Volatility Performance")
+            volatility_df = pd.DataFrame.from_dict(ticker_payload["volatility_performance"], orient="index")
+            if volatility_df.empty:
+                st.info("No volatility breakdown is ready for this ticker yet.")
+            else:
+                st.dataframe(volatility_df.reset_index().rename(columns={"index": "volatility_bucket"}), use_container_width=True)
 
-                st.markdown("#### Return Distribution")
-                distribution_df = pd.DataFrame([ticker_payload["return_distribution"]])
-                st.dataframe(distribution_df, use_container_width=True)
+            st.markdown("#### Return Distribution")
+            distribution_df = pd.DataFrame([ticker_payload["return_distribution"]])
+            st.dataframe(distribution_df, use_container_width=True)
 
-                st.markdown("#### Signal Breakdown")
-                if signal_df.empty:
-                    st.info("No signal history is available for this ticker yet.")
-                else:
-                    st.dataframe(signal_df, use_container_width=True)
+            st.markdown("#### Signal Breakdown")
+            if signal_df.empty:
+                st.info("No signal history is available for this ticker yet.")
+            else:
+                st.dataframe(signal_df, use_container_width=True)
 
     if "Analyst Insights" in tab_map:
         with tab_map["Analyst Insights"]:

--- a/app/data/ingest.py
+++ b/app/data/ingest.py
@@ -6,7 +6,7 @@ from typing import IO, Optional, Tuple
 
 import pandas as pd
 
-from .loaders import load_internal_dataset, load_upload
+from .loaders import load_internal_dataset_with_source, load_upload
 from .metadata import build_metadata, generate_dataset_id
 from .normalize import normalize_data
 from .validate import validate_canonical
@@ -20,7 +20,7 @@ def ingest_dataset(
         raise ValueError("mode must be 'demo' or 'upload'.")
 
     if mode == "demo":
-        raw, source_label = load_internal_dataset()
+        raw, source_label = load_internal_dataset_with_source()
         source = "demo"
     else:
         raw = load_upload(uploaded_file)

--- a/app/data/loader.py
+++ b/app/data/loader.py
@@ -5,5 +5,4 @@ from .loaders import load_internal_dataset, load_upload
 
 def load_demo():
     """Backward-compatible alias for loading the internal dataset."""
-    dataset, _source_label = load_internal_dataset()
-    return dataset
+    return load_internal_dataset()

--- a/app/data/loaders.py
+++ b/app/data/loaders.py
@@ -26,8 +26,8 @@ def _build_legacy_fallback_dataset() -> pd.DataFrame:
     )
 
 
-def load_internal_dataset() -> tuple[pd.DataFrame, str]:
-    """Load and normalize the bundled internal JSE dataset from disk."""
+def load_internal_dataset_with_source() -> tuple[pd.DataFrame, str]:
+    """Load and normalize the bundled internal JSE dataset from disk with source label."""
     if INTERNAL_DATASET_PATH.exists():
         dataset_path = INTERNAL_DATASET_PATH
         source_label = "internal_jse_dataset"
@@ -46,6 +46,18 @@ def load_internal_dataset() -> tuple[pd.DataFrame, str]:
     # Keep `ticker` from the normalized dataset while exposing a mirrored alias.
     normalized["instrument"] = normalized["ticker"]
     return normalized, source_label
+
+
+def load_internal_dataset() -> pd.DataFrame:
+    """Load and normalize the bundled internal JSE dataset from disk."""
+    dataset, _source_label = load_internal_dataset_with_source()
+    return dataset
+
+
+def get_internal_dataset_source_label() -> str:
+    """Return the current source label for the bundled internal dataset."""
+    _dataset, source_label = load_internal_dataset_with_source()
+    return source_label
 
 
 def load_upload(uploaded_file: Optional[IO]) -> pd.DataFrame:

--- a/app/demo/run_demo.py
+++ b/app/demo/run_demo.py
@@ -20,9 +20,18 @@ from app.ranking.engine import rank_instruments
 logger = logging.getLogger(__name__)
 
 
-def run_demo(language_mode: str = "plain") -> dict:
+def run_demo(
+    language_mode: str = "plain",
+    *,
+    canonical_df: pd.DataFrame | None = None,
+    meta: dict | None = None,
+    issues: dict | None = None,
+) -> dict:
     """Run ingestion, cost, ranking, and phase metrics for demo data."""
-    canonical, meta, issues = ingest_dataset("demo")
+    if canonical_df is None or meta is None or issues is None:
+        canonical, meta, issues = ingest_dataset("demo")
+    else:
+        canonical = canonical_df
 
     entries = canonical[["instrument", "date"]].rename(columns={"date": "entry_date"})
 

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -41,6 +41,7 @@ class DummyStreamlit:
         self.info_messages = []
         self.dataframes = []
         self.captions = []
+        self.selectbox_calls = []
 
     def set_page_config(self, **_kwargs):
         return None
@@ -79,6 +80,7 @@ class DummyStreamlit:
         self.dataframes.append((self.current_tab, df.copy()))
 
     def selectbox(self, _label, options):
+        self.selectbox_calls.append(list(options))
         return options[0]
 
     def columns(self, count):
@@ -322,3 +324,65 @@ def test_data_status_uses_both_buckets_without_top_level_keys():
     assert "- Price parse failed on row 3" in markdowns
     assert "- errors" not in markdowns
     assert "- warnings" not in markdowns
+
+
+def test_app_does_not_depend_on_global_cache_data_clear():
+    app_source = (ROOT / "app.py").read_text()
+    assert "cache_data.clear" not in app_source
+
+
+def test_ticker_analysis_selector_uses_canonical_dataset_universe(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit()
+
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": [f"T{i:02d}" for i in range(12)],
+            "date": pd.to_datetime(["2024-01-01"] * 12),
+            "close": [10.0 + i for i in range(12)],
+        }
+    )
+    analyst_subset = pd.DataFrame(
+        {
+            "instrument": ["T00", "T01"],
+            "entry_date": pd.to_datetime(["2024-01-01", "2024-01-01"]),
+            "return_pct": [0.01, -0.01],
+            "holding_window": [5, 5],
+            "quality_tier": ["A", "B"],
+            "volatility_bucket": ["low", "medium"],
+        }
+    )
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (
+            canonical_df,
+            {"source": "demo", "dataset_id": "demo-v1", "dataset_source_label": "internal_jse_dataset"},
+            {"errors": [], "warnings": []},
+        ),
+    )
+    monkeypatch.setattr(app_main, "run_demo", lambda *_args, **_kwargs: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: analyst_subset)
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
+    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(app_main, "compute_ticker_metrics", lambda *_args, **_kwargs: {"summary": "", "behavior": {}})
+    monkeypatch.setattr(
+        app_main,
+        "build_ticker_drilldown",
+        lambda *_args, **_kwargs: {
+            "pattern_summary": "",
+            "signals": [],
+            "holding_window_stats": {},
+            "tier_performance": {},
+            "volatility_performance": {},
+            "return_distribution": {},
+        },
+    )
+
+    app_main.main()
+
+    assert dummy_st.selectbox_calls
+    assert len(dummy_st.selectbox_calls[0]) == 12

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -331,6 +331,60 @@ def test_app_does_not_depend_on_global_cache_data_clear():
     assert "cache_data.clear" not in app_source
 
 
+def test_run_demo_uses_active_dataset_context_when_supported(monkeypatch):
+    app_main = _load_app_module()
+
+    canonical_df = pd.DataFrame({"instrument": ["AAA"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
+    meta = {"dataset_id": "demo-1", "dataset_source_label": "internal_jse_dataset"}
+    issues = {"errors": [], "warnings": []}
+    calls = {}
+
+    def run_demo_with_context(*, canonical_df, meta, issues):
+        calls["canonical_df"] = canonical_df
+        calls["meta"] = meta
+        calls["issues"] = issues
+        return {"ranked": pd.DataFrame()}
+
+    monkeypatch.setattr(app_main, "run_demo", run_demo_with_context)
+
+    result = app_main._run_demo_with_active_dataset(
+        canonical_df=canonical_df,
+        meta=meta,
+        issues=issues,
+    )
+
+    assert "ranked" in result
+    assert isinstance(result["ranked"], pd.DataFrame)
+    assert calls["canonical_df"] is canonical_df
+    assert calls["meta"] is meta
+    assert calls["issues"] is issues
+
+
+def test_run_demo_falls_back_to_legacy_signature_when_context_not_supported(monkeypatch):
+    app_main = _load_app_module()
+
+    canonical_df = pd.DataFrame({"instrument": ["AAA"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
+    meta = {"dataset_id": "demo-1"}
+    issues = {"errors": [], "warnings": []}
+    calls = {"count": 0}
+
+    def legacy_run_demo():
+        calls["count"] += 1
+        return {"ranked": pd.DataFrame()}
+
+    monkeypatch.setattr(app_main, "run_demo", legacy_run_demo)
+
+    result = app_main._run_demo_with_active_dataset(
+        canonical_df=canonical_df,
+        meta=meta,
+        issues=issues,
+    )
+
+    assert "ranked" in result
+    assert isinstance(result["ranked"], pd.DataFrame)
+    assert calls["count"] == 1
+
+
 def test_ticker_analysis_selector_uses_canonical_dataset_universe(monkeypatch):
     app_main = _load_app_module()
     dummy_st = DummyStreamlit()

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -1,4 +1,5 @@
 import sys
+import importlib.util
 from pathlib import Path
 
 import pandas as pd
@@ -69,3 +70,24 @@ def test_build_analyst_dataset_handles_empty_ranked_df(monkeypatch):
 
     assert "net_return_pct" in analyst_df.columns
     assert "quality_tier" not in analyst_df.columns
+
+
+def test_extract_ticker_options_uses_active_dataset_and_is_sorted():
+    spec = importlib.util.spec_from_file_location("app_main", ROOT / "app.py")
+    app_main = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_main)
+
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["CCC", "AAA", "BBB", "AAA", None, " "],
+            "date": pd.to_datetime(
+                ["2024-01-01", "2024-01-01", "2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"]
+            ),
+            "close": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+        }
+    )
+
+    ticker_options = app_main._extract_ticker_options(canonical_df)
+
+    assert ticker_options == ["AAA", "BBB", "CCC"]

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -8,7 +8,12 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
 from app.data.metadata import build_metadata
-from app.data.loaders import INTERNAL_DATASET_PATH, load_internal_dataset
+from app.data.loaders import (
+    INTERNAL_DATASET_PATH,
+    get_internal_dataset_source_label,
+    load_internal_dataset,
+    load_internal_dataset_with_source,
+)
 from app.data.normalize import detect_format, normalize_data
 from app.data.ingest import ingest_dataset
 from app.data.validate import validate_canonical
@@ -86,7 +91,8 @@ def test_internal_loader_returns_ticker_and_instrument_columns(monkeypatch):
     )
     monkeypatch.setattr("app.data.loaders.pd.read_csv", lambda *_args, **_kwargs: sample_raw)
 
-    loaded, source_label = load_internal_dataset()
+    loaded = load_internal_dataset()
+    source_label = get_internal_dataset_source_label()
 
     assert "ticker" in loaded.columns
     assert "instrument" in loaded.columns
@@ -96,6 +102,7 @@ def test_internal_loader_returns_ticker_and_instrument_columns(monkeypatch):
         check_names=False,
     )
     assert source_label in {"internal_jse_dataset", "legacy_demo_dataset"}
+    assert isinstance(loaded, pd.DataFrame)
 
 
 def test_demo_ingestion_path_accepts_internal_loader_compatibility_contract(monkeypatch):
@@ -137,7 +144,7 @@ def test_internal_loader_prefers_bundled_jse_dataset(monkeypatch, tmp_path):
     monkeypatch.setattr("app.data.loaders.INTERNAL_DATASET_PATH", bundled_path)
     monkeypatch.setattr("app.data.loaders.LEGACY_INTERNAL_DATASET_PATH", legacy_path)
 
-    _, source_label = load_internal_dataset()
+    _, source_label = load_internal_dataset_with_source()
 
     assert calls == [bundled_path]
     assert source_label == "internal_jse_dataset"
@@ -147,7 +154,15 @@ def test_internal_loader_uses_real_bundled_dataset_when_available():
     assert INTERNAL_DATASET_PATH.as_posix().endswith("data/internal/jse_dataset.csv")
     assert INTERNAL_DATASET_PATH.exists()
 
-    loaded, source_label = load_internal_dataset()
+    loaded = load_internal_dataset()
+    source_label = get_internal_dataset_source_label()
 
     assert source_label == "internal_jse_dataset"
     assert len(loaded) > 1000
+
+
+def test_internal_loader_real_bundled_dataset_has_more_than_legacy_ticker_universe():
+    loaded = load_internal_dataset()
+    ticker_count = int(loaded["instrument"].dropna().astype(str).nunique())
+
+    assert ticker_count > 9


### PR DESCRIPTION
### Motivation
- Ensure the full bundled JSE dataset (`data/internal/jse_dataset.csv`) is the single active default across the app and that Ticker Analysis shows the full ticker universe. 
- Restore backward-compatible loader behavior so older callers keep receiving a `DataFrame` and provide explicit helpers for source metadata. 
- Remove the fragile global `st.cache_data.clear()` startup hack that caused brittle behavior in some environments.

### Description
- Split loader API in `app/data/loaders.py`: added `load_internal_dataset_with_source() -> tuple[pd.DataFrame, str]`, restored `load_internal_dataset() -> pd.DataFrame` (backward-compatible), and added `get_internal_dataset_source_label() -> str` for UI/source display. 
- Updated ingestion to use the source-aware loader (`app/data/ingest.py`) so `meta["dataset_source_label"]` is reliably populated from the loader. 
- Removed the unconditional `st.cache_data.clear()` logic from `app.py` and made the app use a single canonical ingestion flow (`canonical_df, meta, issues = ingest_dataset("demo")`) as the source-of-truth. 
- Made `run_demo()` accept optional `canonical_df`, `meta`, and `issues` to reuse the already-ingested dataset and preserve compatibility with older callers. 
- Ensured Ticker Analysis builds its selector from the canonical dataset via a new helper `_extract_ticker_options(canonical_df)` in `app.py` so the ticker universe reflects the full bundled dataset while analysis computations continue to use `analyst_df`. 
- Added/updated tests to assert loader contract, source-label helper, canonical ticker universe size, selector wiring, and removal of `cache_data.clear()` dependency.

### Testing
- Ran `pytest -q tests/test_ingestion.py tests/test_app_shell.py tests/test_app_information_architecture.py` and received `22 passed` (all tests in these suites passed). 
- Ran `pytest -q tests/test_ticker_drilldown.py tests/test_ticker_intelligence.py tests/test_demo_pipeline.py`; the analysis and drilldown tests passed but demo pipeline tests failed in this environment due to a missing fixture file (`data/demo/earnings_events.csv`) unrelated to these changes (FileNotFoundError during demo artifact reading). 
- Unit tests added/updated: `tests/test_ingestion.py` (loader contract, source label, ticker-universe check), `tests/test_app_shell.py` (ticker extraction ordering/cleaning), `tests/test_app_information_architecture.py` (no global cache clear dependency, ticker selector uses canonical universe). 
- Summary of exact commands used during validation: `pytest -q tests/test_ingestion.py tests/test_app_shell.py tests/test_app_information_architecture.py` → `22 passed`; `pytest -q tests/test_ticker_drilldown.py tests/test_ticker_intelligence.py tests/test_demo_pipeline.py` → demo pipeline failures due to missing `data/demo/earnings_events.csv` in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db1cf5ae648322a3484d10eea3fd0e)