### PR TITLE
Audit ticker-universe paths and add regression test to prevent ranked-subset leakage

### DIFF
--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -72,6 +72,38 @@ def test_build_analyst_dataset_handles_empty_ranked_df(monkeypatch):
     assert "quality_tier" not in analyst_df.columns
 
 
+def test_build_analyst_dataset_does_not_filter_to_ranked_subset(monkeypatch):
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["AAA", "BBB", "CCC"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-01", "2024-01-01"]),
+            "close": [10.0, 20.0, 30.0],
+            "volume": [1000, 900, 850],
+        }
+    )
+    ranked_df = pd.DataFrame({"instrument": ["AAA"], "tier": ["A"]})
+    trades_stub = pd.DataFrame(
+        {
+            "instrument": ["AAA", "BBB", "CCC"],
+            "holding_window": [10, 10, 10],
+            "net_return_pct": [0.02, -0.01, 0.01],
+        }
+    )
+
+    monkeypatch.setattr(
+        "app.shell.run_cost_engine",
+        lambda df_prices, df_entries: (trades_stub, pd.DataFrame(), None, None),
+    )
+
+    analyst_df = build_analyst_dataset(canonical_df, ranked_df)
+
+    assert set(analyst_df["instrument"]) == {"AAA", "BBB", "CCC"}
+    assert "quality_tier" in analyst_df.columns
+    assert analyst_df.loc[analyst_df["instrument"] == "AAA", "quality_tier"].iat[0] == "A"
+    assert analyst_df.loc[analyst_df["instrument"] == "BBB", "quality_tier"].isna().all()
+    assert analyst_df.loc[analyst_df["instrument"] == "CCC", "quality_tier"].isna().all()
+
+
 def test_extract_ticker_options_uses_active_dataset_and_is_sorted():
     spec = importlib.util.spec_from_file_location("app_main", ROOT / "app.py")
     app_main = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
### Motivation
- Ensure the app derives the active ticker universe from the bundled/canonical dataset rather than a small curated sample or the ranked subset. 
- Prevent past demo/curated subset assumptions from leaking into runtime Analyst and Ticker Analysis views.

### Description
- Performed an audit of ingestion and UI wiring in `app/data/loaders.py`, `app.py`, and `app/shell.py` and confirmed the selector uses the canonical dataset (no runtime hardcoded curated list). 
- Verified the only small-demo fallback is the legacy emergency dataset used when no bundled files exist, and the loader prefers `data/internal/jse_dataset.csv` when present. 
- Added a regression test `test_build_analyst_dataset_does_not_filter_to_ranked_subset` in `tests/test_app_shell.py` to ensure `build_analyst_dataset` preserves all trade instruments from the cost engine output and only left-joins tier labels from the ranked dataframe (no filtering to ranked instruments). 
- Did not change core signal logic or remove any valid quality/liquidity filtering; this PR only adds audit coverage.

### Testing
- Ran `pytest -q tests/test_app_shell.py tests/test_app_information_architecture.py tests/test_ingestion.py` to validate behavior. 
- Test run result: `27 passed` (including the new regression test). 
- Existing tests already verify the ticker selector is populated from the canonical dataset, and those checks still pass, confirming dropdown options now come from the full bundled dataset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbeb9600648322bc6ad6348a701e55)