### PR TITLE
Add execution behavior summary to ticker drilldown and refactor portfolio plan table with analyst fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,6 +118,30 @@ def _build_holding_window_table(holding_window_stats: dict[str, dict], *, analys
     return pd.DataFrame(rows)
 
 
+def _build_execution_behavior_lines(
+    *,
+    execution_summary: dict,
+    behavior: dict,
+    stats: dict,
+    analyst_mode: bool,
+) -> list[str]:
+    lines = [
+        f"Entry framing: {execution_summary.get('entry_reference', '')}",
+        f"Exit framing: {execution_summary.get('planned_exit', '')}",
+        f"Typical outcome (median first): {execution_summary.get('typical_outcome', '')}",
+        f"Execution caveats: {execution_summary.get('execution_risk', '')}",
+    ]
+    if analyst_mode:
+        median_return = float(stats.get("median_return", 0.0))
+        avg_return = float(stats.get("avg_return", 0.0))
+        lines.append(
+            "Outcome context: "
+            + behavior.get("consistency", "")
+            + f" (Median: {median_return:.2%}, Average: {avg_return:.2%})."
+        )
+    return lines
+
+
 def _extract_unique_ticker_count(df: pd.DataFrame) -> int:
     """Count unique tickers/instruments from a dataframe."""
     if df.empty:
@@ -365,12 +389,18 @@ def main() -> None:
                 st.markdown("- The average can be lifted by a smaller number of bigger wins.")
 
             execution_summary = ticker_metrics.get("execution", {})
-            st.markdown("#### D) Execution Lens")
-            st.caption("Rule-based execution framing for reference timing, default exit, typical outcome, and practical risks.")
-            st.markdown(f"- Entry reference: {execution_summary.get('entry_reference', '')}")
-            st.markdown(f"- Planned exit: {execution_summary.get('planned_exit', '')}")
-            st.markdown(f"- Typical outcome: {execution_summary.get('typical_outcome', '')}")
-            st.markdown(f"- Execution risk: {execution_summary.get('execution_risk', '')}")
+            st.markdown("#### D) Execution Behavior")
+            if analyst_mode:
+                st.caption("Expanded execution framing with median-first outcome context and practical caveats.")
+            else:
+                st.caption("Short execution framing for entry, exit, typical outcome, and practical caveats.")
+            for line in _build_execution_behavior_lines(
+                execution_summary=execution_summary,
+                behavior=metrics_behavior,
+                stats=metrics_stats,
+                analyst_mode=analyst_mode,
+            ):
+                st.markdown(f"- {line}")
 
             st.markdown("#### E) What Usually Happens")
             st.caption("This section translates recurring behavior seen in the historical sample.")

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -121,6 +121,38 @@ def render_portfolio_plan(
     summary = build_portfolio_summary(allocations, total_capital)
     funded_trades, unfunded_trades = split_trades_by_funding(allocations)
 
+    def _portfolio_plan_row(trade: Mapping[str, Any], *, funded: bool) -> dict[str, Any]:
+        execution = build_execution_summary(trade, mode=mode)
+        row: dict[str, Any] = {
+            "Ticker": trade.get("instrument", "Unknown"),
+            "Setup Strength": explain_strength(trade.get("quality_tier"), mode=mode),
+            "Confidence / Reliability": explain_confidence(trade.get("confidence_label"), mode=mode),
+            "Holding Window": _format_holding_window_label(trade.get("holding_window")),
+            "Why this trade": (
+                explain_trade_reason(trade, mode=mode) if funded else resolve_unfunded_reason(trade)
+            ),
+            "Execution Summary": _compact_execution_summary(execution["summary"]),
+        }
+
+        if analyst_mode:
+            row.update(
+                {
+                    "Decision Status": classify_decision_status(trade),
+                    "Allocation %": trade.get("allocation_pct", 0.0),
+                    "Allocation Amount": trade.get("allocation_amount", 0.0),
+                    "Selection Rank": trade.get("selection_rank", "N/A"),
+                    "Rule Note": explain_funded_trade_why(trade) if funded else "Not funded this cycle.",
+                }
+            )
+        else:
+            row.update(
+                {
+                    "Allocation Amount": trade.get("allocation_amount", 0.0),
+                    "Decision Status": classify_decision_status(trade),
+                }
+            )
+        return row
+
     def _render_snapshot_blocks() -> None:
         snapshot = build_portfolio_snapshot(allocations, total_capital, mode=mode)
         st_module.markdown("#### Portfolio Snapshot")
@@ -157,23 +189,7 @@ def render_portfolio_plan(
 
         st_module.markdown("#### Funded Trades")
         if funded_trades:
-            funded_df = pd.DataFrame(
-                [
-                    {
-                        "Instrument": trade.get("instrument", "Unknown"),
-                        "Setup Strength": explain_strength(trade.get("quality_tier"), mode=mode),
-                        "Confidence": explain_confidence(trade.get("confidence_label"), mode=mode),
-                        **({"Allocation %": trade.get("allocation_pct", 0.0)} if analyst_mode else {}),
-                        "Allocation Amount": trade.get("allocation_amount", 0.0),
-                        **({"Selection Rank": trade.get("selection_rank", "N/A")} if analyst_mode else {}),
-                        "Decision Status": classify_decision_status(trade),
-                        "Why": explain_trade_reason(trade, mode=mode),
-                        "Execution Framework": build_execution_summary(trade, mode=mode)["summary"],
-                        **({"Rule Note": explain_funded_trade_why(trade)} if analyst_mode else {}),
-                    }
-                    for trade in funded_trades
-                ]
-            )
+            funded_df = pd.DataFrame([_portfolio_plan_row(trade, funded=True) for trade in funded_trades])
             st_module.dataframe(funded_df, use_container_width=True)
         else:
             st_module.info("No funded trades for the selected inputs.")
@@ -181,18 +197,7 @@ def render_portfolio_plan(
         st_module.markdown("#### Unfunded Trades")
         if unfunded_trades:
             unfunded_df = pd.DataFrame(
-                [
-                    {
-                        "Instrument": trade.get("instrument", "Unknown"),
-                        "Setup Strength": explain_strength(trade.get("quality_tier"), mode=mode),
-                        "Confidence": explain_confidence(trade.get("confidence_label"), mode=mode),
-                        **({"Selection Rank": trade.get("selection_rank", "N/A")} if analyst_mode else {}),
-                        "Decision Status": classify_decision_status(trade),
-                        "Why": resolve_unfunded_reason(trade),
-                        "Execution Framework": build_execution_summary(trade, mode=mode)["summary"],
-                    }
-                    for trade in unfunded_trades
-                ]
+                [_portfolio_plan_row(trade, funded=False) for trade in unfunded_trades]
             )
             st_module.dataframe(unfunded_df, use_container_width=True)
         else:
@@ -355,3 +360,26 @@ def _first_sentence(text: str) -> str:
     if not sentence:
         return ""
     return f"{sentence}."
+
+
+def _format_holding_window_label(value: Any) -> str:
+    window = _int_or_none(value)
+    if window is None:
+        return "Plan-defined window"
+    return f"~{window} trading days"
+
+
+def _compact_execution_summary(summary: str) -> str:
+    first_sentence = _first_sentence(summary)
+    if first_sentence:
+        return first_sentence
+    return "Execution plan uses reference pricing, time-based exits, and risk checks."
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -549,6 +549,13 @@ def test_ticker_analysis_beginner_mode_hides_raw_deep_dive_tables(monkeypatch):
                 "reliability": "Win rate is mixed.",
                 "tier_profile": "Setup mix leans to A.",
             },
+            "execution": {
+                "entry_reference": "Use the signal-day close as the entry reference area.",
+                "planned_exit": "Default exit is around 5 trading days.",
+                "typical_outcome": "Typical result is centered on median return near 1.00%.",
+                "execution_risk": "Spread conditions can affect realized fills.",
+                "summary": "Entry reference and exit framing are rule-based.",
+            },
         },
     )
     monkeypatch.setattr(
@@ -567,7 +574,11 @@ def test_ticker_analysis_beginner_mode_hides_raw_deep_dive_tables(monkeypatch):
     app_main.main()
 
     ticker_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Ticker Analysis"]
-    assert "#### F) Analyst Deep Dive" not in ticker_markdowns
+    ticker_captions = [text for tab, text in dummy_st.captions if tab == "Ticker Analysis"]
+    assert "#### D) Execution Behavior" in ticker_markdowns
+    assert "#### G) Analyst Deep Dive" not in ticker_markdowns
+    assert any("Short execution framing" in text for text in ticker_captions)
+    assert not any("Outcome context:" in text for text in ticker_markdowns)
     assert any("Analyst Deep Dive" in text for text in ticker_markdowns)
 
 
@@ -605,6 +616,13 @@ def test_ticker_analysis_analyst_mode_shows_deep_dive_tables(monkeypatch):
                 "reliability": "Win rate is mixed.",
                 "tier_profile": "Setup mix leans to A.",
             },
+            "execution": {
+                "entry_reference": "Use the signal-day close as the entry reference area.",
+                "planned_exit": "Default exit is around 5 trading days.",
+                "typical_outcome": "Typical result is centered on median return near 1.00%.",
+                "execution_risk": "Spread conditions can affect realized fills.",
+                "summary": "Entry reference and exit framing are rule-based.",
+            },
         },
     )
     monkeypatch.setattr(
@@ -623,6 +641,10 @@ def test_ticker_analysis_analyst_mode_shows_deep_dive_tables(monkeypatch):
     app_main.main()
 
     ticker_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Ticker Analysis"]
+    ticker_captions = [text for tab, text in dummy_st.captions if tab == "Ticker Analysis"]
     ticker_dataframes = [df for tab, df in dummy_st.dataframes if tab == "Ticker Analysis"]
-    assert "#### F) Analyst Deep Dive" in ticker_markdowns
+    assert "#### D) Execution Behavior" in ticker_markdowns
+    assert "#### G) Analyst Deep Dive" in ticker_markdowns
+    assert any("Expanded execution framing" in text for text in ticker_captions)
+    assert any("Outcome context:" in text for text in ticker_markdowns)
     assert len(ticker_dataframes) >= 5

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -47,7 +47,7 @@ class DummyStreamlit:
         return [self._DummyTab(), self._DummyTab()]
 
 
-def test_render_portfolio_plan_uses_why_column_and_no_primary_rule_column():
+def test_render_portfolio_plan_uses_cleaned_plan_labels_in_beginner_mode():
     st = DummyStreamlit()
     render_portfolio_plan(
         allocations=[
@@ -74,22 +74,100 @@ def test_render_portfolio_plan_uses_why_column_and_no_primary_rule_column():
     funded_df = st.dataframes[1][0]
     unfunded_df = st.dataframes[2][0]
 
-    assert "Why" in funded_df.columns
-    assert "Why" in unfunded_df.columns
-    assert "Execution Framework" in funded_df.columns
-    assert "Execution Framework" in unfunded_df.columns
+    assert "Ticker" in funded_df.columns
+    assert "Setup Strength" in funded_df.columns
+    assert "Confidence / Reliability" in funded_df.columns
+    assert "Holding Window" in funded_df.columns
+    assert "Why this trade" in funded_df.columns
+    assert "Execution Summary" in funded_df.columns
+    assert "Why this trade" in unfunded_df.columns
+    assert "Execution Summary" in unfunded_df.columns
+    assert "Instrument" not in funded_df.columns
+    assert "Confidence" not in funded_df.columns
+    assert "Execution Framework" not in funded_df.columns
     assert "Setup Strength" in funded_df.columns
     assert "Strong setup" in funded_df.iloc[0]["Setup Strength"]
-    assert "High confidence" in funded_df.iloc[0]["Confidence"]
+    assert "High confidence" in funded_df.iloc[0]["Confidence / Reliability"]
+    assert funded_df.iloc[0]["Holding Window"] == "Plan-defined window"
     assert "Primary Rule/Constraint" not in funded_df.columns
     assert "Primary Rule/Constraint" not in unfunded_df.columns
-    assert "Selected because" in funded_df.iloc[0]["Why"]
-    assert "Entry reference:" in funded_df.iloc[0]["Execution Framework"]
+    assert "Selected because" in funded_df.iloc[0]["Why this trade"]
+    assert funded_df.iloc[0]["Execution Summary"].startswith("Entry reference:")
     assert funded_df.iloc[0]["Decision Status"] == "Selected"
     assert unfunded_df.iloc[0]["Decision Status"] == "Not funded (limit reached)"
     assert "funds the strongest eligible setups first" in st.captions[0]
     assert st.tabs_requested == [["Plan", "Review"]]
     assert any("followed system rules" in line for line in st.markdowns)
+
+
+def test_render_portfolio_plan_beginner_vs_analyst_columns():
+    beginner_st = DummyStreamlit()
+    analyst_st = DummyStreamlit()
+    allocations = [
+        {
+            "instrument": "AAA",
+            "allocation_amount": 1000,
+            "allocation_pct": 0.1,
+            "quality_tier": "A",
+            "confidence_label": "strong",
+            "selection_rank": 1,
+            "holding_window": 10,
+        }
+    ]
+
+    render_portfolio_plan(
+        allocations=allocations,
+        total_capital=10_000,
+        st_module=beginner_st,
+        section="plan",
+        mode="beginner",
+    )
+    render_portfolio_plan(
+        allocations=allocations,
+        total_capital=10_000,
+        st_module=analyst_st,
+        section="plan",
+        mode="analyst",
+    )
+
+    beginner_df = beginner_st.dataframes[1][0]
+    analyst_df = analyst_st.dataframes[1][0]
+
+    assert "Selection Rank" not in beginner_df.columns
+    assert "Allocation %" not in beginner_df.columns
+    assert "Rule Note" not in beginner_df.columns
+
+    assert "Selection Rank" in analyst_df.columns
+    assert "Allocation %" in analyst_df.columns
+    assert "Rule Note" in analyst_df.columns
+    assert analyst_df.iloc[0]["Holding Window"] == "~10 trading days"
+
+
+def test_render_portfolio_plan_keeps_explanations_before_supporting_fields():
+    st = DummyStreamlit()
+    render_portfolio_plan(
+        allocations=[
+            {
+                "instrument": "AAA",
+                "allocation_amount": 2000,
+                "allocation_pct": 0.2,
+                "quality_tier": "A",
+                "confidence_label": "strong",
+                "selection_rank": 1,
+                "holding_window": 5,
+            }
+        ],
+        total_capital=10_000,
+        st_module=st,
+        section="plan",
+        mode="analyst",
+    )
+
+    funded_df = st.dataframes[1][0]
+    ordered_columns = list(funded_df.columns)
+
+    assert ordered_columns.index("Why this trade") < ordered_columns.index("Allocation %")
+    assert ordered_columns.index("Execution Summary") < ordered_columns.index("Selection Rank")
 
 
 def test_group_mistakes_for_display_combines_repeated_types():

--- a/tests/test_ticker_intelligence.py
+++ b/tests/test_ticker_intelligence.py
@@ -105,3 +105,20 @@ def test_compute_ticker_metrics_scopes_to_canonical_ticker_with_marker_variants(
     payload = compute_ticker_metrics(df, "CAR")
 
     assert payload["stats"]["signal_count"] == 4
+
+
+def test_compute_ticker_metrics_execution_typical_outcome_is_median_first():
+    df = pd.DataFrame(
+        {
+            "instrument": ["TEST"] * 6,
+            "holding_window": [5, 5, 5, 20, 20, 20],
+            "net_return_pct": [0.01, 0.01, 0.01, 0.01, 0.08, -0.01],
+        }
+    )
+
+    payload = compute_ticker_metrics(df, "TEST", mode="analyst")
+    typical_outcome = payload["execution"]["typical_outcome"]
+
+    assert "median return" in typical_outcome
+    assert "Supporting average return" in typical_outcome
+    assert typical_outcome.index("median return") < typical_outcome.index("Supporting average return")


### PR DESCRIPTION
### Motivation
- Surface a concise, consistent execution framing in the Ticker Drilldown that shows entry/exit, typical outcome and caveats while providing extra context for analyst mode.
- Simplify and standardize portfolio plan table columns and ordering so beginner-mode shows compact labels and analyst-mode includes supporting fields for deeper inspection.

### Description
- Added `_build_execution_behavior_lines` to assemble execution framing lines and integrated it into the ticker drilldown display, replacing multiple inline `st.markdown` calls with a loop that respects `analyst_mode`.
- Introduced helper utilities in `app/planner/portfolio_ui.py`: `_portfolio_plan_row`, `_format_holding_window_label`, `_compact_execution_summary`, and `_int_or_none` to centralize row construction, compact execution text, and uniform holding-window labels.
- Refactored portfolio plan rendering to build funded and unfunded DataFrames from `_portfolio_plan_row`, changing column names and ordering to `Ticker`, `Setup Strength`, `Confidence / Reliability`, `Holding Window`, `Why this trade`, `Execution Summary`, and conditionally adding analyst-only columns such as `Allocation %`, `Selection Rank`, and `Rule Note`.
- Updated `main` UI labels and captions for the execution section to show a short framing for beginners and an expanded framing for analysts.
- Adjusted tests to match the new headings, captions, column names, and to add a unit test asserting `compute_ticker_metrics` reports a median-first typical outcome in analyst mode.

### Testing
- Ran unit tests in `tests/test_app_information_architecture.py`, `tests/test_portfolio_ui.py`, and `tests/test_ticker_intelligence.py` after the changes and all updated/added tests passed.
- Verified UI-related assertions for presence/absence of headings and captions (`Execution Behavior`, beginner vs analyst captions) succeeded.
- Verified portfolio table column membership, ordering, and analyst-mode fields through the updated tests and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1c69cc048322aa135b6bf6c98e83)