### PR TITLE
Preserve raw symbol metadata in long-format normalization

### DIFF
--- a/app/data/normalize.py
+++ b/app/data/normalize.py
@@ -42,8 +42,32 @@ def _normalize_long(df: pd.DataFrame, source: str, dataset_id: str) -> pd.DataFr
     symbol_parts = raw_symbols.map(canonicalize_symbol_parts)
     data["ticker"] = symbol_parts.map(lambda parts: parts[0])
     data["instrument"] = data["ticker"]
-    data["raw_symbol"] = symbol_parts.map(lambda parts: parts[2])
-    data["symbol_marker"] = symbol_parts.map(lambda parts: parts[1])
+    fallback_raw_symbol = symbol_parts.map(lambda parts: parts[2])
+
+    if "raw_symbol" in cols:
+        preserved_raw_symbol = df[cols["raw_symbol"]].astype(str).str.strip().str.upper()
+        data["raw_symbol"] = preserved_raw_symbol.mask(
+            preserved_raw_symbol.isin({"", "NAN", "NONE"}), fallback_raw_symbol
+        )
+    else:
+        data["raw_symbol"] = fallback_raw_symbol
+
+    if "symbol_marker" in cols:
+        preserved_marker = df[cols["symbol_marker"]].astype(str).str.strip().str.upper()
+        fallback_marker = data["raw_symbol"].map(lambda symbol: canonicalize_symbol_parts(symbol)[1])
+        data["symbol_marker"] = preserved_marker.mask(
+            preserved_marker.isin({"", "NAN", "NONE"}), fallback_marker
+        )
+    else:
+        data["symbol_marker"] = data["raw_symbol"].map(lambda symbol: canonicalize_symbol_parts(symbol)[1])
+
+    if "display_symbol" in cols:
+        preserved_display_symbol = df[cols["display_symbol"]].astype(str).str.strip().str.upper()
+        data["display_symbol"] = preserved_display_symbol.mask(
+            preserved_display_symbol.isin({"", "NAN", "NONE"}), data["raw_symbol"]
+        )
+    else:
+        data["display_symbol"] = data["raw_symbol"]
     data["close"] = pd.to_numeric(df[price_col], errors="coerce")
 
     if "volume" in cols:
@@ -78,6 +102,7 @@ def _normalize_wide(df: pd.DataFrame, source: str, dataset_id: str) -> pd.DataFr
     data["instrument"] = data["ticker"]
     data["raw_symbol"] = symbol_parts.map(lambda parts: parts[2])
     data["symbol_marker"] = symbol_parts.map(lambda parts: parts[1])
+    data["display_symbol"] = data["raw_symbol"]
     data["close"] = pd.to_numeric(prices["close"], errors="coerce")
     data["volume"] = np.nan
     data["market"] = None

--- a/app/data/schema.py
+++ b/app/data/schema.py
@@ -6,6 +6,7 @@ CANONICAL_COLUMNS = [
     "instrument",
     "raw_symbol",
     "symbol_marker",
+    "display_symbol",
     "close",
     "volume",
     "market",

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -214,6 +214,8 @@ def test_demo_ingestion_collapses_marker_variants_to_single_instrument(monkeypat
 
     canonical, _meta, _issues = ingest_dataset("demo")
     assert set(canonical["instrument"]) == {"CAR", "GK"}
+    assert "display_symbol" in canonical.columns
+    assert set(canonical["raw_symbol"]) == {"CAR", "CARXD", "CAR (XD)", "GK", "GKXD", "GK (XD)"}
 
 
 def test_normalize_data_collapses_marker_variants_to_single_canonical_ticker():
@@ -246,3 +248,68 @@ def test_normalize_data_parenthesized_gk_xd_maps_to_gk():
     assert fmt == "long"
     assert set(canonical["ticker"]) == {"GK"}
     assert set(canonical["instrument"]) == {"GK"}
+
+
+def test_normalize_data_preserves_existing_raw_symbol_metadata_in_long_format():
+    raw = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02", "2024-01-03"],
+            "instrument": ["CAR", "CAR", "CAR"],
+            "ticker": ["CAR", "CAR", "CAR"],
+            "raw_symbol": ["CAR", "CARXD", "CAR (XD)"],
+            "symbol_marker": [None, "XD", "XD"],
+            "display_symbol": ["CAR", "CARXD", "CAR (XD)"],
+            "close": [10.0, 10.1, 10.2],
+        }
+    )
+
+    canonical, fmt = normalize_data(raw, source="demo", dataset_id="dataset-preserve-1")
+
+    assert fmt == "long"
+    assert canonical["ticker"].tolist() == ["CAR", "CAR", "CAR"]
+    assert canonical["instrument"].tolist() == ["CAR", "CAR", "CAR"]
+    assert canonical["raw_symbol"].tolist() == ["CAR", "CARXD", "CAR (XD)"]
+    assert canonical["symbol_marker"].tolist() == [None, "XD", "XD"]
+    assert canonical["display_symbol"].tolist() == ["CAR", "CARXD", "CAR (XD)"]
+
+
+def test_normalize_data_preserves_parenthesized_xd_metadata_with_canonical_ticker():
+    raw = pd.DataFrame(
+        {
+            "date": ["2024-01-01"],
+            "instrument": ["CAR"],
+            "raw_symbol": ["CAR (XD)"],
+            "symbol_marker": ["XD"],
+            "display_symbol": ["CAR (XD)"],
+            "close": [10.3],
+        }
+    )
+
+    canonical, _fmt = normalize_data(raw, source="demo", dataset_id="dataset-preserve-2")
+    row = canonical.iloc[0]
+
+    assert row["ticker"] == "CAR"
+    assert row["instrument"] == "CAR"
+    assert row["raw_symbol"] == "CAR (XD)"
+    assert row["symbol_marker"] == "XD"
+    assert row["display_symbol"] == "CAR (XD)"
+
+
+def test_normalize_data_keeps_canonical_universe_collapsed_when_raw_metadata_varies():
+    raw = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"],
+            "instrument": ["CAR", "CAR", "CAR", "CAR"],
+            "raw_symbol": ["CAR", "CARXD", "CAR (XD)", "CAR XD"],
+            "symbol_marker": [None, "XD", "XD", "XD"],
+            "display_symbol": ["CAR", "CARXD", "CAR (XD)", "CAR XD"],
+            "close": [10.0, 10.1, 10.2, 10.3],
+        }
+    )
+
+    canonical, _fmt = normalize_data(raw, source="demo", dataset_id="dataset-preserve-3")
+
+    assert set(canonical["ticker"]) == {"CAR"}
+    assert set(canonical["instrument"]) == {"CAR"}
+    assert canonical["raw_symbol"].nunique() == 4
+    assert canonical["display_symbol"].tolist() == ["CAR", "CARXD", "CAR (XD)", "CAR XD"]


### PR DESCRIPTION
### Motivation
- The live dashboard was showing temporary markers like `XD` because long-format normalization rebuilt `raw_symbol`/`symbol_marker`/`display_symbol` from canonical `instrument`/`ticker` rather than preserving original provenance. 
- Re-deriving display/raw metadata during normalization risks leaking marker text into canonical grouping, dropdowns, ranking, and portfolio logic. 
- The intent is to preserve source-provided raw/display metadata while keeping canonical `ticker`/`instrument` stable.

### Description
- Added `display_symbol` to the canonical schema and output so display metadata survives normalization (`app/data/schema.py`).
- In `_normalize_long` the code now preserves input `raw_symbol`, `symbol_marker`, and `display_symbol` when those columns are present and non-empty, and only falls back to derivation from canonicalized parts when fields are missing or empty (`app/data/normalize.py`).
- Wide-format normalization now sets `display_symbol` from `raw_symbol` so display metadata is consistently present (`app/data/normalize.py`).
- Canonical contract remains unchanged: `ticker` and `instrument` are derived from canonical parts and continue to drive dropdowns, drilldown grouping, ranking, and portfolio logic (raw/display fields are only for presentation).

### Testing
- Added/updated tests in `tests/test_ingestion.py` covering preservation of existing long-format `raw_symbol`/`symbol_marker`/`display_symbol`, that `CAR (XD)` preserves raw metadata while `ticker/instrument` remain `CAR`, that canonical universe is still collapsed, and that `display_symbol` is present. 
- Ran `pytest -q tests/test_ingestion.py` which returned `17 passed`.
- Ran `pytest -q tests/test_demo_pipeline.py tests/test_app_shell.py` which returned `10 passed`.
- Confirmation: automated tests passed and manual inspection of the normalization logic shows raw symbol metadata is preserved and `XD` no longer leaks into canonical behavior; canonical `ticker`/`instrument` remain authoritative for app logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc033c48e88322a22a8c819716c5b4)