### PR TITLE
Fix abbreviation-aware compact execution summary sentence splitting

### DIFF
--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -29,6 +29,16 @@ from app.planner.explanations import (
 
 _ALLOCATOR_REASON_KEYS = REASON_KEYS
 _SENTENCE_BOUNDARY_PATTERN = re.compile(r"([.!?])\s+")
+_KNOWN_ABBREVIATIONS = {
+    "e.g.",
+    "i.e.",
+    "mr.",
+    "mrs.",
+    "ms.",
+    "dr.",
+    "prof.",
+}
+_INITIALISM_PATTERN = re.compile(r"(?:[A-Z]\.){2,}$")
 
 
 def build_portfolio_summary(
@@ -368,9 +378,27 @@ def _first_sentence(text: str) -> str:
         if punctuation == "." and prev_char.isdigit() and next_char.isdigit():
             continue
 
+        if punctuation == "." and _is_abbreviation_boundary(cleaned, punctuation_idx):
+            continue
+
         return cleaned[: punctuation_idx + 1].strip()
 
     return cleaned
+
+
+def _is_abbreviation_boundary(text: str, punctuation_idx: int) -> bool:
+    fragment = text[: punctuation_idx + 1]
+    token_match = re.search(r"(\S+)$", fragment)
+    if token_match is None:
+        return False
+
+    token = token_match.group(1).strip()
+    normalized_token = token.strip("\"'”’)]}").lstrip("\"'“‘([{")
+    lowered = normalized_token.lower()
+    if lowered in _KNOWN_ABBREVIATIONS:
+        return True
+
+    return bool(_INITIALISM_PATTERN.fullmatch(normalized_token))
 
 
 def _format_holding_window_label(value: Any) -> str:

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -279,3 +279,39 @@ def test_first_sentence_splits_when_next_sentence_starts_with_quote():
     )
 
     assert _first_sentence(text) == "Execution uses signal-day close."
+
+
+def test_first_sentence_keeps_e_g_abbreviation_in_first_sentence():
+    text = (
+        "Use limit orders, e.g. near VWAP for cleaner fills. "
+        "Avoid chasing late prints."
+    )
+
+    assert _first_sentence(text) == "Use limit orders, e.g. near VWAP for cleaner fills."
+
+
+def test_first_sentence_keeps_i_e_abbreviation_in_first_sentence():
+    text = (
+        "Scale risk, i.e. reduce size when spreads widen. "
+        "Wait for liquidity to improve."
+    )
+
+    assert _first_sentence(text) == "Scale risk, i.e. reduce size when spreads widen."
+
+
+def test_first_sentence_keeps_title_abbreviation_in_first_sentence():
+    text = (
+        "Follow Dr. Lane's execution note before entry. "
+        "Then stage the order across two clips."
+    )
+
+    assert _first_sentence(text) == "Follow Dr. Lane's execution note before entry."
+
+
+def test_first_sentence_keeps_initialism_abbreviation_in_first_sentence():
+    text = (
+        "Focus on U.S. large-cap names when liquidity thins. "
+        "Delay small-cap entries until spread normalizes."
+    )
+
+    assert _first_sentence(text) == "Focus on U.S. large-cap names when liquidity thins."


### PR DESCRIPTION
### Motivation
- The first-sentence extraction used by the compact Execution Summary was truncating valid sentences at abbreviation periods like `e.g.`, `i.e.`, `Dr.`, and `U.S.`. 
- The goal is to avoid early returns on those abbreviation boundaries while preserving existing decimal protections (e.g., `10.50`) and the compact-first-sentence behavior.

### Description
- Added a small abbreviation set `_KNOWN_ABBREVIATIONS` and an `_INITIALISM_PATTERN` regex to detect repeated capital-letter initialisms (e.g., `U.S.`) in `app/planner/portfolio_ui.py`.
- Implemented `_is_abbreviation_boundary(text, punctuation_idx)` which normalizes the token ending at the punctuation and returns true for known abbreviations or matched initialisms, and wired this check into `_first_sentence()` so period boundaries belonging to abbreviations are skipped.
- Kept the existing decimal safeguard (`if punctuation == "." and prev_char.isdigit() and next_char.isdigit(): continue`) and otherwise returned the first sentence unchanged; only the compact-summary extraction logic was modified.
- Files changed: `app/planner/portfolio_ui.py` and `tests/test_portfolio_ui.py` (added focused tests for `e.g.`, `i.e.`, title abbreviations, and initialisms).

### Testing
- Added tests: `test_first_sentence_keeps_e_g_abbreviation_in_first_sentence`, `test_first_sentence_keeps_i_e_abbreviation_in_first_sentence`, `test_first_sentence_keeps_title_abbreviation_in_first_sentence`, and `test_first_sentence_keeps_initialism_abbreviation_in_first_sentence` in `tests/test_portfolio_ui.py`.
- Ran `pytest -q tests/test_portfolio_ui.py` and observed all tests passing: `15 passed`.
- Existing decimal and sentence-splitting tests in the same test file continue to pass unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc240ee9e48322865737a9497126d8)