### PR TITLE
Sprint 13: clarify portfolio holding window and compact exit timing copy

### DIFF
--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -143,7 +143,7 @@ def render_portfolio_plan(
             "Why this trade": (
                 explain_trade_reason(trade, mode=mode) if funded else resolve_unfunded_reason(trade)
             ),
-            "Execution Summary": _compact_execution_summary(execution["summary"]),
+            "Execution Summary": _compact_execution_summary(execution, mode=mode),
         }
 
         if analyst_mode:
@@ -403,16 +403,36 @@ def _is_abbreviation_boundary(text: str, punctuation_idx: int) -> bool:
 
 def _format_holding_window_label(value: Any) -> str:
     window = _int_or_none(value)
-    if window is None:
-        return "Plan-defined window"
-    return f"~{window} trading days"
+    if window is None or window <= 0:
+        return "Not specified"
+    return f"{window} trading days"
 
 
-def _compact_execution_summary(summary: str) -> str:
-    first_sentence = _first_sentence(summary)
-    if first_sentence:
-        return first_sentence
-    return "Execution plan uses reference pricing, time-based exits, and risk checks."
+def _compact_execution_summary(execution: Mapping[str, Any], *, mode: str = "beginner") -> str:
+    entry_reference = _first_sentence(str(execution.get("entry_reference", "")).strip())
+    entry_phrase = "Entry reference uses the signal-day close area"
+    if entry_reference:
+        entry_phrase = entry_reference
+
+    planned_exit = str(execution.get("planned_exit", "")).strip()
+    holding_days = _extract_holding_days(planned_exit)
+    analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
+
+    if holding_days is None:
+        exit_phrase = "planned exit timing is not specified"
+    elif analyst_mode:
+        exit_phrase = f"planned exit review occurs after {holding_days} trading days"
+    else:
+        exit_phrase = f"planned exit after {holding_days} trading days"
+
+    return f"{entry_phrase}; {exit_phrase}."
+
+
+def _extract_holding_days(planned_exit: str) -> int | None:
+    match = re.search(r"(\d+)\s+trading\s+days", str(planned_exit or ""), flags=re.IGNORECASE)
+    if match is None:
+        return None
+    return _int_or_none(match.group(1))
 
 
 def _int_or_none(value: Any) -> int | None:

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -4,6 +4,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
+from app.language.formatter import contains_advisory_language
 from app.planner.portfolio_ui import (
     _compact_execution_summary,
     _first_sentence,
@@ -93,11 +94,12 @@ def test_render_portfolio_plan_uses_cleaned_plan_labels_in_beginner_mode():
     assert "Setup Strength" in funded_df.columns
     assert "Strong setup" in funded_df.iloc[0]["Setup Strength"]
     assert "High confidence" in funded_df.iloc[0]["Confidence / Reliability"]
-    assert funded_df.iloc[0]["Holding Window"] == "Plan-defined window"
+    assert funded_df.iloc[0]["Holding Window"] == "Not specified"
     assert "Primary Rule/Constraint" not in funded_df.columns
     assert "Primary Rule/Constraint" not in unfunded_df.columns
     assert "Selected because" in funded_df.iloc[0]["Why this trade"]
-    assert funded_df.iloc[0]["Execution Summary"].startswith("Entry reference:")
+    assert "planned exit" in funded_df.iloc[0]["Execution Summary"]
+    assert "trading days" not in funded_df.iloc[0]["Execution Summary"]
     assert funded_df.iloc[0]["Decision Status"] == "Selected"
     assert unfunded_df.iloc[0]["Decision Status"] == "Not funded (limit reached)"
     assert "funds the strongest eligible setups first" in st.captions[0]
@@ -145,7 +147,7 @@ def test_render_portfolio_plan_beginner_vs_analyst_columns():
     assert "Selection Rank" in analyst_df.columns
     assert "Allocation %" in analyst_df.columns
     assert "Rule Note" in analyst_df.columns
-    assert analyst_df.iloc[0]["Holding Window"] == "~10 trading days"
+    assert analyst_df.iloc[0]["Holding Window"] == "10 trading days"
 
 
 def test_render_portfolio_plan_keeps_explanations_before_supporting_fields():
@@ -245,16 +247,63 @@ def test_first_sentence_keeps_percentage_intact():
     assert _first_sentence(text) == "Protective stop sits at 1.00% below entry to cap downside."
 
 
-def test_compact_execution_summary_returns_first_sentence_only():
-    summary = (
-        "Entry reference: use VWAP and keep slippage below 0.25%. "
-        "If momentum stalls, reduce size and wait for confirmation."
+def test_compact_execution_summary_includes_entry_and_exit_timing_for_beginner():
+    compact = _compact_execution_summary(
+        {
+            "entry_reference": "Use the signal-day close area as a reference, not an exact guaranteed fill.",
+            "planned_exit": "Default exit is after about 10 trading days, unless conditions are reviewed earlier.",
+        },
+        mode="beginner",
     )
 
-    compact = _compact_execution_summary(summary)
+    assert "signal-day close" in compact
+    assert "planned exit after 10 trading days" in compact
 
-    assert compact == "Entry reference: use VWAP and keep slippage below 0.25%."
-    assert "If momentum stalls" not in compact
+
+def test_compact_execution_summary_includes_entry_and_exit_timing_for_analyst():
+    compact = _compact_execution_summary(
+        {
+            "entry_reference": "Use the signal-day close area (around 12.34) as a reference, not an exact guaranteed fill.",
+            "planned_exit": "Default exit is after about 20 trading days, unless conditions are reviewed earlier.",
+        },
+        mode="analyst",
+    )
+
+    assert "signal-day close" in compact
+    assert "after 20 trading days" in compact
+
+
+
+
+def test_compact_execution_summary_has_no_advisory_language_in_both_modes():
+    beginner = _compact_execution_summary(
+        {
+            "entry_reference": "Use the signal-day close area as a reference, not an exact guaranteed fill.",
+            "planned_exit": "Default exit is after about 5 trading days, unless conditions are reviewed earlier.",
+        },
+        mode="beginner",
+    )
+    analyst = _compact_execution_summary(
+        {
+            "entry_reference": "Use the signal-day close area as a reference, not an exact guaranteed fill.",
+            "planned_exit": "Default exit is after about 30 trading days, unless conditions are reviewed earlier.",
+        },
+        mode="analyst",
+    )
+
+    assert contains_advisory_language(beginner) is False
+    assert contains_advisory_language(analyst) is False
+
+
+def test_compact_execution_summary_uses_not_specified_exit_fallback():
+    compact = _compact_execution_summary(
+        {
+            "entry_reference": "Use the signal-day close area as a reference, not an exact guaranteed fill.",
+            "planned_exit": "Use the default time-based exit window and review conditions before closing.",
+        }
+    )
+
+    assert "planned exit timing is not specified" in compact
 
 
 def test_first_sentence_splits_when_next_sentence_starts_lowercase():


### PR DESCRIPTION
### Motivation
- Portfolio tables showed vague text like "Plan-defined window" and compact execution summaries emphasized entry framing without making planned exit timing explicit.  
- Users need a compact, non-predictive way to see both entry framing and when trades are intended to be exited.  
- This change is a display/copy fix only, preserving all execution, allocation, and holding-window assignment logic while giving clearer beginner and analyst phrasing.

### Description
- Updated `app/planner/portfolio_ui.py` to render `Holding Window` as `"N trading days"` when valid, and `"Not specified"` when missing or invalid, replacing the prior "Plan-defined window" fallback.  
- Reworked the compact `Execution Summary` to accept the structured execution payload and always include an entry phrase plus an explicit exit phrase; beginner copy uses `"planned exit after N trading days"` and analyst copy uses `"planned exit review occurs after N trading days"`.  
- Added `_extract_holding_days` helper to parse trading-day counts from the execution `planned_exit` text without touching any execution math or strategy code.  
- Updated `tests/test_portfolio_ui.py` to reflect the new holding-window wording and to add/adjust tests asserting compact summary includes explicit exit timing and preserves non-advisory language; no production logic was altered.

### Testing
- Ran `pytest -q tests/test_portfolio_ui.py tests/test_execution.py`.  Result: `21 passed in 1.37s`.  
- Verified that beginner and analyst compact summaries contain explicit exit timing and that the `Holding Window` column shows either `"N trading days"` or `"Not specified"` as expected.  
- Confirmed no changes to execution logic, ranking, allocation, or holding-window assignment behavior during testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3a0fa4788322bc869f50c160d621)