### PR TITLE
Deduplicate final insight bullets and normalize JSE ticker marker variants

### DIFF
--- a/app/data/loaders.py
+++ b/app/data/loaders.py
@@ -43,7 +43,7 @@ def load_internal_dataset_with_source() -> tuple[pd.DataFrame, str]:
     normalized = normalize_jse_dataset(raw)
 
     # Backward compatibility: downstream app paths still expect `instrument`.
-    # Keep `ticker` from the normalized dataset while exposing a mirrored alias.
+    # Keep `instrument` mirrored to the canonical ticker.
     normalized["instrument"] = normalized["ticker"]
     return normalized, source_label
 

--- a/app/data/processor.py
+++ b/app/data/processor.py
@@ -2,19 +2,46 @@
 
 from __future__ import annotations
 
+import re
+
 import pandas as pd
+
+_TEMPORARY_MARKERS = ("XD",)
+_MARKER_PATTERN = re.compile(r"^(?P<ticker>[A-Z0-9]+?)(?:[.\-_ ]?(?P<marker>XD))?$")
+
+
+def _parse_symbol_parts(symbol: object) -> tuple[str, str | None]:
+    """Split raw JSE symbol into canonical ticker and optional marker suffix."""
+    raw_symbol = str(symbol or "").strip().upper()
+    if not raw_symbol:
+        return "", None
+
+    match = _MARKER_PATTERN.match(raw_symbol)
+    if not match:
+        return raw_symbol, None
+
+    marker = match.group("marker")
+    ticker = match.group("ticker") or raw_symbol
+    if marker in _TEMPORARY_MARKERS:
+        return ticker, marker
+    return raw_symbol, None
 
 
 def normalize_jse_dataset(df: pd.DataFrame) -> pd.DataFrame:
     """Normalize the internal JSE dataset into ingestion-ready long format."""
     normalized = df.rename(
         columns={
-            "symbol": "ticker",
+            "symbol": "raw_symbol",
             "close_price": "close",
         }
     )
 
-    normalized = normalized[["date", "ticker", "close", "volume"]].copy()
+    normalized = normalized[["date", "raw_symbol", "close", "volume"]].copy()
+    symbol_parts = normalized["raw_symbol"].map(_parse_symbol_parts)
+    normalized["ticker"] = symbol_parts.map(lambda parts: parts[0])
+    normalized["symbol_marker"] = symbol_parts.map(lambda parts: parts[1])
+    normalized["display_symbol"] = normalized["raw_symbol"].astype(str).str.strip().str.upper()
+    normalized["instrument"] = normalized["ticker"]
     normalized["date"] = pd.to_datetime(normalized["date"], errors="coerce")
     normalized = normalized.sort_values(["ticker", "date"]).reset_index(drop=True)
     return normalized

--- a/app/insights/embedded.py
+++ b/app/insights/embedded.py
@@ -47,7 +47,11 @@ def generate_embedded_insights(
     if not what_to_watch:
         what_to_watch.append("Results are mixed, so keep an eye on consistency across trades.")
 
+    what_is_happening = _dedupe_lines(what_is_happening)
+    what_to_watch = _dedupe_lines(what_to_watch)
+
     common_mistakes = _common_mistakes_lines(rows, mode=mode)
+    common_mistakes = _dedupe_lines(common_mistakes)
     why_this_matters = (
         "Based on historical data, this helps you understand where the plan is strong, where risk is rising, and what to monitor next. Use it as a decision-support tool, not a guarantee."
     )
@@ -216,6 +220,19 @@ def _count_tokens(
         token = token.upper() if uppercase else token.lower()
         counts[token] = counts.get(token, 0) + 1
     return counts
+
+
+def _dedupe_lines(lines: Sequence[str]) -> list[str]:
+    """Drop duplicate lines while preserving first-seen order."""
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for line in lines:
+        token = str(line).strip()
+        if not token or token in seen:
+            continue
+        seen.add(token)
+        deduped.append(token)
+    return deduped
 
 
 def _mean_numeric(rows: Sequence[Mapping[str, Any]], field: str) -> float | None:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -123,3 +123,23 @@ def test_extract_ticker_options_uses_active_dataset_and_is_sorted():
     ticker_options = app_main._extract_ticker_options(canonical_df)
 
     assert ticker_options == ["AAA", "BBB", "CCC"]
+
+
+def test_extract_ticker_options_does_not_split_marker_variants():
+    spec = importlib.util.spec_from_file_location("app_main", ROOT / "app.py")
+    app_main = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_main)
+
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["CAR", "CAR", "GK", "GK"],
+            "ticker": ["CAR", "CAR", "GK", "GK"],
+            "raw_symbol": ["CAR", "CARXD", "GK", "GKXD"],
+            "display_symbol": ["CAR", "CARXD", "GK", "GKXD"],
+        }
+    )
+
+    ticker_options = app_main._extract_ticker_options(canonical_df)
+
+    assert ticker_options == ["CAR", "GK"]

--- a/tests/test_embedded_insights.py
+++ b/tests/test_embedded_insights.py
@@ -58,3 +58,31 @@ def test_render_embedded_insights_renders_card_and_sections():
     assert any("Final Insight" in block for block in dummy_st.markdowns)
     assert any("What’s happening now" in block for block in dummy_st.markdowns)
     assert any("Why this matters now" in block for block in dummy_st.markdowns)
+
+
+def test_embedded_insights_dedupes_duplicate_lines_per_section():
+    payload = generate_embedded_insights(
+        [
+            {
+                "quality_tier": "B",
+                "volatility_bucket": "medium",
+                "win_rate": 0.40,
+                "avg_return": 0.05,
+                "median_return": 0.01,
+                "holding_window": 5,
+            },
+            {
+                "quality_tier": "B",
+                "volatility_bucket": "medium",
+                "win_rate": 0.42,
+                "avg_return": 0.04,
+                "median_return": 0.01,
+                "holding_window": 20,
+            },
+        ],
+        [{"allocation_amount": 0, "eligible_for_funding": True}],
+    )
+
+    assert payload["what_is_happening"].count(
+        "Only a few trades made it into the final picks this time."
+    ) == 1

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -17,6 +17,7 @@ from app.data.loaders import (
 from app.data.normalize import detect_format, normalize_data
 from app.data.ingest import ingest_dataset
 from app.data.validate import validate_canonical
+from app.data.processor import normalize_jse_dataset
 
 
 def test_detect_format_long_vs_wide():
@@ -179,3 +180,37 @@ def test_demo_ingestion_preserves_large_ticker_universe_from_internal_dataset():
     assert loaded_tickers > 9
     assert canonical_tickers > 9
     assert canonical_tickers >= int(loaded_tickers * 0.8)
+
+
+def test_jse_symbol_markers_normalize_to_canonical_ticker():
+    raw = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-01", "2024-01-02", "2024-01-02"],
+            "symbol": ["CAR", "CARXD", "GK", "GKXD"],
+            "close_price": [10.0, 10.1, 8.0, 8.2],
+            "volume": [1000, 900, 1100, 950],
+        }
+    )
+
+    normalized = normalize_jse_dataset(raw)
+
+    car_rows = normalized[normalized["raw_symbol"].str.startswith("CAR")]
+    gk_rows = normalized[normalized["raw_symbol"].str.startswith("GK")]
+    assert set(car_rows["ticker"]) == {"CAR"}
+    assert set(gk_rows["ticker"]) == {"GK"}
+    assert set(normalized["instrument"]) == {"CAR", "GK"}
+
+
+def test_demo_ingestion_collapses_marker_variants_to_single_instrument(monkeypatch):
+    sample_raw = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02", "2024-01-01", "2024-01-02"],
+            "symbol": ["CAR", "CARXD", "GK", "GKXD"],
+            "close_price": [10.0, 10.2, 8.0, 8.1],
+            "volume": [1000, 1200, 900, 950],
+        }
+    )
+    monkeypatch.setattr("app.data.loaders.pd.read_csv", lambda *_args, **_kwargs: sample_raw)
+
+    canonical, _meta, _issues = ingest_dataset("demo")
+    assert set(canonical["instrument"]) == {"CAR", "GK"}


### PR DESCRIPTION
### Motivation
- Remove repeated identical lines in the global final-insight block so the summary reads cleanly while preserving the existing section order and intent. 
- Treat JSE symbols with temporary markers (e.g., `XD`) as the same underlying instrument so the dashboard and ranking pipeline do not split the ticker universe by display-only suffixes.

### Description
- Implemented ordered deduplication in `generate_embedded_insights` by adding helper ` _dedupe_lines(lines)` which strips blanks, preserves first-seen order, and is applied to `what_is_happening`, `what_to_watch`, and `common_mistakes` before section slicing. 
- Added JSE symbol parsing in `normalize_jse_dataset` using `_parse_symbol_parts` with regex `^(?P<ticker>[A-Z0-9]+?)(?:[.\-_ ]?(?P<marker>XD))?$` and a `_TEMPORARY_MARKERS` list to strip known temporary markers (currently `XD`). 
- Emit and preserve symbol metadata fields `raw_symbol`, `symbol_marker`, and `display_symbol` while deriving canonical `ticker` and mirroring it to `instrument` for backward compatibility so downstream logic (dropdowns, ranking, drilldowns, portfolio) uses the canonical identifier. 
- Files updated: `app/insights/embedded.py`, `app/data/processor.py`, `app/data/loaders.py`, and tests `tests/test_embedded_insights.py`, `tests/test_ingestion.py`, and `tests/test_app_shell.py`.

### Testing
- Added/updated tests: `tests/test_embedded_insights.py` verifies duplicate final-insight bullets are collapsed, `tests/test_ingestion.py` verifies `CAR`/`CARXD` and `GK`/`GKXD` normalize to the same canonical ticker and demo ingestion collapses marker variants, and `tests/test_app_shell.py` ensures ticker dropdown options do not split marker variants. 
- Test command run: `pytest -q tests/test_embedded_insights.py tests/test_ingestion.py tests/test_app_shell.py`. 
- Result: all tests passed (`20 passed` for the test set run). 
- Confirmation: marker variants no longer appear as separate instruments because `instrument` mirrors the canonical `ticker` while raw marker-bearing labels are retained in `raw_symbol`, `symbol_marker`, and `display_symbol` for UX/debugging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf8f07a0c83228eeb1ba90e92f459)