### PR TITLE
Add runtime dataset diagnostics and ticker-universe regression tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,6 +48,30 @@ def _extract_ticker_options(df: pd.DataFrame) -> list[str]:
     return sorted(tickers.unique())
 
 
+def _extract_unique_ticker_count(df: pd.DataFrame) -> int:
+    """Count unique tickers/instruments from a dataframe."""
+    if df.empty:
+        return 0
+    for candidate in ("instrument", "ticker"):
+        if candidate in df.columns:
+            tickers = df[candidate].dropna().astype(str).str.strip()
+            tickers = tickers[tickers != ""]
+            return int(tickers.nunique())
+    return 0
+
+
+def _extract_ticker_preview(df: pd.DataFrame, *, limit: int = 20) -> list[str]:
+    """Return a small preview of distinct tickers/instruments."""
+    if df.empty:
+        return []
+    for candidate in ("instrument", "ticker"):
+        if candidate in df.columns:
+            tickers = df[candidate].dropna().astype(str).str.strip()
+            tickers = tickers[tickers != ""]
+            return tickers.drop_duplicates().head(limit).tolist()
+    return []
+
+
 def _run_demo_with_active_dataset(
     *,
     canonical_df: pd.DataFrame,
@@ -337,6 +361,21 @@ def main() -> None:
                 issues=issues,
                 dataset_id=meta.get("dataset_id"),
                 analyst_mode=mode_token == "analyst",
+            )
+            st.caption("Dataset diagnostics (temporary)")
+            diagnostics_df = pd.DataFrame(
+                [
+                    {"stage": "canonical", "rows": int(len(canonical_df)), "unique_tickers": _extract_unique_ticker_count(canonical_df)},
+                    {"stage": "ranked", "rows": int(len(ranked_df)), "unique_tickers": _extract_unique_ticker_count(ranked_df)},
+                ]
+            )
+            st.dataframe(diagnostics_df, use_container_width=True, hide_index=True)
+            st.code(
+                (
+                    f"canonical first 20 tickers: {_extract_ticker_preview(canonical_df)}\n"
+                    f"ranked first 20 tickers: {_extract_ticker_preview(ranked_df)}"
+                ),
+                language="text",
             )
             st.markdown("#### Main Dashboard")
             st.dataframe(canonical_df.head(50), use_container_width=True)

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -89,6 +89,9 @@ class DummyStreamlit:
     def subheader(self, _text):
         return None
 
+    def code(self, _text, **_kwargs):
+        return None
+
 
 def _load_app_module():
     spec = importlib.util.spec_from_file_location("app_main", ROOT / "app.py")
@@ -248,6 +251,47 @@ def test_analyst_insights_empty_state_when_no_content(monkeypatch):
 
     insight_messages = [text for tab, text in dummy_st.info_messages if tab == "Analyst Insights"]
     assert "Analyst insights are not available for this dataset yet." in insight_messages
+
+
+def test_ticker_analysis_options_come_from_canonical_dataset_not_ranked_subset(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit(mode_choice="Analyst")
+
+    large_ticker_universe = [f"T{i:03d}" for i in range(1, 21)]
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": large_ticker_universe,
+            "date": pd.to_datetime(["2024-01-01"] * len(large_ticker_universe)),
+            "close": [10.0] * len(large_ticker_universe),
+        }
+    )
+    ranked_subset = pd.DataFrame({"instrument": ["T001", "T002"], "selection_rank": [1, 2], "tier": ["A", "B"]})
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (
+            canonical_df,
+            {"source": "demo", "dataset_id": "dataset-42"},
+            {"errors": [], "warnings": []},
+        ),
+    )
+    monkeypatch.setattr(
+        app_main,
+        "run_demo",
+        lambda **_kwargs: {"ranked": ranked_subset},
+    )
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
+    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
+
+    app_main.main()
+
+    ticker_options = dummy_st.selectbox_calls[0]
+    assert len(ticker_options) > 9
+    assert set(large_ticker_universe).issubset(set(ticker_options))
 
 
 def test_data_status_uses_warning_bucket_for_counts_and_details():

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -103,6 +103,7 @@ def test_internal_loader_returns_ticker_and_instrument_columns(monkeypatch):
     )
     assert source_label in {"internal_jse_dataset", "legacy_demo_dataset"}
     assert isinstance(loaded, pd.DataFrame)
+    assert not isinstance(loaded, tuple)
 
 
 def test_demo_ingestion_path_accepts_internal_loader_compatibility_contract(monkeypatch):
@@ -166,3 +167,15 @@ def test_internal_loader_real_bundled_dataset_has_more_than_legacy_ticker_univer
     ticker_count = int(loaded["instrument"].dropna().astype(str).nunique())
 
     assert ticker_count > 9
+
+
+def test_demo_ingestion_preserves_large_ticker_universe_from_internal_dataset():
+    loaded = load_internal_dataset()
+    canonical, _meta, _issues = ingest_dataset("demo")
+
+    loaded_tickers = int(loaded["instrument"].dropna().astype(str).nunique())
+    canonical_tickers = int(canonical["instrument"].dropna().astype(str).nunique())
+
+    assert loaded_tickers > 9
+    assert canonical_tickers > 9
+    assert canonical_tickers >= int(loaded_tickers * 0.8)


### PR DESCRIPTION
### Motivation
- Surface where the active bundled JSE dataset is used at runtime and why downstream views sometimes show a much smaller ranked subset. 
- Verify loader API backward-compatibility so `load_internal_dataset()` returns only a DataFrame and cannot regress to returning a tuple. 
- Add guarded tests and small UI diagnostics to make it obvious that Ticker Analysis and the Data tab are driven by the canonical internal dataset, not a tiny legacy demo set.

### Description
- Added helpers ` _extract_unique_ticker_count` and `_extract_ticker_preview` in `app.py` to consistently derive ticker counts and previews from either `instrument` or `ticker` columns. 
- Rendered a small temporary diagnostics block in the Data tab showing canonical vs ranked row counts, unique ticker counts, and first-20 ticker previews using `st.caption`, `st.dataframe`, and `st.code`. 
- Kept loader API unchanged; `load_internal_dataset()` still returns a single `DataFrame` and the source label remains available via `load_internal_dataset_with_source()`/`get_internal_dataset_source_label()`. 
- Added/updated tests: ensure `load_internal_dataset()` is not a tuple, verify demo ingestion preserves a larger ticker universe, and assert Ticker Analysis options come from the canonical dataset even when ranked is a small subset; also updated `DummyStreamlit` to support `st.code`.

### Testing
- Ran unit tests: `pytest -q tests/test_ingestion.py tests/test_app_information_architecture.py tests/test_app_shell.py`, result: `26 passed` (all green). 
- Measured dataset cardinality via the ingestion+ranking pipeline: loader unique tickers = 174, canonical unique tickers = 174, ranked unique tickers = 126 (these counts printed by automated inspection scripts run during investigation). 
- Confirmed no `st.cache_data.clear()` / cache-clear hack exists in `app.py` and no cache-clearing dependency was introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2710c7ac8322a6e6bf7502267b3d)