### PR TITLE
Handle missing legacy earnings events in demo startup path

### DIFF
--- a/app/costs/net_returns.py
+++ b/app/costs/net_returns.py
@@ -34,6 +34,8 @@ def compute_trade_results(
         entry_price = price_index.get((instrument, entry_date))
         if entry_price is None or pd.isna(entry_price):
             continue
+        if float(entry_price) == 0.0:
+            continue
         for window in holding_windows:
             exit_date = compute_exit_date(calendar, instrument, entry_date, window)
             if exit_date is None:

--- a/app/demo/run_demo.py
+++ b/app/demo/run_demo.py
@@ -20,6 +20,13 @@ from app.ranking.engine import rank_instruments
 logger = logging.getLogger(__name__)
 
 
+def _load_demo_events(events_path: Path) -> pd.DataFrame:
+    """Load optional legacy demo earnings events, returning an empty-safe frame when absent."""
+    if events_path.exists():
+        return pd.read_csv(events_path)
+    return pd.DataFrame(columns=["instrument", "earnings_date", "confidence"])
+
+
 def run_demo(
     language_mode: str = "plain",
     *,
@@ -42,7 +49,7 @@ def run_demo(
     ranked = rank_instruments(summary_instrument, meta, "income_stability")
 
     events_path = Path(__file__).resolve().parents[2] / "data" / "demo" / "earnings_events.csv"
-    events_df = pd.read_csv(events_path)
+    events_df = _load_demo_events(events_path)
 
     tagged_trades = tag_earnings_phase(
         trades,

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -7,6 +7,8 @@ import pandas as pd
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
+from app.demo import run_demo as run_demo_module
+
 
 class DummyColumn:
     def __enter__(self):
@@ -484,3 +486,30 @@ def test_ticker_analysis_selector_uses_canonical_dataset_universe(monkeypatch):
 
     assert dummy_st.selectbox_calls
     assert len(dummy_st.selectbox_calls[0]) == 12
+
+
+def test_main_startup_path_is_not_blocked_by_missing_legacy_events_file(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit(mode_choice="Beginner")
+    events_path = (ROOT / "data" / "demo" / "earnings_events.csv").resolve()
+    original_exists = Path.exists
+    original_read_csv = pd.read_csv
+
+    def patched_exists(path_obj):
+        if path_obj.resolve() == events_path:
+            return False
+        return original_exists(path_obj)
+
+    def fail_if_events_read(path, *args, **kwargs):
+        if Path(path).resolve() == events_path:
+            raise AssertionError("app startup attempted to read missing legacy events file")
+        return original_read_csv(path, *args, **kwargs)
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(Path, "exists", patched_exists)
+    monkeypatch.setattr(run_demo_module.pd, "read_csv", fail_if_events_read)
+    monkeypatch.setattr(app_main, "run_demo", lambda **kwargs: run_demo_module.run_demo(**kwargs))
+
+    app_main.main()
+
+    assert dummy_st.tabs_requested

--- a/tests/test_cost_engine.py
+++ b/tests/test_cost_engine.py
@@ -94,3 +94,29 @@ def test_insufficient_future_data_excluded_from_summary():
     assert trades.empty
     assert summary_instrument.empty
     assert summary_overall.empty
+
+
+def test_zero_entry_price_is_skipped_to_avoid_invalid_returns():
+    dates = pd.date_range("2024-01-01", periods=6, freq="D")
+    df_prices = pd.DataFrame(
+        {
+            "date": dates,
+            "instrument": ["AAA"] * 6,
+            "close": [0.0, 101, 102, 103, 104, 110],
+        }
+    )
+    df_entries = pd.DataFrame({"instrument": ["AAA"], "entry_date": [dates[0]]})
+
+    trades, summary_instrument, summary_overall, _ = run_cost_engine(
+        df_prices,
+        df_entries,
+        holding_windows=[5],
+        broker_profile="Default",
+        override_enabled=True,
+        broker_fee=0.0,
+        cess=0.0,
+    )
+
+    assert trades.empty
+    assert summary_instrument.empty
+    assert summary_overall.empty

--- a/tests/test_demo_pipeline.py
+++ b/tests/test_demo_pipeline.py
@@ -37,7 +37,7 @@ def test_demo_pipeline_outputs():
     assert {"tier", "best_window", "score_total"}.issubset(ranked.columns)
 
     events_path = ROOT / "data" / "demo" / "earnings_events.csv"
-    events_df = pd.read_csv(events_path)
+    events_df = run_demo_module._load_demo_events(events_path)
     tagged = tag_earnings_phase(
         trades,
         events_df,
@@ -89,3 +89,28 @@ def test_run_demo_does_not_swallow_unexpected_os_errors(monkeypatch):
 
     with pytest.raises(OSError, match="disk full"):
         run_demo_module.run_demo()
+
+
+def test_run_demo_works_when_legacy_events_file_is_missing(monkeypatch):
+    events_path = (ROOT / "data" / "demo" / "earnings_events.csv").resolve()
+    original_exists = Path.exists
+    original_read_csv = pd.read_csv
+
+    def patched_exists(path_obj):
+        if path_obj.resolve() == events_path:
+            return False
+        return original_exists(path_obj)
+
+    def fail_if_events_read(path, *args, **kwargs):
+        if Path(path).resolve() == events_path:
+            raise AssertionError("run_demo attempted to read missing legacy events file")
+        return original_read_csv(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "exists", patched_exists)
+    monkeypatch.setattr(run_demo_module.pd, "read_csv", fail_if_events_read)
+
+    result = run_demo_module.run_demo()
+
+    assert not result["ranked"].empty
+    assert not result["phase_metrics"].empty
+    assert set(result["phase_metrics"]["earnings_phase"].unique()) == {"non"}


### PR DESCRIPTION
### Motivation
- The demo startup previously crashed when the legacy file `data/demo/earnings_events.csv` was absent, causing a `FileNotFoundError` during app startup and tests.
- The app should run from the bundled internal JSE dataset without requiring legacy demo event artifacts and should degrade earnings tagging gracefully when event data is unavailable.

### Description
- Added `_load_demo_events(events_path: Path)` in `app/demo/run_demo.py` which returns `pd.read_csv(events_path)` when present and otherwise returns an empty DataFrame with columns `instrument`, `earnings_date`, and `confidence`, and wired `run_demo()` to use it instead of an unconditional `pd.read_csv`.
- Added a small guard in `app/costs/net_returns.py` to skip entries with `entry_price == 0.0` to avoid divide-by-zero/invalid return calculations during net return computation.
- Updated and added tests to cover the missing-events fallback and zero-entry-price behavior, and adjusted the demo pipeline test to use the new loader helper so it no longer hard-depends on the legacy CSV.

### Testing
- Ran targeted test suite: `pytest -q tests/test_demo_pipeline.py tests/test_app_information_architecture.py tests/test_cost_engine.py` and observed all tests passing.
- Result of the test run was `24 passed` (no failures) for the invoked test set, confirming `run_demo()` and `app.main()` are safe when the legacy events file is missing and zero entry prices are skipped.
- Existing behavior for ranking and Phase 1 earnings tagging was preserved and validated by the updated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbef32dcd48322bb8f2caaee346f36)