### PR TITLE
Preserve falsy labels in display_label (only treat None as missing)

### DIFF
--- a/app/ui/display_labels.py
+++ b/app/ui/display_labels.py
@@ -24,7 +24,10 @@ _LABEL_OVERRIDES = {
 
 def display_label(raw_label: Any) -> str:
     """Convert common raw labels (snake_case) into cleaned UI labels."""
-    token = str(raw_label or "").strip()
+    if raw_label is None:
+        return ""
+
+    token = str(raw_label).strip()
     if token == "":
         return ""
 

--- a/tests/test_display_labels.py
+++ b/tests/test_display_labels.py
@@ -33,3 +33,15 @@ def test_clean_dataframe_labels_renames_headers_and_selected_value_columns():
 
     assert list(cleaned.columns) == ["Quality Tier", "Exit Reason", "Win Rate"]
     assert cleaned.loc[0, "Exit Reason"] == "Target Hit"
+
+
+def test_display_label_preserves_zero_label():
+    assert display_label(0) == "0"
+
+
+def test_display_label_preserves_false_label():
+    assert display_label(False) == "False"
+
+
+def test_display_label_handles_none_as_missing():
+    assert display_label(None) == ""


### PR DESCRIPTION
### Motivation
- `display_label` previously used `str(raw_label or "")`, which treated legitimate falsy values like `0` and `False` as missing and produced blank or duplicate headers and ambiguous matrices. 
- The intent is to treat only `None` as missing while preserving all other values (including numeric and boolean) for correct UI rendering. 

### Description
- Updated `display_label` to return `""` only when `raw_label is None`, then compute `token` with `token = str(raw_label).strip()` so `0` and `False` are preserved. 
- Kept existing override mapping (`_LABEL_OVERRIDES`), snake_case → spaced words normalization, and title-casing logic unchanged. 
- Added tests `test_display_label_preserves_zero_label`, `test_display_label_preserves_false_label`, and `test_display_label_handles_none_as_missing`. 
- Files updated: `app/ui/display_labels.py` and `tests/test_display_labels.py`.

### Testing
- Ran `pytest -q tests/test_display_labels.py` and it passed: `6 passed`. 
- Ran `pytest -q tests/test_analyst_insights.py` and it passed: `13 passed`. 
- Confirmed no regressions in existing label cleanup behavior covered by tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc270ca7708322a16b4aabe616a8c6)