### PR TITLE
Fix confidence ratio interpretation for funded portfolio snapshots

### DIFF
--- a/app/insights/portfolio_snapshot.py
+++ b/app/insights/portfolio_snapshot.py
@@ -154,41 +154,57 @@ def _build_strength_line(
 
 def _build_confidence_line(*, funded_trades: Sequence[Mapping[str, Any]], mode: str) -> str | None:
     analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
-    if not funded_trades:
+    total_funded = len(funded_trades)
+    if total_funded == 0:
         return None
 
     labels = [str(trade.get("confidence_label", "")).strip().lower() for trade in funded_trades]
-    known = [label for label in labels if label]
-    if not known:
-        return "Confidence detail is limited for the currently funded portfolio."
+    high_count = sum(1 for label in labels if label in {"high", "strong"})
+    medium_count = sum(1 for label in labels if label in {"medium", "moderate", "mixed"})
+    low_count = sum(1 for label in labels if label in {"low", "weak", "high risk"})
+    labeled_count = high_count + medium_count + low_count
+    unknown_count = total_funded - labeled_count
 
-    high_count = sum(1 for label in known if label in {"high", "strong"})
-    medium_count = sum(1 for label in known if label in {"medium", "moderate", "mixed"})
-    low_count = sum(1 for label in known if label in {"low", "weak", "high risk"})
+    coverage_ratio = labeled_count / total_funded
+    if coverage_ratio < 0.5:
+        if analyst_mode:
+            coverage_pct = round(coverage_ratio * 100)
+            return (
+                "Confidence detail is limited for this plan "
+                f"(high: {high_count}, medium: {medium_count}, low: {low_count}, unknown: {unknown_count}; "
+                f"coverage ~{coverage_pct}%)."
+            )
+        return "Confidence detail is limited for this plan."
 
-    coverage = len(known)
-    high_ratio = high_count / coverage
-    low_ratio = low_count / coverage
+    high_ratio = high_count / total_funded
+    low_ratio = low_count / total_funded
+    coverage_pct = round(coverage_ratio * 100)
 
     if high_ratio >= 0.6:
         if analyst_mode:
-            return f"Current funded confidence mix is high/reliable in most rows ({high_count}/{coverage} high-confidence labels)."
+            return (
+                "Current funded confidence mix is high/reliable in most rows "
+                f"(high: {high_count}, medium: {medium_count}, low: {low_count}, unknown: {unknown_count}; "
+                f"coverage ~{coverage_pct}%)."
+            )
         return "Current funded confidence is mostly high and historically more reliable."
 
     if low_ratio >= 0.6:
         if analyst_mode:
-            return f"Current funded confidence mix is low in most rows ({low_count}/{coverage} low-confidence labels)."
+            return (
+                "Current funded confidence mix is low in most rows "
+                f"(high: {high_count}, medium: {medium_count}, low: {low_count}, unknown: {unknown_count}; "
+                f"coverage ~{coverage_pct}%)."
+            )
         return "Current funded confidence is mostly low, so reliability is weaker."
 
-    if medium_count > 0 or (high_count > 0 and low_count > 0):
-        if analyst_mode:
-            return (
-                "Current funded confidence mix is medium/mixed "
-                f"({high_count} high, {medium_count} medium, {low_count} low across {coverage} funded labels)."
-            )
-        return "Current funded confidence is mixed across the funded portfolio."
-
-    return "Confidence detail is limited for the currently funded portfolio."
+    if analyst_mode:
+        return (
+            "Current funded confidence mix is medium/mixed "
+            f"(high: {high_count}, medium: {medium_count}, low: {low_count}, unknown: {unknown_count}; "
+            f"coverage ~{coverage_pct}%)."
+        )
+    return "Current funded confidence is mixed across the funded portfolio."
 
 
 def _build_glossary_support_line(*, mode: str) -> str:

--- a/tests/test_portfolio_snapshot.py
+++ b/tests/test_portfolio_snapshot.py
@@ -88,6 +88,38 @@ def test_snapshot_strong_funded_portfolio_is_data_driven_not_hardcoded():
     assert "current funded confidence mix is high/reliable" in blob
 
 
+def test_snapshot_missing_labels_do_not_inflate_to_mostly_high():
+    snapshot = build_portfolio_snapshot(
+        [
+            {"allocation_amount": 3_000, "quality_tier": "A", "confidence_label": "high"},
+            {"allocation_amount": 2_000, "quality_tier": "B", "confidence_label": "strong"},
+            {"allocation_amount": 1_500, "quality_tier": "C", "confidence_label": ""},
+            {"allocation_amount": 1_000, "quality_tier": "C"},
+        ],
+        10_000,
+        mode="beginner",
+    )
+
+    blob = " ".join(snapshot["lines"]).lower()
+    assert "current funded confidence is mostly high" not in blob
+    assert "current funded confidence is mixed across the funded portfolio" in blob
+
+
+def test_snapshot_low_coverage_triggers_limited_confidence_detail():
+    snapshot = build_portfolio_snapshot(
+        [
+            {"allocation_amount": 3_000, "quality_tier": "A", "confidence_label": "high"},
+            {"allocation_amount": 2_500, "quality_tier": "B", "confidence_label": ""},
+            {"allocation_amount": 1_500, "quality_tier": "C"},
+        ],
+        10_000,
+        mode="beginner",
+    )
+
+    blob = " ".join(snapshot["lines"])
+    assert "Confidence detail is limited for this plan." in blob
+
+
 def test_snapshot_mixed_funded_portfolio_uses_mixed_language():
     snapshot = build_portfolio_snapshot(
         [
@@ -105,6 +137,40 @@ def test_snapshot_mixed_funded_portfolio_uses_mixed_language():
     assert "high confidence" not in blob or "example glossary only" in blob
 
 
+def test_snapshot_mixed_labeled_and_unlabeled_uses_total_funded_denominator():
+    snapshot = build_portfolio_snapshot(
+        [
+            {"allocation_amount": 3_000, "quality_tier": "A", "confidence_label": "high"},
+            {"allocation_amount": 2_500, "quality_tier": "B", "confidence_label": "medium"},
+            {"allocation_amount": 1_500, "quality_tier": "C", "confidence_label": "low"},
+            {"allocation_amount": 1_000, "quality_tier": "C"},
+        ],
+        10_000,
+        mode="beginner",
+    )
+
+    blob = " ".join(snapshot["lines"]).lower()
+    assert "current funded confidence is mixed across the funded portfolio" in blob
+
+
+def test_snapshot_analyst_mode_includes_coverage_and_unknown_details():
+    snapshot = build_portfolio_snapshot(
+        [
+            {"allocation_amount": 3_000, "quality_tier": "A", "confidence_label": "high"},
+            {"allocation_amount": 2_500, "quality_tier": "B", "confidence_label": "medium"},
+            {"allocation_amount": 1_500, "quality_tier": "C", "confidence_label": "low"},
+            {"allocation_amount": 1_000, "quality_tier": "C"},
+        ],
+        10_000,
+        mode="analyst",
+    )
+
+    blob = " ".join(snapshot["lines"]).lower()
+    assert "current funded confidence mix is medium/mixed" in blob
+    assert "high: 1, medium: 1, low: 1, unknown: 1" in blob
+    assert "coverage ~75%" in blob
+
+
 def test_snapshot_unfunded_portfolio_does_not_claim_strong_or_high_confidence():
     snapshot = build_portfolio_snapshot(
         [
@@ -119,6 +185,21 @@ def test_snapshot_unfunded_portfolio_does_not_claim_strong_or_high_confidence():
     assert "no trades were funded" in blob
     assert "current funded confidence is mostly high" not in blob
     assert "current funded confidence mix is high/reliable" not in blob
+
+
+def test_snapshot_confidence_copy_remains_non_advisory_with_coverage_logic():
+    snapshot = build_portfolio_snapshot(
+        [
+            {"allocation_amount": 3_000, "quality_tier": "A", "confidence_label": "high"},
+            {"allocation_amount": 2_500, "quality_tier": "B", "confidence_label": ""},
+            {"allocation_amount": 1_500, "quality_tier": "C"},
+        ],
+        10_000,
+        mode="analyst",
+    )
+
+    combined = " ".join(snapshot["lines"])
+    assert contains_advisory_language(combined) is False
 
 
 def test_snapshot_glossary_text_is_clearly_separated_from_live_interpretation():


### PR DESCRIPTION
### Motivation
- The previous snapshot logic filtered out unlabeled funded trades when computing confidence ratios, which inflated ratios (e.g., `mostly high`) and misrepresented the funded portfolio mix.
- The change ensures interpretation reflects the actual funded trade mix by including missing/empty labels in the denominator and adding a coverage guardrail.
- Analyst users need more transparent counts and coverage percent to interpret confidence assessments when labels are incomplete.

### Description
- Reworked `app/insights/portfolio_snapshot.py::_build_confidence_line` to compute `total_funded = len(funded_trades)` and to derive `high_count`, `medium_count`, `low_count`, `labeled_count`, and `unknown_count` from all funded rows rather than only labeled rows.
- Added `coverage_ratio = labeled_count / total_funded` and an early `None` return when `total_funded == 0`.
- If `coverage_ratio < 0.5` the function now returns `"Confidence detail is limited for this plan."` in beginner mode and the same message with `(high: X, medium: Y, low: Z, unknown: N; coverage ~P%)` appended in analyst mode.
- When coverage is sufficient, ratios are computed against `total_funded` and interpreted as: `high_ratio >= 0.6` → mostly high, `low_ratio >= 0.6` → mostly low, otherwise → mixed; analyst-mode messages include counts and coverage percent.
- Only `app/insights/portfolio_snapshot.py` (interpretation layer) and `tests/test_portfolio_snapshot.py` were changed; no scoring, allocation, or ranking logic was modified.

### Testing
- Added/updated tests in `tests/test_portfolio_snapshot.py`: `test_snapshot_missing_labels_do_not_inflate_to_mostly_high`, `test_snapshot_low_coverage_triggers_limited_confidence_detail`, `test_snapshot_mixed_labeled_and_unlabeled_uses_total_funded_denominator`, `test_snapshot_analyst_mode_includes_coverage_and_unknown_details`, and `test_snapshot_confidence_copy_remains_non_advisory_with_coverage_logic`.
- Ran `pytest -q tests/test_portfolio_snapshot.py`; all tests passed (`13 passed`).
- Confirmed no other unit tests or production logic for scoring/allocation/ranking were altered by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1d9e30508322bc30df2c5bc74b60)