### PR TITLE
Validate and parse holding_window, update holding-window UI and rank deviation copy

### DIFF
--- a/app/insights/execution.py
+++ b/app/insights/execution.py
@@ -48,8 +48,11 @@ def _build_entry_reference(row: Mapping[str, Any]) -> str:
 
 def _build_planned_exit(row: Mapping[str, Any]) -> str:
     holding_window = _int_or_none(row.get("holding_window"))
-    if holding_window is None:
-        return "Use the default time-based exit window and review conditions before closing."
+    if holding_window is None or holding_window <= 0:
+        return (
+            "Planned exit timing is not specified, so use the default time-based exit window "
+            "and review conditions before closing."
+        )
     return (
         f"Default exit is after about {holding_window} trading days, "
         "unless conditions are reviewed earlier."

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -39,6 +39,10 @@ _KNOWN_ABBREVIATIONS = {
     "prof.",
 }
 _INITIALISM_PATTERN = re.compile(r"(?:[A-Z]\.){2,}$")
+_HOLDING_WINDOW_PATTERN = re.compile(
+    r"^\s*([+-]?\d+)\s*(?:trading\s+days?|days?|d)?\s*$",
+    re.IGNORECASE,
+)
 
 
 def build_portfolio_summary(
@@ -135,12 +139,15 @@ def render_portfolio_plan(
     funded_trades, unfunded_trades = split_trades_by_funding(allocations)
 
     def _portfolio_plan_row(trade: Mapping[str, Any], *, funded: bool) -> dict[str, Any]:
-        execution = build_execution_summary(trade, mode=mode)
+        holding_days = _extract_holding_days(trade.get("holding_window"))
+        execution_row = dict(trade)
+        execution_row["holding_window"] = holding_days
+        execution = build_execution_summary(execution_row, mode=mode)
         row: dict[str, Any] = {
             "Ticker": trade.get("instrument", "Unknown"),
             "Setup Strength": explain_strength(trade.get("quality_tier"), mode=mode),
             "Confidence / Reliability": explain_confidence(trade.get("confidence_label"), mode=mode),
-            "Holding Window": _format_holding_window_label(trade.get("holding_window")),
+            "Holding Window": _format_holding_window_label(holding_days),
             "Why this trade": (
                 explain_trade_reason(trade, mode=mode) if funded else resolve_unfunded_reason(trade)
             ),
@@ -414,10 +421,33 @@ def _is_abbreviation_boundary(text: str, punctuation_idx: int) -> bool:
 
 
 def _format_holding_window_label(value: Any) -> str:
-    window = _int_or_none(value)
+    window = _extract_holding_days(value)
     if window is None:
-        return "Plan-defined window"
+        return "Not specified"
     return f"~{window} trading days"
+
+
+def _extract_holding_days(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float):
+        if pd.isna(value) or not value.is_integer():
+            return None
+        integer_value = int(value)
+        return integer_value if integer_value > 0 else None
+
+    match = _HOLDING_WINDOW_PATTERN.fullmatch(str(value))
+    if match is None:
+        return None
+
+    days = _int_or_none(match.group(1))
+    if days is None or days <= 0:
+        return None
+    return days
 
 
 def _build_decision_audit_table(review_df: pd.DataFrame) -> pd.DataFrame:
@@ -459,9 +489,9 @@ def _translate_review_row(row: Mapping[str, Any]) -> tuple[str, str, str]:
 
     if str(row.get("deviation_type", "")).lower() == "rank_deviation":
         return (
-            "Not funded due to stronger-ranked setups",
-            "Higher-ranked eligible trades were funded first.",
-            "Rank-order discipline protected capital from drifting into lower-priority setups.",
+            "Rank order deviation",
+            "A lower-ranked trade was selected while a higher-ranked eligible trade was available.",
+            "This breaks rank discipline and may reduce overall portfolio quality.",
         )
 
     return (

--- a/tests/test_decision_review.py
+++ b/tests/test_decision_review.py
@@ -12,6 +12,7 @@ from app.planner.decision_review import (
     compute_trade_review,
     detect_decision_mistakes,
 )
+from app.planner.portfolio_ui import _translate_review_row
 
 
 def _signals_df():
@@ -249,3 +250,68 @@ def test_detect_decision_mistakes_keeps_cooldown_check_when_trades_are_allocatio
     mistake_types = {item["type"] for item in mistakes}
 
     assert "cooldown_violation" in mistake_types
+
+
+def test_translate_review_row_rank_deviation_mapping():
+    row = {
+        "deviation_type": "rank_deviation",
+        "selected_rank": 5,
+        "best_available_rank": 2,
+        "followed_rules": False,
+        "quality_flag": "pass",
+        "liquidity_flag": "pass",
+    }
+
+    status, what_happened, why_it_matters = _translate_review_row(row)
+
+    assert status == "Rank order deviation"
+    assert "lower-ranked trade was selected" in what_happened
+    assert "breaks rank discipline" in why_it_matters
+
+
+def test_translate_review_row_no_false_positive_rank_deviation_message():
+    quality_row = {
+        "deviation_type": "quality_deviation",
+        "followed_rules": False,
+        "quality_flag": "fail",
+        "liquidity_flag": "pass",
+    }
+    normal_row = {
+        "deviation_type": None,
+        "followed_rules": True,
+        "quality_flag": "pass",
+        "liquidity_flag": "pass",
+    }
+
+    quality_status, quality_happened, quality_matters = _translate_review_row(quality_row)
+    normal_status, normal_happened, normal_matters = _translate_review_row(normal_row)
+
+    combined_text = " ".join(
+        [
+            quality_status,
+            quality_happened,
+            quality_matters,
+            normal_status,
+            normal_happened,
+            normal_matters,
+        ]
+    ).lower()
+
+    assert "rank order deviation" not in combined_text
+    assert "lower-ranked trade was selected" not in combined_text
+    assert "breaks rank discipline" not in combined_text
+
+
+def test_translate_review_row_does_not_use_inverted_rank_deviation_wording():
+    row = {
+        "deviation_type": "rank_deviation",
+        "followed_rules": False,
+        "quality_flag": "pass",
+        "liquidity_flag": "pass",
+    }
+
+    status, what_happened, why_it_matters = _translate_review_row(row)
+    combined_text = f"{status} {what_happened} {why_it_matters}".lower()
+
+    assert "not funded due to stronger-ranked setups" not in combined_text
+    assert "rank discipline preserved" not in combined_text

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -56,3 +56,13 @@ def test_execution_copy_has_no_predictive_or_advisory_language():
     blob = " ".join(payload.values())
     assert contains_advisory_language(blob) is False
     assert "guaranteed fill" in payload["entry_reference"]
+
+
+def test_planned_exit_falls_back_when_holding_window_is_non_positive_or_invalid():
+    zero_payload = build_execution_summary({"holding_window": 0})
+    negative_payload = build_execution_summary({"holding_window": -5})
+    invalid_payload = build_execution_summary({"holding_window": "invalid"})
+
+    assert "Planned exit timing is not specified" in zero_payload["planned_exit"]
+    assert "Planned exit timing is not specified" in negative_payload["planned_exit"]
+    assert "Planned exit timing is not specified" in invalid_payload["planned_exit"]

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -6,7 +6,9 @@ sys.path.append(str(ROOT))
 
 from app.planner.portfolio_ui import (
     _compact_execution_summary,
+    _extract_holding_days,
     _first_sentence,
+    _format_holding_window_label,
     _group_mistakes_for_display,
     render_portfolio_plan,
 )
@@ -93,7 +95,7 @@ def test_render_portfolio_plan_uses_cleaned_plan_labels_in_beginner_mode():
     assert "Setup Strength" in funded_df.columns
     assert "Strong setup" in funded_df.iloc[0]["Setup Strength"]
     assert "High confidence" in funded_df.iloc[0]["Confidence / Reliability"]
-    assert funded_df.iloc[0]["Holding Window"] == "Plan-defined window"
+    assert funded_df.iloc[0]["Holding Window"] == "Not specified"
     assert "Primary Rule/Constraint" not in funded_df.columns
     assert "Primary Rule/Constraint" not in unfunded_df.columns
     assert "Selected because" in funded_df.iloc[0]["Why this trade"]
@@ -382,3 +384,18 @@ def test_first_sentence_keeps_initialism_abbreviation_in_first_sentence():
     )
 
     assert _first_sentence(text) == "Focus on U.S. large-cap names when liquidity thins."
+
+
+def test_extract_holding_days_accepts_positive_values_only():
+    assert _extract_holding_days(10) == 10
+    assert _extract_holding_days("10 trading days") == 10
+    assert _extract_holding_days("0 trading days") is None
+    assert _extract_holding_days("-5 trading days") is None
+    assert _extract_holding_days("window: 5? maybe") is None
+
+
+def test_format_holding_window_label_falls_back_for_invalid_or_non_positive_values():
+    assert _format_holding_window_label(10) == "~10 trading days"
+    assert _format_holding_window_label("0 trading days") == "Not specified"
+    assert _format_holding_window_label("-5 trading days") == "Not specified"
+    assert _format_holding_window_label("invalid window") == "Not specified"


### PR DESCRIPTION
### Motivation
- Ensure `holding_window` values are parsed and validated consistently across the UI and summaries so non-positive or malformed values do not produce misleading labels or guidance.
- Make the planned-exit copy explicit when the holding window cannot be interpreted as a positive integer.
- Fix confusing/inverted wording for `rank_deviation` audit messages so the review table communicates the actual deviation clearly.

### Description
- Add `_extract_holding_days` to `app/planner/portfolio_ui.py` to normalize `holding_window` input (handles ints, floats, strings via `_HOLDING_WINDOW_PATTERN`, and rejects non-positive or invalid values) and use it when building execution summaries and labels.
- Introduce `_HOLDING_WINDOW_PATTERN` regex to parse common textual holding-window forms like `"10 trading days"`.
- Change `_format_holding_window_label` to use the extractor and return `"Not specified"` when a valid positive integer is not present, instead of the previous `"Plan-defined window"` wording.
- Update `_build_planned_exit` in `app/insights/execution.py` to treat non-positive and invalid windows the same as missing values and emit clearer fallback copy.
- Adjust `_translate_review_row` copy for `rank_deviation` to communicate that a lower-ranked trade was selected and that this breaks rank discipline.
- Update tests to cover: `_extract_holding_days`, `_format_holding_window_label`, the planned-exit fallback for non-positive/invalid values, and the revised `rank_deviation` messaging.

### Testing
- Ran unit tests in `tests/test_execution.py`, `tests/test_portfolio_ui.py`, and `tests/test_decision_review.py` which exercise the new parsing, label, and copy paths; all tests passed.
- Added specific tests `test_planned_exit_falls_back_when_holding_window_is_non_positive_or_invalid`, `test_extract_holding_days_accepts_positive_values_only`, `test_format_holding_window_label_falls_back_for_invalid_or_non_positive_values`, and `test_translate_review_row_rank_deviation_mapping` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3d75a3f0832291fd3a4882072001)