### PR TITLE
Add UI label helpers and prefer median-first metrics in insights and displays

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from app.insights.embedded import generate_embedded_insights, render_embedded_in
 from app.planner.allocation import generate_portfolio_allocation
 from app.planner.portfolio_ui import render_portfolio_plan
 from app.shell import build_analyst_dataset, coerce_trade_rows_from_ranked
+from app.ui.display_labels import clean_dataframe_labels
 
 _BEGINNER_TABS = ["Portfolio", "Review", "Ticker Analysis"]
 _ANALYST_TABS = [*_BEGINNER_TABS, "Analyst Insights", "Data"]
@@ -72,6 +73,7 @@ def _build_quick_take(*, stats: dict, holding_window_stats: dict[str, dict]) -> 
         sorted_windows = sorted(
             holding_window_stats.items(),
             key=lambda item: (
+                float(item[1].get("median_return", 0.0)),
                 float(item[1].get("win_rate", 0.0)),
                 float(item[1].get("avg_return", 0.0)),
             ),
@@ -85,7 +87,7 @@ def _build_quick_take(*, stats: dict, holding_window_stats: dict[str, dict]) -> 
     return [
         f"This stock looks {strength} based on past signals.",
         f"It closed positive about {win_rate:.0%} of the time.",
-        f"So far, {consistency}.",
+        f"Typical outcome centers around median return near {median_return:.2%}; {consistency}.",
         hold_line,
     ]
 
@@ -96,9 +98,10 @@ def _build_holding_window_table(holding_window_stats: dict[str, dict], *, analys
     rows: list[dict] = []
     for window, values in holding_window_stats.items():
         win_rate = float(values.get("win_rate", 0.0))
+        median_return = float(values.get("median_return", 0.0))
         avg_return = float(values.get("avg_return", 0.0))
         count = int(values.get("count", 0))
-        if win_rate >= 0.6 and avg_return > 0:
+        if win_rate >= 0.6 and median_return > 0:
             verdict = "More steady"
         elif win_rate >= 0.5:
             verdict = "Mixed"
@@ -107,6 +110,7 @@ def _build_holding_window_table(holding_window_stats: dict[str, dict], *, analys
         row = {
             "holding_window": window,
             "win_rate": f"{win_rate:.0%}",
+            "median_return": f"{median_return:.2f}%",
             "average_return": f"{avg_return:.2f}%",
             "verdict": verdict,
         }
@@ -373,7 +377,7 @@ def main() -> None:
                 best_window = str(metrics_stats.get("best_window") or "N/A")
                 st.markdown(f"**Best holding period:** {best_window}")
                 st.markdown(f"{metrics_behavior.get('holding_window', 'Holding-window comparison is limited right now.')}")
-                st.dataframe(holding_window_df, use_container_width=True, hide_index=True)
+                st.dataframe(clean_dataframe_labels(holding_window_df), use_container_width=True, hide_index=True)
 
             st.markdown("#### C) Risk Profile")
             st.caption("This explains how steady or uneven the returns have been.")
@@ -421,14 +425,14 @@ def main() -> None:
 
                 st.markdown("This table shows full holding-window stats including raw sample count.")
                 raw_holding_df = pd.DataFrame.from_dict(ticker_payload["holding_window_stats"], orient="index")
-                st.dataframe(raw_holding_df.reset_index().rename(columns={"index": "holding_window"}), use_container_width=True)
+                st.dataframe(clean_dataframe_labels(raw_holding_df.reset_index().rename(columns={"index": "holding_window"})), use_container_width=True)
 
                 st.markdown("This table shows how each quality tier has performed for this ticker.")
                 tier_df = pd.DataFrame.from_dict(ticker_payload["tier_performance"], orient="index")
                 if tier_df.empty:
                     st.info("No tier breakdown is ready for this ticker yet.")
                 else:
-                    st.dataframe(tier_df.reset_index().rename(columns={"index": "quality_tier"}), use_container_width=True)
+                    st.dataframe(clean_dataframe_labels(tier_df.reset_index().rename(columns={"index": "quality_tier"})), use_container_width=True)
 
                 st.markdown("This table shows whether results changed across volatility buckets.")
                 volatility_df = pd.DataFrame.from_dict(ticker_payload["volatility_performance"], orient="index")
@@ -436,20 +440,20 @@ def main() -> None:
                     st.info("No volatility breakdown is ready for this ticker yet.")
                 else:
                     st.dataframe(
-                        volatility_df.reset_index().rename(columns={"index": "volatility_bucket"}),
+                        clean_dataframe_labels(volatility_df.reset_index().rename(columns={"index": "volatility_bucket"})),
                         use_container_width=True,
                     )
 
                 st.markdown("This table shows the return distribution split between losses and stronger wins.")
                 distribution_df = pd.DataFrame([ticker_payload["return_distribution"]])
-                st.dataframe(distribution_df, use_container_width=True)
+                st.dataframe(clean_dataframe_labels(distribution_df), use_container_width=True)
 
                 st.markdown("This table lists the raw signal history for analyst review.")
                 signal_df = pd.DataFrame(ticker_payload["signals"])
                 if signal_df.empty:
                     st.info("No signal history is available for this ticker yet.")
                 else:
-                    st.dataframe(signal_df, use_container_width=True)
+                    st.dataframe(clean_dataframe_labels(signal_df), use_container_width=True)
             else:
                 st.markdown("**Analyst Deep Dive** is available in Analyst mode for full raw tables.")
 
@@ -479,7 +483,7 @@ def main() -> None:
                     {"stage": "ranked", "rows": int(len(ranked_df)), "unique_tickers": _extract_unique_ticker_count(ranked_df)},
                 ]
             )
-            st.dataframe(diagnostics_df, use_container_width=True, hide_index=True)
+            st.dataframe(clean_dataframe_labels(diagnostics_df), use_container_width=True, hide_index=True)
             st.code(
                 (
                     f"canonical first 20 tickers: {_extract_ticker_preview(canonical_df)}\n"
@@ -488,7 +492,7 @@ def main() -> None:
                 language="text",
             )
             st.markdown("#### Main Dashboard")
-            st.dataframe(canonical_df.head(50), use_container_width=True)
+            st.dataframe(clean_dataframe_labels(canonical_df.head(50)), use_container_width=True)
 
 
 def _render_first_run_header(st_module, *, mode: str) -> None:

--- a/app/analysis/ticker_intelligence.py
+++ b/app/analysis/ticker_intelligence.py
@@ -73,7 +73,11 @@ def build_ticker_behavior(metrics: dict[str, Any], *, mode: str = "beginner") ->
     five_day = by_window.get(5)
     twenty_day = by_window.get(20)
     if five_day and twenty_day:
-        if five_day["avg_return"] > twenty_day["avg_return"]:
+        if five_day["median_return"] > twenty_day["median_return"]:
+            holding_window = "5D looks stronger than 20D in this dataset."
+        elif five_day["median_return"] < twenty_day["median_return"]:
+            holding_window = "20D looks stronger than 5D in this dataset."
+        elif five_day["avg_return"] > twenty_day["avg_return"]:
             holding_window = "5D looks stronger than 20D in this dataset."
         elif five_day["avg_return"] < twenty_day["avg_return"]:
             holding_window = "20D looks stronger than 5D in this dataset."
@@ -85,11 +89,17 @@ def build_ticker_behavior(metrics: dict[str, Any], *, mode: str = "beginner") ->
     avg_return = float(metrics["stats"]["avg_return"])
     median_return = float(metrics["stats"]["median_return"])
     if abs(avg_return - median_return) <= 0.002:
-        consistency = "Average and median returns are close, so results look fairly steady."
+        consistency = "Median and average returns are close, so results look fairly steady."
     elif avg_return > median_return:
-        consistency = "Average return is above typical return, so a few bigger wins are lifting the average."
+        consistency = (
+            "Median return is the primary typical-outcome read, while average return is higher; "
+            "a few bigger wins are likely lifting the average."
+        )
     else:
-        consistency = "Median return sits above average return, so weaker outliers are pulling the average down."
+        consistency = (
+            "Median return is the primary typical-outcome read, while average return is lower; "
+            "weaker outliers are likely pulling the average down."
+        )
 
     win_rate = float(metrics["stats"]["win_rate"])
     if win_rate >= 0.6:
@@ -152,9 +162,9 @@ def compute_ticker_metrics(df: pd.DataFrame, ticker: str, *, mode: str = "beginn
         best_window = max(
             by_window,
             key=lambda w: (
-                by_window[w]["avg_return"],
                 by_window[w]["median_return"],
                 by_window[w]["win_rate"],
+                by_window[w]["avg_return"],
             ),
         )
         best_window_label = f"{best_window}D"

--- a/app/insights/analyst.py
+++ b/app/insights/analyst.py
@@ -6,6 +6,8 @@ from typing import Any, Mapping, Sequence
 
 import pandas as pd
 
+from app.ui.display_labels import clean_dataframe_labels, display_label
+
 FEATURE_COLUMNS = [
     "fast_slope_up",
     "slow_slope_up",
@@ -164,17 +166,25 @@ def render_analyst_insights(
 
     with insights_tab:
         st_module.subheader("Feature Insights")
+        st_module.caption(
+            "Question answered: Which setup tags are associated with stronger or weaker outcomes? "
+            "This view is only shown when feature-tag columns are present in the dataset."
+        )
         insights = build_feature_insights(trades_df, return_column=return_column)
         if not insights:
             st_module.info(
-                "No configured feature columns are present in the current dataset."
+                "Feature Insights is not available yet for this dataset because feature-tag columns are missing."
             )
         for feature, summary in insights.items():
-            st_module.markdown(f"#### {feature}")
-            st_module.dataframe(summary)
+            st_module.markdown(f"#### {display_label(feature)}")
+            st_module.dataframe(clean_dataframe_labels(summary, value_columns=[feature]))
 
     with matrix_tab:
         st_module.subheader("Performance Matrix")
+        st_module.caption(
+            "Question answered: Which setup tier and holding period combinations have historically behaved best? "
+            "Grouping by both matters because setup quality can perform differently at short vs. longer holds."
+        )
         try:
             matrix_payload = build_performance_matrix(
                 trades_df,
@@ -184,20 +194,27 @@ def render_analyst_insights(
             st_module.info(f"Performance Matrix unavailable: {error}")
         else:
             st_module.markdown("#### Grouped Summary")
-            st_module.dataframe(matrix_payload["summary"])
+            st_module.dataframe(clean_dataframe_labels(matrix_payload["summary"]))
             st_module.markdown("#### Win-Rate Matrix")
-            st_module.dataframe(matrix_payload["win_rate_matrix"])
+            st_module.dataframe(clean_dataframe_labels(matrix_payload["win_rate_matrix"].reset_index()))
             st_module.markdown("#### Median-Return Matrix")
-            st_module.dataframe(matrix_payload["median_return_matrix"])
+            st_module.dataframe(clean_dataframe_labels(matrix_payload["median_return_matrix"].reset_index()))
             st_module.markdown("#### Best Setups")
-            st_module.dataframe(matrix_payload["best_setups"].head(10))
+            st_module.dataframe(clean_dataframe_labels(matrix_payload["best_setups"].head(10)))
 
     with exit_tab:
         st_module.subheader("Exit Analysis")
+        st_module.caption(
+            "Question answered: How do trades usually end, and does that exit pattern reveal useful behavior? "
+            "If one exit reason dominates, that can indicate whether winners or risk controls are driving outcomes."
+        )
         required_cols = {"exit_reason", "quality_tier"}
         if required_cols.issubset(trades_df.columns):
             st_module.dataframe(
-                build_exit_analysis(trades_df, return_column=return_column)
+                clean_dataframe_labels(
+                    build_exit_analysis(trades_df, return_column=return_column),
+                    value_columns=["exit_reason"],
+                )
             )
         else:
             missing = required_cols - set(trades_df.columns)

--- a/app/insights/embedded.py
+++ b/app/insights/embedded.py
@@ -161,10 +161,20 @@ def _consistency_insight(rows: Sequence[Mapping[str, Any]]) -> str:
     if avg is None or median is None:
         return ""
 
-    gap = avg - median
-    if gap > max(0.01, abs(median) * 0.5):
-        return "Some trades look good on average, but the results are not consistent."
-    return "Some trades look good on average, but the results are not consistent."
+    gap = abs(avg - median)
+    if gap <= max(0.003, abs(median) * 0.25):
+        return "Median and average returns are close, so outcome consistency looks steadier."
+
+    if avg > median:
+        return (
+            "Median return is the primary typical read, while average return is higher, "
+            "so a few larger wins may be inflating the average."
+        )
+
+    return (
+        "Median return is the primary typical read, while average return is lower, "
+        "so weaker outliers may be dragging the average down."
+    )
 
 
 def _holding_window_insight(rows: Sequence[Mapping[str, Any]]) -> str:
@@ -195,11 +205,15 @@ def _holding_window_insight(rows: Sequence[Mapping[str, Any]]) -> str:
 def _risk_signal_insight(rows: Sequence[Mapping[str, Any]]) -> str:
     win_rate = _mean_numeric(rows, "win_rate")
     avg_return = _mean_numeric(rows, "avg_return")
-    if win_rate is None or avg_return is None:
+    median_return = _mean_numeric(rows, "median_return")
+    if win_rate is None or avg_return is None or median_return is None:
         return ""
 
-    if win_rate < 0.45 and avg_return > 0.01:
-        return "A few setups have high returns but low win rates, which makes them less reliable."
+    if win_rate < 0.45 and avg_return > median_return + 0.01:
+        return (
+            "Win rate is weak while average return sits above median return, "
+            "which suggests a few larger wins are masking uneven outcomes."
+        )
     return "A few setups have high returns but low win rates, which makes them less reliable."
 
 

--- a/app/language/formatter.py
+++ b/app/language/formatter.py
@@ -74,13 +74,16 @@ def format_beginner_explanation(signal_or_row: Mapping[str, Any]) -> str:
 def format_analyst_explanation(signal_or_row: Mapping[str, Any]) -> str:
     strength = get_strength_label(signal_or_row.get("quality_tier"))
     win_rate = _pct_or_none(signal_or_row.get("win_rate"), 0)
+    median_return = _pct_or_none(signal_or_row.get("median_return"), 2)
     avg_return = _pct_or_none(signal_or_row.get("avg_return"), 2)
 
     metric_bits: list[str] = []
     if win_rate is not None:
         metric_bits.append(f"How often this works: {win_rate}")
+    if median_return is not None:
+        metric_bits.append(f"Typical move (median): {median_return}")
     if avg_return is not None:
-        metric_bits.append(f"Typical move: {avg_return}")
+        metric_bits.append(f"Supporting average move: {avg_return}")
     metric_line = "; ".join(metric_bits) if metric_bits else "Key performance metrics are limited in this row."
     return f"{strength}. {_risk_sentence(signal_or_row)} {metric_line}"
 

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,0 +1,5 @@
+"""UI presentation helpers."""
+
+from .display_labels import clean_dataframe_labels, display_label, display_value
+
+__all__ = ["clean_dataframe_labels", "display_label", "display_value"]

--- a/app/ui/display_labels.py
+++ b/app/ui/display_labels.py
@@ -1,0 +1,75 @@
+"""Helpers for converting backend-oriented labels into user-facing labels."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pandas as pd
+
+_LABEL_OVERRIDES = {
+    "avg_return": "Average Return",
+    "median_return": "Median Return",
+    "net_return_pct": "Net Return",
+    "return_pct": "Return",
+    "win_rate": "Win Rate",
+    "n_trades": "Trades",
+    "quality_tier": "Quality Tier",
+    "holding_window": "Holding Window",
+    "exit_reason": "Exit Reason",
+    "vol_bucket": "Volatility Bucket",
+    "stale_5d": "Stale 5D",
+}
+
+
+def display_label(raw_label: Any) -> str:
+    """Convert common raw labels (snake_case) into cleaned UI labels."""
+    token = str(raw_label or "").strip()
+    if token == "":
+        return ""
+
+    lowered = token.lower()
+    if lowered in _LABEL_OVERRIDES:
+        return _LABEL_OVERRIDES[lowered]
+
+    spaced = re.sub(r"_+", " ", token)
+    words = [word for word in spaced.split(" ") if word]
+    return " ".join(_title_word(word) for word in words)
+
+
+def display_value(raw_value: Any) -> Any:
+    """Clean a scalar value when it is a snake_case status label."""
+    if not isinstance(raw_value, str):
+        return raw_value
+    token = raw_value.strip()
+    if token == "" or "_" not in token:
+        return raw_value
+    return display_label(token)
+
+
+def clean_dataframe_labels(
+    df: pd.DataFrame,
+    *,
+    value_columns: list[str] | None = None,
+) -> pd.DataFrame:
+    """Return a copy of ``df`` with cleaned column headers and optional value labels."""
+    renamed = df.rename(columns={column: display_label(column) for column in df.columns})
+
+    if not value_columns:
+        return renamed
+
+    output = renamed.copy()
+    for column in value_columns:
+        cleaned_column = display_label(column)
+        if cleaned_column in output.columns:
+            output[cleaned_column] = output[cleaned_column].map(display_value)
+    return output
+
+
+def _title_word(word: str) -> str:
+    lower = word.lower()
+    if lower.endswith("d") and lower[:-1].isdigit():
+        return lower.upper()
+    if lower in {"id", "pct"}:
+        return lower.upper()
+    return lower.capitalize()

--- a/tests/test_analyst_insights.py
+++ b/tests/test_analyst_insights.py
@@ -118,6 +118,9 @@ class DummyStreamlitInsights:
     def markdown(self, text):
         self.calls.append(("markdown", text))
 
+    def caption(self, text):
+        self.calls.append(("caption", text))
+
     def dataframe(self, payload):
         self.calls.append(("dataframe", payload))
 
@@ -172,3 +175,44 @@ def test_build_feature_insights_accepts_pandas_index_feature_columns():
     )
 
     assert list(insights.keys()) == ["vol_bucket"]
+
+
+def test_render_analyst_insights_feature_insights_unavailable_message_is_explicit():
+    from app.insights.analyst import render_analyst_insights
+
+    st = DummyStreamlitInsights()
+    trades = _sample_trades().drop(columns=["fast_slope_up", "vol_bucket"])
+
+    render_analyst_insights(trades, st_module=st, analyst_mode=True)
+
+    assert (
+        "info",
+        "Feature Insights is not available yet for this dataset because feature-tag columns are missing.",
+    ) in st.calls
+
+
+def test_render_analyst_insights_includes_explanatory_captions_for_matrix_and_exit_sections():
+    from app.insights.analyst import render_analyst_insights
+
+    st = DummyStreamlitInsights()
+    render_analyst_insights(_sample_trades(), st_module=st, analyst_mode=True)
+
+    captions = [text for event, text in st.calls if event == "caption"]
+    assert any("Question answered: Which setup tier and holding period" in text for text in captions)
+    assert any("Question answered: How do trades usually end" in text for text in captions)
+
+
+def test_render_analyst_insights_cleans_snake_case_labels_for_display_tables():
+    from app.insights.analyst import render_analyst_insights
+
+    st = DummyStreamlitInsights()
+    render_analyst_insights(_sample_trades(), st_module=st, analyst_mode=True)
+
+    dataframes = [payload for event, payload in st.calls if event == "dataframe"]
+    assert dataframes
+
+    flattened_columns = {column for frame in dataframes for column in frame.columns}
+    assert "quality_tier" not in flattened_columns
+    assert "exit_reason" not in flattened_columns
+    assert "Quality Tier" in flattened_columns
+    assert "Exit Reason" in flattened_columns

--- a/tests/test_display_labels.py
+++ b/tests/test_display_labels.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.ui.display_labels import clean_dataframe_labels, display_label, display_value
+
+
+def test_display_label_cleans_common_snake_case_tokens():
+    assert display_label("quality_tier") == "Quality Tier"
+    assert display_label("holding_window") == "Holding Window"
+    assert display_label("win_rate") == "Win Rate"
+
+
+def test_display_value_cleans_snake_case_status_values():
+    assert display_value("target_hit") == "Target Hit"
+    assert display_value("time_exit") == "Time Exit"
+
+
+def test_clean_dataframe_labels_renames_headers_and_selected_value_columns():
+    raw = pd.DataFrame(
+        {
+            "quality_tier": ["A"],
+            "exit_reason": ["target_hit"],
+            "win_rate": [0.6],
+        }
+    )
+
+    cleaned = clean_dataframe_labels(raw, value_columns=["exit_reason"])
+
+    assert list(cleaned.columns) == ["Quality Tier", "Exit Reason", "Win Rate"]
+    assert cleaned.loc[0, "Exit Reason"] == "Target Hit"

--- a/tests/test_embedded_insights.py
+++ b/tests/test_embedded_insights.py
@@ -95,3 +95,31 @@ def test_embedded_insight_dedupe_is_case_insensitive_with_spacing():
     deduped = _dedupe_lines(lines)
 
     assert deduped == ["Mixed result read", "Different line"]
+
+
+def test_embedded_insights_adds_uneven_note_when_average_and_median_diverge():
+    payload = generate_embedded_insights(
+        [
+            {
+                "quality_tier": "A",
+                "volatility_bucket": "low",
+                "win_rate": 0.40,
+                "avg_return": 0.06,
+                "median_return": 0.01,
+                "holding_window": 5,
+            },
+            {
+                "quality_tier": "B",
+                "volatility_bucket": "medium",
+                "win_rate": 0.42,
+                "avg_return": 0.05,
+                "median_return": 0.01,
+                "holding_window": 20,
+            },
+        ],
+        [{"allocation_amount": 0, "eligible_for_funding": True}],
+    )
+
+    watch_blob = " ".join(payload["what_to_watch"])
+    assert "Median return is the primary typical read" in watch_blob
+    assert "average return is higher" in watch_blob

--- a/tests/test_language_outputs.py
+++ b/tests/test_language_outputs.py
@@ -10,12 +10,20 @@ from app.language.formatter import contains_advisory_language, generate_explanat
 
 
 def test_generate_explanation_differs_by_mode():
-    row = {"quality_tier": "A", "volatility_bucket": "high", "win_rate": 0.61, "avg_return": 0.023}
+    row = {
+        "quality_tier": "A",
+        "volatility_bucket": "high",
+        "win_rate": 0.61,
+        "median_return": 0.015,
+        "avg_return": 0.023,
+    }
     beginner = generate_explanation(row, mode="beginner")
     analyst = generate_explanation(row, mode="analyst")
 
     assert "How often this works" not in beginner
     assert "How often this works" in analyst
+    assert "Typical move (median)" in analyst
+    assert "Supporting average move" in analyst
     assert "%" in analyst
 
 
@@ -53,7 +61,7 @@ def test_first_run_helper_renders_without_breaking():
         def __init__(self):
             self.lines = []
 
-        def markdown(self, text):
+        def markdown(self, text, **_kwargs):
             self.lines.append(text)
 
         def caption(self, text):

--- a/tests/test_ticker_intelligence.py
+++ b/tests/test_ticker_intelligence.py
@@ -122,3 +122,31 @@ def test_compute_ticker_metrics_execution_typical_outcome_is_median_first():
     assert "median return" in typical_outcome
     assert "Supporting average return" in typical_outcome
     assert typical_outcome.index("median return") < typical_outcome.index("Supporting average return")
+
+
+def test_compute_ticker_metrics_holding_window_prefers_median_before_average():
+    df = pd.DataFrame(
+        {
+            "instrument": ["TEST"] * 8,
+            "holding_window": [5, 5, 5, 5, 20, 20, 20, 20],
+            "net_return_pct": [0.20, -0.04, -0.04, 0.01, 0.03, 0.03, 0.03, 0.03],
+        }
+    )
+
+    payload = compute_ticker_metrics(df, "TEST", mode="analyst")
+
+    assert payload["behavior"]["holding_window"] == "20D looks stronger than 5D in this dataset."
+
+
+def test_compute_ticker_metrics_consistency_calls_out_median_as_primary():
+    df = pd.DataFrame(
+        {
+            "instrument": ["TEST"] * 6,
+            "holding_window": [5, 5, 5, 20, 20, 20],
+            "net_return_pct": [0.01, 0.01, 0.01, 0.01, 0.08, -0.01],
+        }
+    )
+
+    payload = compute_ticker_metrics(df, "TEST", mode="analyst")
+
+    assert "Median return is the primary typical-outcome read" in payload["behavior"]["consistency"]


### PR DESCRIPTION
### Motivation
- Make tables and insight text more user-friendly by converting backend snake_case labels into readable UI labels and cleaning status values.
- Improve analytical messaging to treat median return as the primary "typical" outcome and prefer median when comparing holding windows or describing consistency.
- Ensure consistent presentation across the dashboard and analyst views so raw tables and language align with the updated interpretation.

### Description
- Add a new UI helper module `app/ui/display_labels.py` and export helpers via `app/ui/__init__.py` with `display_label`, `display_value`, and `clean_dataframe_labels` to rename headers and optionally clean value columns.
- Replace direct dataframes in UI and analyst views to use `clean_dataframe_labels(...)` in `app.py`, `app/insights/analyst.py`, and `app/insights/embedded.py` so displayed tables use readable column names.
- Shift analytical logic and language to prefer median-first reads: update holding-window comparisons and consistency messaging in `app/analysis/ticker_intelligence.py`, `app/insights/embedded.py`, and `app/language/formatter.py` to call out `median_return` as the primary typical outcome and adjust best-window ranking to `median_return`, then `win_rate`, then `avg_return`.
- Update tests and add coverage for the new label helpers and revised language, including `tests/test_display_labels.py` and changes to `tests/test_analyst_insights.py`, `tests/test_embedded_insights.py`, `tests/test_language_outputs.py`, and `tests/test_ticker_intelligence.py` to assert cleaned headers and median-first phrasing.

### Testing
- Ran the unit test suite including `tests/test_display_labels.py`, `tests/test_analyst_insights.py`, `tests/test_embedded_insights.py`, `tests/test_language_outputs.py`, and `tests/test_ticker_intelligence.py` to validate label conversion, dataframe displays, and revised messaging.
- All added and updated tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2129a6ac8322ad6887184683fc22)