### PR TITLE
Make app.analysis package import-safe by removing eager re-exports

### DIFF
--- a/app/analysis/__init__.py
+++ b/app/analysis/__init__.py
@@ -1,15 +1,1 @@
 """Ticker analysis helpers for user-friendly stock behavior insights."""
-
-from .ticker_drilldown import build_ticker_drilldown
-from .ticker_intelligence import (
-    build_ticker_behavior,
-    build_ticker_summary,
-    compute_ticker_metrics,
-)
-
-__all__ = [
-    "compute_ticker_metrics",
-    "build_ticker_summary",
-    "build_ticker_behavior",
-    "build_ticker_drilldown",
-]


### PR DESCRIPTION
### Motivation
- The app intermittently crashed on startup with `KeyError: 'app.analysis.ticker_intelligence'` due to eager re-exports in `app/analysis/__init__.py` while `app.py` already imports the analysis helpers directly, so removing package-level imports reduces fragile import-time coupling.

### Description
- Replaced the contents of `app/analysis/__init__.py` with only the package docstring and removed eager re-exports of `build_ticker_drilldown`, `build_ticker_behavior`, `build_ticker_summary`, and `compute_ticker_metrics`, leaving no other code or imports changed.

### Testing
- Ran `rg "from app\.analysis\.ticker_drilldown import build_ticker_drilldown|from app\.analysis\.ticker_intelligence import compute_ticker_metrics" -n app.py` (verified direct imports remain), ran `rg "from app\.analysis import|import app\.analysis" -n .` (verified no package-root imports to update), and verified the targeted change via `git status --short` and a successful `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc45a12d708322a6291c52ac2d676a)