### PR TITLE
Harden nullable symbol metadata fallback in long-format normalization

### DIFF
--- a/app/data/normalize.py
+++ b/app/data/normalize.py
@@ -21,6 +21,18 @@ def detect_format(df: pd.DataFrame) -> str:
     raise ValueError("Unable to detect input format.")
 
 
+
+
+def _normalize_optional_symbol_metadata(
+    series: pd.Series, fallback: pd.Series
+) -> pd.Series:
+    """Normalize optional symbol metadata with robust missing-value fallback."""
+    normalized = series.astype("string").str.strip().str.upper()
+    missing_mask = series.isna() | normalized.isin({"", "NAN", "NONE", "<NA>"})
+    preserved = normalized.mask(missing_mask, fallback)
+    return preserved.astype(object).where(pd.notna(preserved), None)
+
+
 def _normalize_long(df: pd.DataFrame, source: str, dataset_id: str) -> pd.DataFrame:
     """Normalize long-format input into canonical schema."""
     cols = {col.lower(): col for col in df.columns}
@@ -45,26 +57,23 @@ def _normalize_long(df: pd.DataFrame, source: str, dataset_id: str) -> pd.DataFr
     fallback_raw_symbol = symbol_parts.map(lambda parts: parts[2])
 
     if "raw_symbol" in cols:
-        preserved_raw_symbol = df[cols["raw_symbol"]].astype(str).str.strip().str.upper()
-        data["raw_symbol"] = preserved_raw_symbol.mask(
-            preserved_raw_symbol.isin({"", "NAN", "NONE"}), fallback_raw_symbol
+        data["raw_symbol"] = _normalize_optional_symbol_metadata(
+            df[cols["raw_symbol"]], fallback_raw_symbol
         )
     else:
         data["raw_symbol"] = fallback_raw_symbol
 
+    fallback_marker = data["raw_symbol"].map(lambda symbol: canonicalize_symbol_parts(symbol)[1])
     if "symbol_marker" in cols:
-        preserved_marker = df[cols["symbol_marker"]].astype(str).str.strip().str.upper()
-        fallback_marker = data["raw_symbol"].map(lambda symbol: canonicalize_symbol_parts(symbol)[1])
-        data["symbol_marker"] = preserved_marker.mask(
-            preserved_marker.isin({"", "NAN", "NONE"}), fallback_marker
+        data["symbol_marker"] = _normalize_optional_symbol_metadata(
+            df[cols["symbol_marker"]], fallback_marker
         )
     else:
-        data["symbol_marker"] = data["raw_symbol"].map(lambda symbol: canonicalize_symbol_parts(symbol)[1])
+        data["symbol_marker"] = fallback_marker
 
     if "display_symbol" in cols:
-        preserved_display_symbol = df[cols["display_symbol"]].astype(str).str.strip().str.upper()
-        data["display_symbol"] = preserved_display_symbol.mask(
-            preserved_display_symbol.isin({"", "NAN", "NONE"}), data["raw_symbol"]
+        data["display_symbol"] = _normalize_optional_symbol_metadata(
+            df[cols["display_symbol"]], data["raw_symbol"]
         )
     else:
         data["display_symbol"] = data["raw_symbol"]

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -295,6 +295,56 @@ def test_normalize_data_preserves_parenthesized_xd_metadata_with_canonical_ticke
     assert row["display_symbol"] == "CAR (XD)"
 
 
+
+
+def test_normalize_data_nullable_string_raw_symbol_na_falls_back_to_canonical_metadata():
+    raw = pd.DataFrame(
+        {
+            "date": ["2024-01-01"],
+            "instrument": ["CAR (XD)"],
+            "raw_symbol": pd.Series([pd.NA], dtype="string"),
+            "symbol_marker": pd.Series([pd.NA], dtype="string"),
+            "display_symbol": pd.Series([pd.NA], dtype="string"),
+            "close": [10.3],
+        }
+    )
+
+    canonical, fmt = normalize_data(raw, source="demo", dataset_id="dataset-preserve-nullable")
+    row = canonical.iloc[0]
+
+    assert fmt == "long"
+    assert row["ticker"] == "CAR"
+    assert row["instrument"] == "CAR"
+    assert row["raw_symbol"] == "CAR (XD)"
+    assert row["symbol_marker"] == "XD"
+    assert row["display_symbol"] == "CAR (XD)"
+
+
+def test_normalize_data_string_missing_tokens_fall_back_for_optional_symbol_metadata():
+    raw = pd.DataFrame(
+        {
+            "date": [
+                "2024-01-01",
+                "2024-01-02",
+                "2024-01-03",
+                "2024-01-04",
+            ],
+            "instrument": ["CAR (XD)", "CAR (XD)", "CAR (XD)", "CAR (XD)"],
+            "raw_symbol": ["", "nan", "none", "<NA>"],
+            "symbol_marker": ["", "nan", "none", "<NA>"],
+            "display_symbol": ["", "nan", "none", "<NA>"],
+            "close": [10.3, 10.4, 10.5, 10.6],
+        }
+    )
+
+    canonical, _fmt = normalize_data(raw, source="demo", dataset_id="dataset-preserve-missing-tokens")
+
+    assert set(canonical["ticker"]) == {"CAR"}
+    assert set(canonical["instrument"]) == {"CAR"}
+    assert canonical["raw_symbol"].tolist() == ["CAR (XD)", "CAR (XD)", "CAR (XD)", "CAR (XD)"]
+    assert canonical["symbol_marker"].tolist() == ["XD", "XD", "XD", "XD"]
+    assert canonical["display_symbol"].tolist() == ["CAR (XD)", "CAR (XD)", "CAR (XD)", "CAR (XD)"]
+
 def test_normalize_data_keeps_canonical_universe_collapsed_when_raw_metadata_varies():
     raw = pd.DataFrame(
         {


### PR DESCRIPTION
### Motivation
- Nullable pandas string inputs could produce the literal token `"<NA>"` (or other null-like tokens) after string conversion, causing upstream `raw_symbol`/`symbol_marker`/`display_symbol` preservation logic to treat missing values as present and corrupt canonical metadata.
- Make the new metadata-preservation behavior robust by detecting missing values safely for pandas `StringDtype` and falling back to canonicalized values only when incoming metadata is truly non-empty.

### Description
- Added helper `_normalize_optional_symbol_metadata(series, fallback)` in `app/data/normalize.py` to centralize robust missing-value detection and fallback behavior for optional symbol metadata.
- Exact null-handling logic added: convert candidate values with `series.astype("string").str.strip().str.upper()`, treat a value as missing when `series.isna()` (covers `None`/`pd.NA`/`NaN`) OR the normalized string is in the set `{"", "NAN", "NONE", "<NA>"}`, then use the provided `fallback` when missing, and convert pandas NA-style values to Python `None` for stable downstream behavior.
- Applied the helper to long-format normalization for `raw_symbol`, `symbol_marker`, and `display_symbol`; computed `fallback_raw_symbol` from `canonicalize_symbol_parts(...)` as before and `fallback_marker` from the normalized `raw_symbol` so canonical fallback behavior is preserved.
- No changes to wide-format normalization behavior; existing canonicalization-derived fallbacks remain unchanged.

### Testing
- Added tests in `tests/test_ingestion.py`: `test_normalize_data_nullable_string_raw_symbol_na_falls_back_to_canonical_metadata` (covers `pd.NA` with `StringDtype`) and `test_normalize_data_string_missing_tokens_fall_back_for_optional_symbol_metadata` (covers `""`, `"nan"`, `"none"`, `"<NA>"`).
- Commands run: `pytest -q tests/test_ingestion.py -k 'preserves_existing_raw_symbol_metadata_in_long_format or nullable_string_raw_symbol_na or missing_tokens_fall_back'` and `pytest -q tests/test_ingestion.py`.
- Results: the focused test run passed (3 passed) and the full ingestion test file passed (19 passed). The literal `"<NA>"` token no longer blocks raw-symbol fallback.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc06f3dc048322a0bb357eb93b8636)