### PR TITLE
Add portfolio snapshot & reserved-cash explanations, translation helpers, and UI integration

### DIFF
--- a/app/insights/portfolio_snapshot.py
+++ b/app/insights/portfolio_snapshot.py
@@ -1,0 +1,130 @@
+"""Interpretation-first helpers for portfolio snapshot and reserved cash language."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from app.language.formatter import explain_confidence, explain_strength
+
+
+def build_portfolio_snapshot(
+    allocations: Sequence[Mapping[str, Any]],
+    total_capital: float,
+    *,
+    mode: str = "beginner",
+) -> dict[str, Any]:
+    """Build concise snapshot copy shown before detailed portfolio tables."""
+    candidate_count = len(allocations)
+    funded_count = sum(
+        1 for trade in allocations if float(trade.get("allocation_amount", 0.0) or 0.0) > 0
+    )
+    strong_candidates = sum(1 for trade in allocations if _is_stronger_setup(trade))
+    funded_strong = sum(
+        1
+        for trade in allocations
+        if float(trade.get("allocation_amount", 0.0) or 0.0) > 0 and _is_stronger_setup(trade)
+    )
+
+    safe_capital = float(total_capital or 0.0)
+    allocated_amount = round(
+        sum(float(trade.get("allocation_amount", 0.0) or 0.0) for trade in allocations),
+        2,
+    )
+    reserve_ratio = round((safe_capital - allocated_amount) / safe_capital, 4) if safe_capital > 0 else 0.0
+
+    lines = [
+        f"The system found {candidate_count} possible trade{'s' if candidate_count != 1 else ''}.",
+        f"{funded_count} trade{'s' if funded_count != 1 else ''} were funded from this set.",
+        _build_strength_line(funded_count=funded_count, strong_candidates=strong_candidates, funded_strong=funded_strong),
+    ]
+    lines.append(_build_translation_support_line(mode=mode))
+
+    if reserve_ratio > 0:
+        lines.append("Some cash is being held back intentionally when strong opportunities are limited.")
+    else:
+        lines.append("Most available cash is currently deployed across funded trades.")
+
+    analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
+    if analyst_mode:
+        lines.append(
+            f"Context: funded {funded_count}/{candidate_count}; reserve ratio {reserve_ratio:.0%}."
+        )
+
+    return {
+        "title": "Portfolio Snapshot",
+        "lines": lines,
+        "candidate_count": candidate_count,
+        "funded_count": funded_count,
+        "reserve_ratio": reserve_ratio,
+        "strong_candidates": strong_candidates,
+        "funded_strong": funded_strong,
+    }
+
+
+def build_reserved_cash_explanation(
+    allocations: Sequence[Mapping[str, Any]],
+    total_capital: float,
+    *,
+    mode: str = "beginner",
+) -> dict[str, Any]:
+    """Explain why portfolio cash may remain unallocated."""
+    safe_capital = float(total_capital or 0.0)
+    funded_count = sum(
+        1 for trade in allocations if float(trade.get("allocation_amount", 0.0) or 0.0) > 0
+    )
+    unfunded_count = max(len(allocations) - funded_count, 0)
+    allocated_amount = round(
+        sum(float(trade.get("allocation_amount", 0.0) or 0.0) for trade in allocations),
+        2,
+    )
+    reserve_amount = round(safe_capital - allocated_amount, 2)
+    reserve_ratio = round(reserve_amount / safe_capital, 4) if safe_capital > 0 else 0.0
+
+    if reserve_ratio <= 0:
+        reason = "Little or no cash is reserved because available capital is already allocated."
+    elif funded_count == 0 and len(allocations) > 0:
+        reason = "Cash is being held back because current setups did not clear funding conditions."
+    elif reserve_ratio >= 0.4 and unfunded_count > 0:
+        reason = "Cash is reserved because stronger risk controls are active while market conditions are mixed."
+    elif unfunded_count > 0:
+        reason = "Cash is being held back because only part of the candidate list met stronger setup conditions."
+    else:
+        reason = "Cash remains reserved to avoid forcing trades when high-quality opportunities are limited."
+
+    lines = [reason]
+    analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
+    if analyst_mode and reserve_ratio > 0:
+        lines.append(
+            f"Reserve context: {reserve_ratio:.0%} unallocated ({reserve_amount:,.2f}) with {funded_count} funded and {unfunded_count} unfunded."
+        )
+
+    return {
+        "title": "Why cash is reserved",
+        "lines": lines,
+        "reserve_ratio": reserve_ratio,
+        "reserve_amount": reserve_amount,
+        "funded_count": funded_count,
+        "unfunded_count": unfunded_count,
+    }
+
+
+def _is_stronger_setup(trade: Mapping[str, Any]) -> bool:
+    tier = str(trade.get("quality_tier", "")).strip().upper()
+    confidence = str(trade.get("confidence_label", "")).strip().lower()
+    return tier == "A" or confidence == "strong"
+
+
+def _build_strength_line(*, funded_count: int, strong_candidates: int, funded_strong: int) -> str:
+    if funded_count <= 0:
+        return "No setups were funded, so stronger-priority filters are blocking this round."
+    if funded_strong == funded_count and funded_count > 0:
+        return "Funded trades are dominated by stronger setups."
+    if strong_candidates > funded_strong:
+        return "Stronger setups are being prioritized, with some lower-strength trades left unfunded."
+    return "Setup strength is mixed across funded trades in this run."
+
+
+def _build_translation_support_line(*, mode: str) -> str:
+    strength_line = explain_strength("A", mode=mode)
+    confidence_line = explain_confidence("high", mode=mode)
+    return f"{strength_line} {confidence_line}"

--- a/app/language/formatter.py
+++ b/app/language/formatter.py
@@ -19,6 +19,52 @@ def get_strength_label(tier: Any) -> str:
     return STRENGTH_LABELS.get(token, "Unrated setup")
 
 
+def explain_strength(tier: Any, mode: str = "beginner") -> str:
+    """Translate quality tier labels into plain-language setup meaning."""
+    token = str(tier or "").strip().upper()
+    analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
+
+    if token == "A":
+        if analyst_mode:
+            return "Strong setup (Tier A) — more key conditions are aligned and quality is higher."
+        return "Strong setup — more key conditions are aligned."
+    if token == "B":
+        if analyst_mode:
+            return "Mixed setup (Tier B) — supportive signals are present, but quality is not fully aligned."
+        return "Mixed setup — some conditions are supportive, and some are weaker."
+    if token == "C":
+        if analyst_mode:
+            return "Weak setup (Tier C) — fewer quality conditions are aligned, so risk is higher."
+        return "Weak setup — quality is lower and risk is higher."
+
+    if analyst_mode:
+        return "Unrated setup — tier data is limited for this row."
+    return "Unrated setup — this row has limited setup detail."
+
+
+def explain_confidence(value_or_label: Any, mode: str = "beginner") -> str:
+    """Translate confidence labels into non-predictive reliability language."""
+    token = str(value_or_label or "").strip().lower()
+    analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
+
+    if token in {"high", "strong"}:
+        if analyst_mode:
+            return "High confidence — similar setups have shown more reliable behavior in past observations."
+        return "High confidence — similar setups have behaved more reliably in the past."
+    if token in {"medium", "moderate", "mixed"}:
+        if analyst_mode:
+            return "Medium confidence — historical reliability is mixed across similar setups."
+        return "Medium confidence — history is mixed for similar setups."
+    if token in {"low", "weak", "high risk"}:
+        if analyst_mode:
+            return "Low confidence — similar setups have shown less reliable outcomes in historical samples."
+        return "Low confidence — outcomes have been less reliable in similar setups."
+
+    if analyst_mode:
+        return "Confidence is unclear — the reliability signal is limited in this row."
+    return "Confidence is unclear — this row has limited reliability detail."
+
+
 def format_beginner_explanation(signal_or_row: Mapping[str, Any]) -> str:
     strength = get_strength_label(signal_or_row.get("quality_tier"))
     risk_line = _risk_sentence(signal_or_row)

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -6,7 +6,15 @@ from typing import Any, Mapping, Sequence
 
 import pandas as pd
 
-from app.language.formatter import generate_explanation
+from app.language.formatter import (
+    explain_confidence,
+    explain_strength,
+    generate_explanation,
+)
+from app.insights.portfolio_snapshot import (
+    build_portfolio_snapshot,
+    build_reserved_cash_explanation,
+)
 from app.planner.decision_review import (
     build_behavior_summary,
     compute_discipline_score,
@@ -116,7 +124,22 @@ def render_portfolio_plan(
     summary = build_portfolio_summary(allocations, total_capital)
     funded_trades, unfunded_trades = split_trades_by_funding(allocations)
 
+    def _render_snapshot_blocks() -> None:
+        snapshot = build_portfolio_snapshot(allocations, total_capital, mode=mode)
+        st_module.markdown("#### Portfolio Snapshot")
+        for line in snapshot["lines"]:
+            st_module.markdown(f"- {line}")
+
+        reserved_cash = build_reserved_cash_explanation(allocations, total_capital, mode=mode)
+        if reserved_cash["reserve_ratio"] > 0:
+            st_module.markdown("#### Why cash is reserved")
+            for line in reserved_cash["lines"]:
+                st_module.markdown(f"- {line}")
+
+
     def _render_plan_section() -> None:
+        _render_snapshot_blocks()
+
         st_module.markdown(
             '<div class="jse-card"><div class="jse-eyebrow">Portfolio Summary</div><p style="margin:0;" class="jse-muted">Funding view of current eligible setups and reserve coverage.</p></div>',
             unsafe_allow_html=True,
@@ -141,8 +164,8 @@ def render_portfolio_plan(
                 [
                     {
                         "Instrument": trade.get("instrument", "Unknown"),
-                        "Setup Strength": trade.get("quality_tier", "N/A"),
-                        "Confidence": trade.get("confidence_label", "N/A"),
+                        "Setup Strength": explain_strength(trade.get("quality_tier"), mode=mode),
+                        "Confidence": explain_confidence(trade.get("confidence_label"), mode=mode),
                         **({"Allocation %": trade.get("allocation_pct", 0.0)} if analyst_mode else {}),
                         "Allocation Amount": trade.get("allocation_amount", 0.0),
                         **({"Selection Rank": trade.get("selection_rank", "N/A")} if analyst_mode else {}),
@@ -163,8 +186,8 @@ def render_portfolio_plan(
                 [
                     {
                         "Instrument": trade.get("instrument", "Unknown"),
-                        "Setup Strength": trade.get("quality_tier", "N/A"),
-                        "Confidence": trade.get("confidence_label", "N/A"),
+                        "Setup Strength": explain_strength(trade.get("quality_tier"), mode=mode),
+                        "Confidence": explain_confidence(trade.get("confidence_label"), mode=mode),
                         **({"Selection Rank": trade.get("selection_rank", "N/A")} if analyst_mode else {}),
                         "Decision Status": classify_decision_status(trade),
                         "Why": resolve_unfunded_reason(trade),

--- a/tests/test_portfolio_snapshot.py
+++ b/tests/test_portfolio_snapshot.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.insights.portfolio_snapshot import build_portfolio_snapshot, build_reserved_cash_explanation
+from app.language.formatter import contains_advisory_language
+
+
+def test_snapshot_contains_required_interpretation_sections():
+    snapshot = build_portfolio_snapshot(
+        [
+            {"allocation_amount": 3_000, "quality_tier": "A", "confidence_label": "strong"},
+            {"allocation_amount": 0, "quality_tier": "B", "confidence_label": "medium"},
+        ],
+        10_000,
+        mode="beginner",
+    )
+
+    blob = " ".join(snapshot["lines"])
+    assert snapshot["title"] == "Portfolio Snapshot"
+    assert "found 2 possible trades" in blob.lower()
+    assert "were funded" in blob.lower()
+    assert "stronger" in blob.lower()
+    assert "cash" in blob.lower()
+
+
+def test_reserved_cash_explanation_appears_when_capital_is_held_back():
+    explanation = build_reserved_cash_explanation(
+        [
+            {"allocation_amount": 3_000, "quality_tier": "A"},
+            {"allocation_amount": 0, "quality_tier": "B"},
+        ],
+        10_000,
+        mode="beginner",
+    )
+
+    assert explanation["reserve_ratio"] > 0
+    assert explanation["title"] == "Why cash is reserved"
+    assert any("cash" in line.lower() for line in explanation["lines"])
+
+
+def test_beginner_vs_analyst_snapshot_behavior_differs_with_context_line():
+    beginner_snapshot = build_portfolio_snapshot(
+        [{"allocation_amount": 2_000, "quality_tier": "A"}], 10_000, mode="beginner"
+    )
+    analyst_snapshot = build_portfolio_snapshot(
+        [{"allocation_amount": 2_000, "quality_tier": "A"}], 10_000, mode="analyst"
+    )
+
+    assert len(analyst_snapshot["lines"]) > len(beginner_snapshot["lines"])
+    assert any("reserve ratio" in line.lower() for line in analyst_snapshot["lines"])
+    assert all("reserve ratio" not in line.lower() for line in beginner_snapshot["lines"])
+
+
+def test_snapshot_and_reserved_cash_copy_has_no_advisory_language():
+    snapshot = build_portfolio_snapshot(
+        [{"allocation_amount": 2_000, "quality_tier": "A"}, {"allocation_amount": 0, "quality_tier": "C"}],
+        10_000,
+        mode="analyst",
+    )
+    reserved_cash = build_reserved_cash_explanation(
+        [{"allocation_amount": 2_000, "quality_tier": "A"}, {"allocation_amount": 0, "quality_tier": "C"}],
+        10_000,
+        mode="analyst",
+    )
+
+    combined = " ".join(snapshot["lines"] + reserved_cash["lines"])
+    assert contains_advisory_language(combined) is False

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -77,6 +77,8 @@ def test_render_portfolio_plan_uses_why_column_and_no_primary_rule_column():
     assert "Why" in funded_df.columns
     assert "Why" in unfunded_df.columns
     assert "Setup Strength" in funded_df.columns
+    assert "Strong setup" in funded_df.iloc[0]["Setup Strength"]
+    assert "High confidence" in funded_df.iloc[0]["Confidence"]
     assert "Primary Rule/Constraint" not in funded_df.columns
     assert "Primary Rule/Constraint" not in unfunded_df.columns
     assert funded_df.iloc[0]["Decision Status"] == "Selected"
@@ -98,3 +100,41 @@ def test_group_mistakes_for_display_combines_repeated_types():
 
     assert "3 trade(s) missed the setup-quality rule." in grouped
     assert "1 trade(s) failed the liquidity check." in grouped
+
+
+def test_render_portfolio_plan_places_snapshot_and_reserved_cash_before_tables():
+    st = DummyStreamlit()
+    render_portfolio_plan(
+        allocations=[
+            {
+                "instrument": "AAA",
+                "allocation_amount": 2000,
+                "allocation_pct": 0.2,
+                "quality_tier": "A",
+                "confidence_label": "strong",
+                "selection_rank": 1,
+            },
+            {
+                "instrument": "BBB",
+                "allocation_amount": 0,
+                "allocation_pct": 0.0,
+                "quality_tier": "B",
+                "confidence_label": "medium",
+                "selection_rank": 4,
+                "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
+            },
+        ],
+        total_capital=10_000,
+        st_module=st,
+        section="plan",
+    )
+
+    assert "#### Portfolio Snapshot" in st.markdowns
+    assert "#### Why cash is reserved" in st.markdowns
+    snapshot_idx = st.markdowns.index("#### Portfolio Snapshot")
+    summary_idx = next(
+        idx
+        for idx, text in enumerate(st.markdowns)
+        if "Portfolio Summary" in text
+    )
+    assert snapshot_idx < summary_idx

--- a/tests/test_translation_layer.py
+++ b/tests/test_translation_layer.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.language.formatter import contains_advisory_language, explain_confidence, explain_strength
+
+
+def test_beginner_translation_is_simple_and_jargon_light():
+    strength = explain_strength("A", mode="beginner")
+    confidence = explain_confidence("strong", mode="beginner")
+
+    assert "Tier" not in strength
+    assert "Strong setup" in strength
+    assert "High confidence" in confidence
+
+
+def test_analyst_translation_is_more_precise_than_beginner():
+    beginner_strength = explain_strength("B", mode="beginner")
+    analyst_strength = explain_strength("B", mode="analyst")
+    beginner_confidence = explain_confidence("medium", mode="beginner")
+    analyst_confidence = explain_confidence("medium", mode="analyst")
+
+    assert "Tier B" in analyst_strength
+    assert "Tier B" not in beginner_strength
+    assert "historical reliability" in analyst_confidence
+    assert "historical reliability" not in beginner_confidence
+
+
+def test_confidence_wording_remains_non_predictive():
+    low = explain_confidence("low", mode="beginner").lower()
+    high = explain_confidence("high", mode="analyst").lower()
+
+    assert "will" not in low
+    assert "will" not in high
+    assert "guarantee" not in low
+    assert "guarantee" not in high
+
+
+def test_translation_helpers_avoid_advisory_language():
+    blob = " ".join(
+        [
+            explain_strength("A", mode="beginner"),
+            explain_strength("C", mode="analyst"),
+            explain_confidence("strong", mode="beginner"),
+            explain_confidence("weak", mode="analyst"),
+        ]
+    )
+    assert contains_advisory_language(blob) is False


### PR DESCRIPTION
### Motivation
- Provide interpretation-first copy for portfolio outputs so users see concise snapshot and reasons cash is reserved.
- Introduce a translation layer to convert quality tiers and confidence labels into plain-language beginner/analyst text while avoiding advisory wording.
- Surface these explanations in the UI and replace raw tier/confidence cells with human-friendly phrases.

### Description
- Add `app.insights.portfolio_snapshot` with `build_portfolio_snapshot` and `build_reserved_cash_explanation` to compute counts, reserve ratios, and short explanation lines (including analyst-mode context). 
- Extend `app.language.formatter` with `explain_strength` and `explain_confidence` to emit mode-aware, non-advisory wording for tiers and confidence labels. 
- Integrate the new snapshot and reserved-cash blocks into `app.planner.portfolio_ui.render_portfolio_plan`, render them before portfolio tables, and replace raw `quality_tier`/`confidence_label` cells with `explain_strength`/`explain_confidence` outputs. 
- Add helpers and tests to ensure beginner vs analyst wording differences and that generated copy avoids advisory language.

### Testing
- Added and ran `tests/test_portfolio_snapshot.py` which validates snapshot contents, reserved-cash logic, and analyst-mode context; tests passed. 
- Added and ran `tests/test_translation_layer.py` which verifies `explain_strength`/`explain_confidence` behavior and lack of advisory language; tests passed. 
- Updated `tests/test_portfolio_ui.py` to assert snapshot/reserved-cash render order and translated cells in the UI; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc13d5faec83228aff978af73d7fef)