### PR TITLE
Fix Sprint 13 portfolio snapshot to reflect funded setup and confidence mix

### DIFF
--- a/app/insights/portfolio_snapshot.py
+++ b/app/insights/portfolio_snapshot.py
@@ -14,16 +14,12 @@ def build_portfolio_snapshot(
     mode: str = "beginner",
 ) -> dict[str, Any]:
     """Build concise snapshot copy shown before detailed portfolio tables."""
+    analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
     candidate_count = len(allocations)
-    funded_count = sum(
-        1 for trade in allocations if float(trade.get("allocation_amount", 0.0) or 0.0) > 0
-    )
+    funded_trades = [trade for trade in allocations if float(trade.get("allocation_amount", 0.0) or 0.0) > 0]
+    funded_count = len(funded_trades)
     strong_candidates = sum(1 for trade in allocations if _is_stronger_setup(trade))
-    funded_strong = sum(
-        1
-        for trade in allocations
-        if float(trade.get("allocation_amount", 0.0) or 0.0) > 0 and _is_stronger_setup(trade)
-    )
+    funded_strong = sum(1 for trade in funded_trades if _is_stronger_setup(trade))
 
     safe_capital = float(total_capital or 0.0)
     allocated_amount = round(
@@ -35,16 +31,23 @@ def build_portfolio_snapshot(
     lines = [
         f"The system found {candidate_count} possible trade{'s' if candidate_count != 1 else ''}.",
         f"{funded_count} trade{'s' if funded_count != 1 else ''} were funded from this set.",
-        _build_strength_line(funded_count=funded_count, strong_candidates=strong_candidates, funded_strong=funded_strong),
+        _build_strength_line(
+            funded_count=funded_count,
+            strong_candidates=strong_candidates,
+            funded_strong=funded_strong,
+            mode=mode,
+        ),
     ]
-    lines.append(_build_translation_support_line(mode=mode))
+    confidence_line = _build_confidence_line(funded_trades=funded_trades, mode=mode)
+    if confidence_line:
+        lines.append(confidence_line)
+    lines.append(_build_glossary_support_line(mode=mode))
 
     if reserve_ratio > 0:
         lines.append("Some cash is being held back intentionally when strong opportunities are limited.")
     else:
         lines.append("Most available cash is currently deployed across funded trades.")
 
-    analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
     if analyst_mode:
         lines.append(
             f"Context: funded {funded_count}/{candidate_count}; reserve ratio {reserve_ratio:.0%}."
@@ -114,17 +117,81 @@ def _is_stronger_setup(trade: Mapping[str, Any]) -> bool:
     return tier == "A" or confidence == "strong"
 
 
-def _build_strength_line(*, funded_count: int, strong_candidates: int, funded_strong: int) -> str:
+def _build_strength_line(
+    *,
+    funded_count: int,
+    strong_candidates: int,
+    funded_strong: int,
+    mode: str,
+) -> str:
+    analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
+
     if funded_count <= 0:
-        return "No setups were funded, so stronger-priority filters are blocking this round."
-    if funded_strong == funded_count and funded_count > 0:
-        return "Funded trades are dominated by stronger setups."
+        if analyst_mode:
+            return "No trades were funded in the current portfolio, so no strong setups cleared funding conditions this round."
+        return "No trades were funded right now because no strong setups cleared the funding rules."
+
+    strong_ratio = funded_strong / funded_count
+    if strong_ratio >= 0.6:
+        if analyst_mode:
+            return f"Current funded setup mix is strong: {funded_strong}/{funded_count} funded trades are Tier A or strong-confidence setups."
+        return "Current funded setup mix is strong, with most funded trades in higher-quality setups."
+
+    if strong_ratio >= 0.25:
+        if analyst_mode:
+            return f"Current funded setup mix is constructive but mixed: {funded_strong}/{funded_count} funded trades are stronger-quality and the rest are moderate quality."
+        return "Current funded setup mix is mixed but still constructive."
+
     if strong_candidates > funded_strong:
-        return "Stronger setups are being prioritized, with some lower-strength trades left unfunded."
-    return "Setup strength is mixed across funded trades in this run."
+        if analyst_mode:
+            return "Current funded setup mix is cautious: fewer stronger-quality setups were funded while stronger candidates remained limited."
+        return "Current funded setup mix is weaker and more cautious."
+
+    if analyst_mode:
+        return "Current funded setup mix is weaker overall, with mostly lower-quality funded setups."
+    return "Current funded setup mix is weaker overall, so caution is higher."
 
 
-def _build_translation_support_line(*, mode: str) -> str:
+def _build_confidence_line(*, funded_trades: Sequence[Mapping[str, Any]], mode: str) -> str | None:
+    analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
+    if not funded_trades:
+        return None
+
+    labels = [str(trade.get("confidence_label", "")).strip().lower() for trade in funded_trades]
+    known = [label for label in labels if label]
+    if not known:
+        return "Confidence detail is limited for the currently funded portfolio."
+
+    high_count = sum(1 for label in known if label in {"high", "strong"})
+    medium_count = sum(1 for label in known if label in {"medium", "moderate", "mixed"})
+    low_count = sum(1 for label in known if label in {"low", "weak", "high risk"})
+
+    coverage = len(known)
+    high_ratio = high_count / coverage
+    low_ratio = low_count / coverage
+
+    if high_ratio >= 0.6:
+        if analyst_mode:
+            return f"Current funded confidence mix is high/reliable in most rows ({high_count}/{coverage} high-confidence labels)."
+        return "Current funded confidence is mostly high and historically more reliable."
+
+    if low_ratio >= 0.6:
+        if analyst_mode:
+            return f"Current funded confidence mix is low in most rows ({low_count}/{coverage} low-confidence labels)."
+        return "Current funded confidence is mostly low, so reliability is weaker."
+
+    if medium_count > 0 or (high_count > 0 and low_count > 0):
+        if analyst_mode:
+            return (
+                "Current funded confidence mix is medium/mixed "
+                f"({high_count} high, {medium_count} medium, {low_count} low across {coverage} funded labels)."
+            )
+        return "Current funded confidence is mixed across the funded portfolio."
+
+    return "Confidence detail is limited for the currently funded portfolio."
+
+
+def _build_glossary_support_line(*, mode: str) -> str:
     strength_line = explain_strength("A", mode=mode)
     confidence_line = explain_confidence("high", mode=mode)
-    return f"{strength_line} {confidence_line}"
+    return f"How to read setup strength and confidence: Example glossary only — {strength_line} {confidence_line}"

--- a/tests/test_portfolio_snapshot.py
+++ b/tests/test_portfolio_snapshot.py
@@ -22,7 +22,9 @@ def test_snapshot_contains_required_interpretation_sections():
     assert snapshot["title"] == "Portfolio Snapshot"
     assert "found 2 possible trades" in blob.lower()
     assert "were funded" in blob.lower()
-    assert "stronger" in blob.lower()
+    assert "current funded setup mix" in blob.lower()
+    assert "current funded confidence" in blob.lower()
+    assert "example glossary only" in blob.lower()
     assert "cash" in blob.lower()
 
 
@@ -68,3 +70,64 @@ def test_snapshot_and_reserved_cash_copy_has_no_advisory_language():
 
     combined = " ".join(snapshot["lines"] + reserved_cash["lines"])
     assert contains_advisory_language(combined) is False
+
+
+def test_snapshot_strong_funded_portfolio_is_data_driven_not_hardcoded():
+    snapshot = build_portfolio_snapshot(
+        [
+            {"allocation_amount": 3_000, "quality_tier": "A", "confidence_label": "high"},
+            {"allocation_amount": 2_000, "quality_tier": "A", "confidence_label": "strong"},
+            {"allocation_amount": 1_500, "quality_tier": "B", "confidence_label": "high"},
+        ],
+        10_000,
+        mode="analyst",
+    )
+
+    blob = " ".join(snapshot["lines"]).lower()
+    assert "current funded setup mix is strong" in blob
+    assert "current funded confidence mix is high/reliable" in blob
+
+
+def test_snapshot_mixed_funded_portfolio_uses_mixed_language():
+    snapshot = build_portfolio_snapshot(
+        [
+            {"allocation_amount": 3_000, "quality_tier": "A", "confidence_label": "high"},
+            {"allocation_amount": 2_500, "quality_tier": "B", "confidence_label": "medium"},
+            {"allocation_amount": 1_500, "quality_tier": "C", "confidence_label": "low"},
+        ],
+        10_000,
+        mode="beginner",
+    )
+
+    blob = " ".join(snapshot["lines"]).lower()
+    assert "mixed but still constructive" in blob
+    assert "current funded confidence is mixed" in blob
+    assert "high confidence" not in blob or "example glossary only" in blob
+
+
+def test_snapshot_unfunded_portfolio_does_not_claim_strong_or_high_confidence():
+    snapshot = build_portfolio_snapshot(
+        [
+            {"allocation_amount": 0, "quality_tier": "B", "confidence_label": "medium"},
+            {"allocation_amount": 0, "quality_tier": "C", "confidence_label": "low"},
+        ],
+        10_000,
+        mode="beginner",
+    )
+
+    blob = " ".join(snapshot["lines"]).lower()
+    assert "no trades were funded" in blob
+    assert "current funded confidence is mostly high" not in blob
+    assert "current funded confidence mix is high/reliable" not in blob
+
+
+def test_snapshot_glossary_text_is_clearly_separated_from_live_interpretation():
+    snapshot = build_portfolio_snapshot(
+        [
+            {"allocation_amount": 2_000, "quality_tier": "C", "confidence_label": "low"},
+        ],
+        10_000,
+        mode="analyst",
+    )
+
+    assert any(line.startswith("How to read setup strength and confidence:") for line in snapshot["lines"])


### PR DESCRIPTION
### Motivation
- The snapshot previously emitted a hardcoded example translation (`Tier A` / `high` confidence) which could be misleading when the actual funded portfolio was mixed, weak, or unfunded. 
- The goal is to make the snapshot copy reflect the actual funded/current allocations and confidence labels while keeping allocation/ranking math unchanged. 
- Make beginner and analyst modes show the same data-driven interpretation first, with analyst mode optionally adding precision.

### Description
- Files updated: `app/insights/portfolio_snapshot.py` and `tests/test_portfolio_snapshot.py` to move interpretation from hardcoded examples to data-driven funded-mix language.  
- `build_portfolio_snapshot` now derives `funded_trades` from actual `allocation_amount > 0` and passes `funded_strong`/`funded_count` into a new data-driven `_build_strength_line` which handles: no funded trades, strong mix (`strong_ratio >= 0.6`), mixed/constructive (`strong_ratio >= 0.25`), and weaker/cautious mixes, with analyst-mode variants that include counts/ratios.  
- Added `_build_confidence_line` which computes a distribution over funded `confidence_label` values and returns data-driven sentences: high (`high_ratio >= 0.6`), low (`low_ratio >= 0.6`), mixed/medium, or a clear message when confidence detail is limited; it omits a confidence sentence when no funded trades exist.  
- Separated the educational glossary from live interpretation into `_build_glossary_support_line` which is clearly labeled `How to read setup strength and confidence: Example glossary only — ...`, ensuring glossary text cannot be mistaken for the portfolio’s current-state interpretation.  
- No changes to allocation math, ranking logic, or confidence scoring were made; this change affects interpretation/copy only.

### Testing
- Tests added/updated in `tests/test_portfolio_snapshot.py` to cover: strong-funded portfolio (data-driven strong + high confidence), mixed-funded portfolio (uses mixed language, not defaults), unfunded portfolio (does not claim strong/high), glossary separation, and preserved non-advisory language.  
- Exact test commands and results: `pytest -q tests/test_portfolio_snapshot.py` — initial run exposed and was fixed for a temporary indentation issue; final run: `8 passed in 0.47s`.  
- All added/modified tests passed locally and confirm the snapshot now reports strength and confidence derived from the funded mix and that the glossary is distinct from live interpretation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1a9694588322847fa902d136bf41)