### PR TITLE
Fix compact execution summary truncation for decimals and percentages

### DIFF
--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any, Mapping, Sequence
 
 import pandas as pd
@@ -27,6 +28,7 @@ from app.planner.explanations import (
 
 
 _ALLOCATOR_REASON_KEYS = REASON_KEYS
+_SENTENCE_BOUNDARY_PATTERN = re.compile(r"(?<=[.!?])\s+(?=[A-Z]|$)")
 
 
 def build_portfolio_summary(
@@ -356,10 +358,8 @@ def _first_sentence(text: str) -> str:
     if not cleaned:
         return ""
 
-    sentence = cleaned.split(".")[0].strip()
-    if not sentence:
-        return ""
-    return f"{sentence}."
+    sentence = _SENTENCE_BOUNDARY_PATTERN.split(cleaned, maxsplit=1)[0].strip()
+    return sentence
 
 
 def _format_holding_window_label(value: Any) -> str:

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -4,7 +4,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-from app.planner.portfolio_ui import _group_mistakes_for_display, render_portfolio_plan
+from app.planner.portfolio_ui import (
+    _compact_execution_summary,
+    _first_sentence,
+    _group_mistakes_for_display,
+    render_portfolio_plan,
+)
 
 
 class DummyStreamlit:
@@ -220,3 +225,33 @@ def test_render_portfolio_plan_places_snapshot_and_reserved_cash_before_tables()
         if "Portfolio Summary" in text
     )
     assert snapshot_idx < summary_idx
+
+
+def test_first_sentence_keeps_decimal_number_intact():
+    text = (
+        "Entry reference: place a limit at 10.50 with staged risk controls. "
+        "Exit after two sessions if momentum fades."
+    )
+
+    assert _first_sentence(text) == "Entry reference: place a limit at 10.50 with staged risk controls."
+
+
+def test_first_sentence_keeps_percentage_intact():
+    text = (
+        "Protective stop sits at 1.00% below entry to cap downside. "
+        "Trim size if spread widens."
+    )
+
+    assert _first_sentence(text) == "Protective stop sits at 1.00% below entry to cap downside."
+
+
+def test_compact_execution_summary_returns_first_sentence_only():
+    summary = (
+        "Entry reference: use VWAP and keep slippage below 0.25%. "
+        "If momentum stalls, reduce size and wait for confirmation."
+    )
+
+    compact = _compact_execution_summary(summary)
+
+    assert compact == "Entry reference: use VWAP and keep slippage below 0.25%."
+    assert "If momentum stalls" not in compact


### PR DESCRIPTION
### Motivation
- The compact execution summary helper previously used `cleaned.split(".")[0].strip()` which incorrectly treated decimal and percentage tokens (e.g., `10.50`, `1.00%`) as sentence boundaries and produced misleading truncated fragments.
- The goal is to keep the compact-first-sentence behavior for table scannability while avoiding accidental splits inside numeric values.

### Description
- Replaced naive period-based split with a regex sentence-boundary splitter and applied it inside `_first_sentence` so compact summaries no longer cut inside decimals/percentages; the new pattern is `_SENTENCE_BOUNDARY_PATTERN = re.compile(r"(?<=[.!?])\s+(?=[A-Z]|$)")` and the extraction uses `_SENTENCE_BOUNDARY_PATTERN.split(cleaned, maxsplit=1)[0].strip()`.
- Files updated: `app/planner/portfolio_ui.py` and `tests/test_portfolio_ui.py`.
- Kept compact behavior unchanged by returning only the first sentence from `_compact_execution_summary`; no execution logic, portfolio ordering, or label changes were made.
- Key diff excerpts: added `import re` and `_SENTENCE_BOUNDARY_PATTERN`, replaced `cleaned.split(".")[0].strip()` with the regex-based split, and added three targeted tests for decimal/percentage handling and compact-first-sentence behavior.
- Confirmation: the change is isolated to the compact-summary sentence extraction (`_first_sentence` and its use in `_compact_execution_summary`) and does not alter other portfolio UI logic.

### Testing
- Tests added/updated: added `test_first_sentence_keeps_decimal_number_intact`, `test_first_sentence_keeps_percentage_intact`, and `test_compact_execution_summary_returns_first_sentence_only` in `tests/test_portfolio_ui.py`, and existing portfolio UI tests were retained.
- Command run: `pytest -q tests/test_portfolio_ui.py`.
- Result: `8 passed` (all tests in that file passed).
- No regression observed in current portfolio UI tests and the new cases for decimals/percentages behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1f6b4ba88322875cd7adb9ab0987)