### PR TITLE
Canonicalize JSE ticker symbols, collapse marker variants, and enhance Ticker Analysis UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from app.analysis.ticker_drilldown import build_ticker_drilldown
 from app.analysis.ticker_intelligence import compute_ticker_metrics
+from app.data.processor import canonicalize_symbol
 from app.data.ingest import ingest_dataset
 from app.demo.run_demo import run_demo
 from app.insights.analyst import render_analyst_insights
@@ -43,9 +44,78 @@ def _extract_ticker_options(df: pd.DataFrame) -> list[str]:
     if ticker_column is None:
         return []
 
-    tickers = df[ticker_column].dropna().astype(str).str.strip()
+    tickers = df[ticker_column].dropna().astype(str).str.strip().map(canonicalize_symbol)
     tickers = tickers[tickers != ""]
     return sorted(tickers.unique())
+
+
+def _ticker_strength_label(win_rate: float) -> str:
+    if win_rate >= 0.60:
+        return "strong"
+    if win_rate >= 0.45:
+        return "mixed"
+    return "weak"
+
+
+def _build_quick_take(*, stats: dict, holding_window_stats: dict[str, dict]) -> list[str]:
+    win_rate = float(stats.get("win_rate", 0.0))
+    avg_return = float(stats.get("avg_return", 0.0))
+    median_return = float(stats.get("median_return", 0.0))
+
+    strength = _ticker_strength_label(win_rate)
+    consistency = (
+        "returns are fairly steady"
+        if abs((avg_return - median_return) * 100) <= 0.3
+        else "returns are a bit uneven"
+    )
+    if len(holding_window_stats) >= 2:
+        sorted_windows = sorted(
+            holding_window_stats.items(),
+            key=lambda item: (
+                float(item[1].get("win_rate", 0.0)),
+                float(item[1].get("avg_return", 0.0)),
+            ),
+            reverse=True,
+        )
+        best_label = sorted_windows[0][0]
+        hold_line = f"{best_label} has looked better than shorter alternatives in this sample."
+    else:
+        hold_line = "There is not enough history yet to compare short and long holding styles."
+
+    return [
+        f"This stock looks {strength} based on past signals.",
+        f"It closed positive about {win_rate:.0%} of the time.",
+        f"So far, {consistency}.",
+        hold_line,
+    ]
+
+
+def _build_holding_window_table(holding_window_stats: dict[str, dict], *, analyst_mode: bool) -> pd.DataFrame:
+    if not holding_window_stats:
+        return pd.DataFrame()
+    rows: list[dict] = []
+    for window, values in holding_window_stats.items():
+        win_rate = float(values.get("win_rate", 0.0))
+        avg_return = float(values.get("avg_return", 0.0))
+        count = int(values.get("count", 0))
+        if win_rate >= 0.6 and avg_return > 0:
+            verdict = "More steady"
+        elif win_rate >= 0.5:
+            verdict = "Mixed"
+        else:
+            verdict = "Less steady"
+        row = {
+            "holding_window": window,
+            "win_rate": f"{win_rate:.0%}",
+            "average_return": f"{avg_return:.2f}%",
+            "verdict": verdict,
+        }
+        if analyst_mode:
+            row["count"] = count
+        else:
+            row["sample_note"] = f"Based on ~{count} historical trades"
+        rows.append(row)
+    return pd.DataFrame(rows)
 
 
 def _extract_unique_ticker_count(df: pd.DataFrame) -> int:
@@ -257,91 +327,93 @@ def main() -> None:
             selected_ticker = st.selectbox("Select ticker", ticker_options)
             ticker_payload = build_ticker_drilldown(analyst_df, selected_ticker)
             ticker_metrics = compute_ticker_metrics(analyst_df, selected_ticker, mode=mode_token)
+            analyst_mode = mode_token == "analyst"
+            metrics_stats = ticker_metrics.get("stats", {})
+            metrics_behavior = ticker_metrics.get("behavior", {})
 
-            st.markdown("#### Ticker Summary")
-            st.write(ticker_metrics["summary"])
-
-            st.markdown("#### Behavior Insights")
-            for line in ticker_metrics["behavior"].values():
+            st.markdown("#### A) Quick Take")
+            st.caption("A fast read of what this stock has looked like so far.")
+            for line in _build_quick_take(
+                stats=metrics_stats, holding_window_stats=ticker_payload["holding_window_stats"]
+            ):
                 st.markdown(f"- {line}")
 
-            st.markdown("#### Pattern Summary")
-            st.write(ticker_payload["pattern_summary"])
-
-            signal_df = pd.DataFrame(ticker_payload["signals"])
-            signal_count = int(len(signal_df))
-            if signal_df.empty or "return_pct" not in signal_df.columns:
-                key_stats = {
-                    "Signal Count": signal_count,
-                    "Win Rate": 0.0,
-                    "Median Return": 0.0,
-                    "Average Return": 0.0,
-                }
-            else:
-                returns = pd.to_numeric(signal_df["return_pct"], errors="coerce").dropna()
-                if returns.empty:
-                    key_stats = {
-                        "Signal Count": signal_count,
-                        "Win Rate": 0.0,
-                        "Median Return": 0.0,
-                        "Average Return": 0.0,
-                    }
-                else:
-                    key_stats = {
-                        "Signal Count": signal_count,
-                        "Win Rate": float((returns > 0).mean()),
-                        "Median Return": float(returns.median()),
-                        "Average Return": float(returns.mean()),
-                    }
-
-            st.markdown(
-                (
-                    '<div class="jse-metric-grid">'
-                    f'<div class="jse-metric"><div class="jse-metric-label">Signal Count</div><div class="jse-metric-value">{key_stats["Signal Count"]}</div></div>'
-                    f'<div class="jse-metric"><div class="jse-metric-label">Win Rate</div><div class="jse-metric-value">{key_stats["Win Rate"]:.1%}</div></div>'
-                    f'<div class="jse-metric"><div class="jse-metric-label">Median Return</div><div class="jse-metric-value">{key_stats["Median Return"]:.2%}</div></div>'
-                    f'<div class="jse-metric"><div class="jse-metric-label">Average Return</div><div class="jse-metric-value">{key_stats["Average Return"]:.2%}</div></div>'
-                    "</div>"
-                ),
-                unsafe_allow_html=True,
-            )
-
-            if mode_token == "analyst":
-                st.markdown("#### Key Stats")
-                st.dataframe(pd.DataFrame([key_stats]), use_container_width=True)
-
-            st.markdown("#### Holding Window Comparison")
-            holding_window_df = pd.DataFrame.from_dict(
-                ticker_payload["holding_window_stats"], orient="index"
+            st.markdown("#### B) Best Holding Strategy")
+            st.caption("This compares how the stock has behaved across holding periods and highlights the strongest window.")
+            holding_window_df = _build_holding_window_table(
+                ticker_payload["holding_window_stats"], analyst_mode=analyst_mode
             )
             if holding_window_df.empty:
                 st.info("No holding window data is ready for this ticker yet.")
             else:
-                st.dataframe(holding_window_df.reset_index().rename(columns={"index": "holding_window"}), use_container_width=True)
+                best_window = str(metrics_stats.get("best_window") or "N/A")
+                st.markdown(f"**Best holding period:** {best_window}")
+                st.markdown(f"{metrics_behavior.get('holding_window', 'Holding-window comparison is limited right now.')}")
+                st.dataframe(holding_window_df, use_container_width=True, hide_index=True)
 
-            st.markdown("#### Tier Performance")
-            tier_df = pd.DataFrame.from_dict(ticker_payload["tier_performance"], orient="index")
-            if tier_df.empty:
-                st.info("No tier breakdown is ready for this ticker yet.")
+            st.markdown("#### C) Risk Profile")
+            st.caption("This explains how steady or uneven the returns have been.")
+            for key in ("reliability", "consistency"):
+                st.markdown(f"- {metrics_behavior.get(key, '')}")
+            distribution = ticker_payload["return_distribution"]
+            st.markdown(
+                f"- Losses: {distribution.get('negative', 0)} | Smaller wins: {distribution.get('small_positive', 0)} | Strong wins: {distribution.get('strong_positive', 0)}."
+            )
+            if distribution.get("strong_positive", 0) > 0 and distribution.get("strong_positive", 0) <= distribution.get(
+                "small_positive", 0
+            ):
+                st.markdown("- The average can be lifted by a smaller number of bigger wins.")
+
+            st.markdown("#### D) What Usually Happens")
+            st.caption("This section translates recurring behavior seen in the historical sample.")
+            st.markdown(f"- {ticker_payload['pattern_summary']}")
+            st.markdown(f"- {metrics_behavior.get('holding_window', '')}")
+            st.markdown(f"- {metrics_behavior.get('tier_profile', '')}")
+
+            st.markdown("#### E) What to Watch")
+            st.caption("These points flag caution areas that can make results look better or worse than expected.")
+            if "20D looks stronger" in metrics_behavior.get("holding_window", ""):
+                st.markdown("- Short-term setups have looked weaker than longer holds in this sample.")
+            st.markdown("- Results can look mixed when win rate and average return move in different directions.")
+            st.markdown("- A smaller number of bigger moves can shape the average return.")
+
+            if analyst_mode:
+                st.markdown("#### F) Analyst Deep Dive")
+                st.caption("These tables provide the full raw breakdown for deeper inspection.")
+
+                st.markdown("This table shows full holding-window stats including raw sample count.")
+                raw_holding_df = pd.DataFrame.from_dict(ticker_payload["holding_window_stats"], orient="index")
+                st.dataframe(raw_holding_df.reset_index().rename(columns={"index": "holding_window"}), use_container_width=True)
+
+                st.markdown("This table shows how each quality tier has performed for this ticker.")
+                tier_df = pd.DataFrame.from_dict(ticker_payload["tier_performance"], orient="index")
+                if tier_df.empty:
+                    st.info("No tier breakdown is ready for this ticker yet.")
+                else:
+                    st.dataframe(tier_df.reset_index().rename(columns={"index": "quality_tier"}), use_container_width=True)
+
+                st.markdown("This table shows whether results changed across volatility buckets.")
+                volatility_df = pd.DataFrame.from_dict(ticker_payload["volatility_performance"], orient="index")
+                if volatility_df.empty:
+                    st.info("No volatility breakdown is ready for this ticker yet.")
+                else:
+                    st.dataframe(
+                        volatility_df.reset_index().rename(columns={"index": "volatility_bucket"}),
+                        use_container_width=True,
+                    )
+
+                st.markdown("This table shows the return distribution split between losses and stronger wins.")
+                distribution_df = pd.DataFrame([ticker_payload["return_distribution"]])
+                st.dataframe(distribution_df, use_container_width=True)
+
+                st.markdown("This table lists the raw signal history for analyst review.")
+                signal_df = pd.DataFrame(ticker_payload["signals"])
+                if signal_df.empty:
+                    st.info("No signal history is available for this ticker yet.")
+                else:
+                    st.dataframe(signal_df, use_container_width=True)
             else:
-                st.dataframe(tier_df.reset_index().rename(columns={"index": "quality_tier"}), use_container_width=True)
-
-            st.markdown("#### Volatility Performance")
-            volatility_df = pd.DataFrame.from_dict(ticker_payload["volatility_performance"], orient="index")
-            if volatility_df.empty:
-                st.info("No volatility breakdown is ready for this ticker yet.")
-            else:
-                st.dataframe(volatility_df.reset_index().rename(columns={"index": "volatility_bucket"}), use_container_width=True)
-
-            st.markdown("#### Return Distribution")
-            distribution_df = pd.DataFrame([ticker_payload["return_distribution"]])
-            st.dataframe(distribution_df, use_container_width=True)
-
-            st.markdown("#### Signal Breakdown")
-            if signal_df.empty:
-                st.info("No signal history is available for this ticker yet.")
-            else:
-                st.dataframe(signal_df, use_container_width=True)
+                st.markdown("**Analyst Deep Dive** is available in Analyst mode for full raw tables.")
 
     if "Analyst Insights" in tab_map:
         with tab_map["Analyst Insights"]:

--- a/app/analysis/ticker_drilldown.py
+++ b/app/analysis/ticker_drilldown.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pandas as pd
 
+from app.data.processor import canonicalize_symbol
 
 TICKER_COLUMNS = ["ticker", "instrument"]
 RETURN_COLUMNS = ["net_return_pct", "net_return", "return_pct", "return"]
@@ -50,7 +51,8 @@ def _scope_to_ticker(df: pd.DataFrame, ticker: str) -> pd.DataFrame:
     ticker_column = _resolve_ticker_column(df)
     if df.empty or ticker_column is None:
         return pd.DataFrame(columns=df.columns)
-    scoped = df[df[ticker_column].astype(str) == str(ticker)].copy()
+    ticker_token = canonicalize_symbol(ticker)
+    scoped = df[df[ticker_column].astype(str).map(canonicalize_symbol) == ticker_token].copy()
     return scoped
 
 

--- a/app/analysis/ticker_intelligence.py
+++ b/app/analysis/ticker_intelligence.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pandas as pd
 
+from app.data.processor import canonicalize_symbol
 RETURN_COLUMNS = ["net_return_pct", "net_return", "return_pct", "return"]
 
 
@@ -123,7 +124,8 @@ def compute_ticker_metrics(df: pd.DataFrame, ticker: str, *, mode: str = "beginn
     if return_column is None:
         return _empty_payload()
 
-    scoped = df[df["instrument"].astype(str) == str(ticker)].copy()
+    ticker_token = canonicalize_symbol(ticker)
+    scoped = df[df["instrument"].astype(str).map(canonicalize_symbol) == ticker_token].copy()
     scoped = scoped.dropna(subset=[return_column])
     if scoped.empty:
         return _empty_payload()

--- a/app/data/normalize.py
+++ b/app/data/normalize.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 
 from .schema import CANONICAL_COLUMNS, FORMAT_LONG, FORMAT_WIDE, LONG_REQUIRED_COLUMNS
+from .processor import canonicalize_symbol_parts
 
 
 def detect_format(df: pd.DataFrame) -> str:
@@ -37,7 +38,12 @@ def _normalize_long(df: pd.DataFrame, source: str, dataset_id: str) -> pd.DataFr
     if instrument_col not in cols:
         raise ValueError("Missing instrument or ticker column.")
 
-    data["instrument"] = df[cols[instrument_col]].astype(str).str.strip().str.upper()
+    raw_symbols = df[cols[instrument_col]].astype(str).str.strip().str.upper()
+    symbol_parts = raw_symbols.map(canonicalize_symbol_parts)
+    data["ticker"] = symbol_parts.map(lambda parts: parts[0])
+    data["instrument"] = data["ticker"]
+    data["raw_symbol"] = symbol_parts.map(lambda parts: parts[2])
+    data["symbol_marker"] = symbol_parts.map(lambda parts: parts[1])
     data["close"] = pd.to_numeric(df[price_col], errors="coerce")
 
     if "volume" in cols:
@@ -66,7 +72,12 @@ def _normalize_wide(df: pd.DataFrame, source: str, dataset_id: str) -> pd.DataFr
     prices = df.melt(id_vars=[date_col], var_name="instrument", value_name="close")
     data = pd.DataFrame()
     data["date"] = pd.to_datetime(prices[date_col], errors="coerce")
-    data["instrument"] = prices["instrument"].astype(str).str.strip().str.upper()
+    raw_symbols = prices["instrument"].astype(str).str.strip().str.upper()
+    symbol_parts = raw_symbols.map(canonicalize_symbol_parts)
+    data["ticker"] = symbol_parts.map(lambda parts: parts[0])
+    data["instrument"] = data["ticker"]
+    data["raw_symbol"] = symbol_parts.map(lambda parts: parts[2])
+    data["symbol_marker"] = symbol_parts.map(lambda parts: parts[1])
     data["close"] = pd.to_numeric(prices["close"], errors="coerce")
     data["volume"] = np.nan
     data["market"] = None

--- a/app/data/processor.py
+++ b/app/data/processor.py
@@ -7,7 +7,9 @@ import re
 import pandas as pd
 
 _TEMPORARY_MARKERS = ("XD",)
-_MARKER_PATTERN = re.compile(r"^(?P<ticker>[A-Z0-9]+?)(?:[.\-_ ]?(?P<marker>XD))?$")
+_MARKER_PATTERN = re.compile(
+    r"^(?P<ticker>[A-Z0-9]+?)(?:(?:[.\-_ ]?(?P<marker>XD))|(?:\s*\((?P<paren_marker>XD)\)))?$"
+)
 
 
 def _parse_symbol_parts(symbol: object) -> tuple[str, str | None]:
@@ -20,11 +22,24 @@ def _parse_symbol_parts(symbol: object) -> tuple[str, str | None]:
     if not match:
         return raw_symbol, None
 
-    marker = match.group("marker")
+    marker = match.group("marker") or match.group("paren_marker")
     ticker = match.group("ticker") or raw_symbol
     if marker in _TEMPORARY_MARKERS:
         return ticker, marker
     return raw_symbol, None
+
+
+def canonicalize_symbol_parts(symbol: object) -> tuple[str, str | None, str]:
+    """Return canonical ticker, optional marker, and normalized raw symbol."""
+    raw_symbol = str(symbol or "").strip().upper()
+    ticker, marker = _parse_symbol_parts(raw_symbol)
+    return ticker, marker, raw_symbol
+
+
+def canonicalize_symbol(symbol: object) -> str:
+    """Return canonical ticker token from a raw market symbol."""
+    ticker, _marker, _raw = canonicalize_symbol_parts(symbol)
+    return ticker
 
 
 def normalize_jse_dataset(df: pd.DataFrame) -> pd.DataFrame:
@@ -37,7 +52,7 @@ def normalize_jse_dataset(df: pd.DataFrame) -> pd.DataFrame:
     )
 
     normalized = normalized[["date", "raw_symbol", "close", "volume"]].copy()
-    symbol_parts = normalized["raw_symbol"].map(_parse_symbol_parts)
+    symbol_parts = normalized["raw_symbol"].map(canonicalize_symbol_parts)
     normalized["ticker"] = symbol_parts.map(lambda parts: parts[0])
     normalized["symbol_marker"] = symbol_parts.map(lambda parts: parts[1])
     normalized["display_symbol"] = normalized["raw_symbol"].astype(str).str.strip().str.upper()

--- a/app/data/schema.py
+++ b/app/data/schema.py
@@ -2,7 +2,10 @@
 
 CANONICAL_COLUMNS = [
     "date",
+    "ticker",
     "instrument",
+    "raw_symbol",
+    "symbol_marker",
     "close",
     "volume",
     "market",

--- a/app/insights/embedded.py
+++ b/app/insights/embedded.py
@@ -228,9 +228,10 @@ def _dedupe_lines(lines: Sequence[str]) -> list[str]:
     seen: set[str] = set()
     for line in lines:
         token = str(line).strip()
-        if not token or token in seen:
+        key = " ".join(token.casefold().split())
+        if not token or key in seen:
             continue
-        seen.add(token)
+        seen.add(key)
         deduped.append(token)
     return deduped
 

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -513,3 +513,116 @@ def test_main_startup_path_is_not_blocked_by_missing_legacy_events_file(monkeypa
     app_main.main()
 
     assert dummy_st.tabs_requested
+
+
+def test_ticker_analysis_beginner_mode_hides_raw_deep_dive_tables(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit(mode_choice="Beginner")
+
+    canonical_df = pd.DataFrame({"instrument": ["CAR"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
+    analyst_df = pd.DataFrame({"instrument": ["CAR"], "holding_window": [5], "net_return_pct": [0.01]})
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (
+            canonical_df,
+            {"source": "demo", "dataset_id": "demo-v1", "dataset_source_label": "internal_jse_dataset"},
+            {"errors": [], "warnings": []},
+        ),
+    )
+    monkeypatch.setattr(app_main, "run_demo", lambda *_args, **_kwargs: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: analyst_df)
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
+    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        app_main,
+        "compute_ticker_metrics",
+        lambda *_args, **_kwargs: {
+            "summary": "",
+            "stats": {"win_rate": 0.5, "avg_return": 0.01, "median_return": 0.01, "best_window": "5D"},
+            "behavior": {
+                "holding_window": "5D looks stronger than 20D in this dataset.",
+                "consistency": "Average and median returns are close.",
+                "reliability": "Win rate is mixed.",
+                "tier_profile": "Setup mix leans to A.",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        app_main,
+        "build_ticker_drilldown",
+        lambda *_args, **_kwargs: {
+            "pattern_summary": "This stock has mixed results so far.",
+            "signals": [{"holding_window": "5D", "return_pct": 1.0}],
+            "holding_window_stats": {"5D": {"count": 12, "win_rate": 0.5, "avg_return": 1.0}},
+            "tier_performance": {"A": {"count": 10, "win_rate": 0.6, "avg_return": 1.2}},
+            "volatility_performance": {"low": {"count": 10, "win_rate": 0.6, "avg_return": 1.2}},
+            "return_distribution": {"negative": 5, "small_positive": 4, "strong_positive": 3},
+        },
+    )
+
+    app_main.main()
+
+    ticker_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Ticker Analysis"]
+    assert "#### F) Analyst Deep Dive" not in ticker_markdowns
+    assert any("Analyst Deep Dive" in text for text in ticker_markdowns)
+
+
+def test_ticker_analysis_analyst_mode_shows_deep_dive_tables(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit(mode_choice="Analyst")
+
+    canonical_df = pd.DataFrame({"instrument": ["CAR"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
+    analyst_df = pd.DataFrame({"instrument": ["CAR"], "holding_window": [5], "net_return_pct": [0.01]})
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (
+            canonical_df,
+            {"source": "demo", "dataset_id": "demo-v1", "dataset_source_label": "internal_jse_dataset"},
+            {"errors": [], "warnings": []},
+        ),
+    )
+    monkeypatch.setattr(app_main, "run_demo", lambda *_args, **_kwargs: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: analyst_df)
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
+    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        app_main,
+        "compute_ticker_metrics",
+        lambda *_args, **_kwargs: {
+            "summary": "",
+            "stats": {"win_rate": 0.5, "avg_return": 0.01, "median_return": 0.01, "best_window": "5D"},
+            "behavior": {
+                "holding_window": "5D looks stronger than 20D in this dataset.",
+                "consistency": "Average and median returns are close.",
+                "reliability": "Win rate is mixed.",
+                "tier_profile": "Setup mix leans to A.",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        app_main,
+        "build_ticker_drilldown",
+        lambda *_args, **_kwargs: {
+            "pattern_summary": "This stock has mixed results so far.",
+            "signals": [{"holding_window": "5D", "return_pct": 1.0}],
+            "holding_window_stats": {"5D": {"count": 12, "win_rate": 0.5, "avg_return": 1.0}},
+            "tier_performance": {"A": {"count": 10, "win_rate": 0.6, "avg_return": 1.2}},
+            "volatility_performance": {"low": {"count": 10, "win_rate": 0.6, "avg_return": 1.2}},
+            "return_distribution": {"negative": 5, "small_positive": 4, "strong_positive": 3},
+        },
+    )
+
+    app_main.main()
+
+    ticker_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Ticker Analysis"]
+    ticker_dataframes = [df for tab, df in dummy_st.dataframes if tab == "Ticker Analysis"]
+    assert "#### F) Analyst Deep Dive" in ticker_markdowns
+    assert len(ticker_dataframes) >= 5

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -133,10 +133,10 @@ def test_extract_ticker_options_does_not_split_marker_variants():
 
     canonical_df = pd.DataFrame(
         {
-            "instrument": ["CAR", "CAR", "GK", "GK"],
-            "ticker": ["CAR", "CAR", "GK", "GK"],
-            "raw_symbol": ["CAR", "CARXD", "GK", "GKXD"],
-            "display_symbol": ["CAR", "CARXD", "GK", "GKXD"],
+            "instrument": ["CAR", "CARXD", "CAR (XD)", "GK", "GKXD", "GK (XD)"],
+            "ticker": ["CAR", "CAR", "CAR", "GK", "GK", "GK"],
+            "raw_symbol": ["CAR", "CARXD", "CAR (XD)", "GK", "GKXD", "GK (XD)"],
+            "display_symbol": ["CAR", "CARXD", "CAR (XD)", "GK", "GKXD", "GK (XD)"],
         }
     )
 

--- a/tests/test_embedded_insights.py
+++ b/tests/test_embedded_insights.py
@@ -86,3 +86,12 @@ def test_embedded_insights_dedupes_duplicate_lines_per_section():
     assert payload["what_is_happening"].count(
         "Only a few trades made it into the final picks this time."
     ) == 1
+
+
+def test_embedded_insight_dedupe_is_case_insensitive_with_spacing():
+    from app.insights.embedded import _dedupe_lines
+
+    lines = ["Mixed result read", "  mixed result read  ", "Different line"]
+    deduped = _dedupe_lines(lines)
+
+    assert deduped == ["Mixed result read", "Different line"]

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -185,10 +185,10 @@ def test_demo_ingestion_preserves_large_ticker_universe_from_internal_dataset():
 def test_jse_symbol_markers_normalize_to_canonical_ticker():
     raw = pd.DataFrame(
         {
-            "date": ["2024-01-01", "2024-01-01", "2024-01-02", "2024-01-02"],
-            "symbol": ["CAR", "CARXD", "GK", "GKXD"],
-            "close_price": [10.0, 10.1, 8.0, 8.2],
-            "volume": [1000, 900, 1100, 950],
+            "date": ["2024-01-01", "2024-01-01", "2024-01-02", "2024-01-02", "2024-01-03", "2024-01-03"],
+            "symbol": ["CAR", "CARXD", "GK", "GKXD", "CAR (XD)", "GK (XD)"],
+            "close_price": [10.0, 10.1, 8.0, 8.2, 10.3, 8.3],
+            "volume": [1000, 900, 1100, 950, 980, 920],
         }
     )
 
@@ -204,13 +204,45 @@ def test_jse_symbol_markers_normalize_to_canonical_ticker():
 def test_demo_ingestion_collapses_marker_variants_to_single_instrument(monkeypatch):
     sample_raw = pd.DataFrame(
         {
-            "date": ["2024-01-01", "2024-01-02", "2024-01-01", "2024-01-02"],
-            "symbol": ["CAR", "CARXD", "GK", "GKXD"],
-            "close_price": [10.0, 10.2, 8.0, 8.1],
-            "volume": [1000, 1200, 900, 950],
+            "date": ["2024-01-01", "2024-01-02", "2024-01-01", "2024-01-02", "2024-01-03", "2024-01-03"],
+            "symbol": ["CAR", "CARXD", "GK", "GKXD", "CAR (XD)", "GK (XD)"],
+            "close_price": [10.0, 10.2, 8.0, 8.1, 10.3, 8.2],
+            "volume": [1000, 1200, 900, 950, 980, 930],
         }
     )
     monkeypatch.setattr("app.data.loaders.pd.read_csv", lambda *_args, **_kwargs: sample_raw)
 
     canonical, _meta, _issues = ingest_dataset("demo")
     assert set(canonical["instrument"]) == {"CAR", "GK"}
+
+
+def test_normalize_data_collapses_marker_variants_to_single_canonical_ticker():
+    raw = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02", "2024-01-01", "2024-01-03"],
+            "instrument": ["CAR", "CARXD", "CAR XD", "CAR (XD)"],
+            "close": [10.0, 10.1, 10.2, 10.4],
+        }
+    )
+
+    canonical, fmt = normalize_data(raw, source="upload", dataset_id="dataset-1")
+
+    assert fmt == "long"
+    assert set(canonical["ticker"]) == {"CAR"}
+    assert set(canonical["instrument"]) == {"CAR"}
+
+
+def test_normalize_data_parenthesized_gk_xd_maps_to_gk():
+    raw = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02"],
+            "instrument": ["GK", "GK (XD)"],
+            "close": [8.0, 8.1],
+        }
+    )
+
+    canonical, fmt = normalize_data(raw, source="upload", dataset_id="dataset-2")
+
+    assert fmt == "long"
+    assert set(canonical["ticker"]) == {"GK"}
+    assert set(canonical["instrument"]) == {"GK"}

--- a/tests/test_ticker_drilldown.py
+++ b/tests/test_ticker_drilldown.py
@@ -276,6 +276,21 @@ def test_drilldown_outputs_are_schema_consistent_across_return_aliases():
         assert payloads[alias]["pattern_summary"] == baseline["pattern_summary"]
 
 
+def test_scoping_uses_canonical_ticker_and_collapses_marker_variants():
+    df = pd.DataFrame(
+        {
+            "instrument": ["CAR", "CARXD", "CAR XD", "CAR (XD)", "GK"],
+            "holding_window": [5, 20, 5, 20, 5],
+            "net_return_pct": [1.0, 2.0, -1.0, 1.5, 3.0],
+        }
+    )
+
+    payload = build_ticker_drilldown(df, "CAR")
+
+    assert len(payload["signals"]) == 4
+    assert set(payload["holding_window_stats"].keys()) == {"5D", "20D"}
+
+
 def _pattern_window_df(return_column: str, five_day_returns_pct: list[float], twenty_day_returns_pct: list[float]) -> pd.DataFrame:
     all_returns_pct = five_day_returns_pct + twenty_day_returns_pct
     returns = (

--- a/tests/test_ticker_intelligence.py
+++ b/tests/test_ticker_intelligence.py
@@ -84,3 +84,17 @@ def test_compute_ticker_metrics_handles_missing_data():
     assert payload["stats"]["signal_count"] == 0
     assert payload["stats"]["best_window"] == "N/A"
     assert "No clean return data" in payload["summary"]
+
+
+def test_compute_ticker_metrics_scopes_to_canonical_ticker_with_marker_variants():
+    df = pd.DataFrame(
+        {
+            "instrument": ["CAR", "CARXD", "CAR XD", "CAR (XD)", "GK"],
+            "holding_window": [5, 20, 5, 20, 5],
+            "net_return_pct": [0.01, 0.02, -0.01, 0.015, 0.04],
+        }
+    )
+
+    payload = compute_ticker_metrics(df, "CAR")
+
+    assert payload["stats"]["signal_count"] == 4


### PR DESCRIPTION
### Motivation
- Ensure market symbols with temporary markers (e.g. `XD`, `CAR (XD)`) collapse to a single canonical ticker so analyses and UI selectors operate on a stable universe.
- Surface clearer, plain-language ticker-level insights and allow analyst-mode deep dives while keeping beginner views concise.
- Fix deduplication and normalization edge-cases so downstream summaries and tests are robust.

### Description
- Added symbol parsing helpers in `app.data.processor` (`canonicalize_symbol_parts`, `canonicalize_symbol`) and extended the regex to recognize parenthesized markers like `(XD)`.
- Updated normalization flows (`app/data/normalize.py`, `app/data/schema.py`, and `normalize_jse_dataset`) to populate `ticker`, `raw_symbol`, and `symbol_marker` and to use the canonical ticker for `instrument`/`ticker` fields.
- Scoping and selection logic now use canonical tickers in `app.analysis.ticker_drilldown`, `app.analysis.ticker_intelligence`, and `app.py` (ticker options), and added richer Ticker Analysis UI sections (`Quick Take`, `Best Holding Strategy`, `Risk Profile`, `What Usually Happens`, `What to Watch`, and an `Analyst Deep Dive` gated to analyst mode).
- Improved deduplication logic in `app.insights.embedded` to be case-insensitive and whitespace-normalized.
- Updated and added tests to verify canonicalization behavior, UI presentation differences between Beginner/Analyst modes, and dedupe behavior (`tests/*` updates include new cases for parenthesized markers and canonical scoping).

### Testing
- Ran the unit test suite focusing on ingestion and ticker analysis tests including `test_ingestion.py`, `test_ticker_drilldown.py`, `test_ticker_intelligence.py`, and UI selector tests, and they passed.
- Added tests `test_normalize_data_*` and `test_compute_ticker_metrics_scopes_to_canonical_ticker_with_marker_variants` that validate collapsing marker variants into single canonical tickers and they passed.
- Verified embedded-insights dedupe behavior with `test_embedded_insight_dedupe_is_case_insensitive_with_spacing` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfecede00832294d306d5ce172fe6)