### PR TITLE
Fix compact execution summary NameError regression

### DIFF
--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -469,23 +469,23 @@ def _compact_execution_summary(execution: Mapping[str, Any], *, mode: str = "beg
     entry_reference = _first_sentence(str(execution.get("entry_reference", "")).strip())
     entry_phrase = "Entry reference uses the signal-day close area"
     if entry_reference:
-        entry_phrase = entry_reference
+        entry_phrase = entry_reference.rstrip(".")
 
     planned_exit = str(execution.get("planned_exit", "")).strip()
-    holding_days = _extract_holding_days(planned_exit)
+    holding_days = _extract_planned_exit_days(planned_exit)
     analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
 
-    if str(row.get("deviation_type", "")).lower() == "rank_deviation":
-        return (
-            "Rank order deviation",
-            "A lower-ranked trade was selected while a higher-ranked eligible trade was available.",
-            "This breaks rank discipline and may reduce overall portfolio quality.",
-        )
+    if holding_days is None:
+        exit_phrase = "planned exit timing is not specified"
+    elif analyst_mode:
+        exit_phrase = f"planned exit after {holding_days} trading days"
+    else:
+        exit_phrase = f"planned exit after {holding_days} trading days"
 
     return f"{entry_phrase}; {exit_phrase}."
 
 
-def _extract_holding_days(planned_exit: str) -> int | None:
+def _extract_planned_exit_days(planned_exit: str) -> int | None:
     match = re.search(r"(\d+)\s+trading\s+days", str(planned_exit or ""), flags=re.IGNORECASE)
     if match is None:
         return None

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -364,6 +364,18 @@ def test_compact_execution_summary_has_no_advisory_language_in_both_modes():
     assert contains_advisory_language(analyst) is False
 
 
+
+
+def test_compact_execution_summary_ignores_deviation_type_without_row_context():
+    compact = _compact_execution_summary(
+        {
+            "entry_reference": "Use the signal-day close area as a reference, not an exact guaranteed fill.",
+            "planned_exit": "Default exit is after about 8 trading days, unless conditions are reviewed earlier.",
+            "deviation_type": "rank_deviation",
+        }
+    )
+
+    assert "planned exit after 8 trading days" in compact
 def test_compact_execution_summary_uses_not_specified_exit_fallback():
     compact = _compact_execution_summary(
         {


### PR DESCRIPTION
### Motivation
- The Streamlit app crashed with `NameError: name 'row' is not defined` because `_compact_execution_summary` referenced a `row` variable that does not exist in its scope.

### Description
- Remove the stale `row` reference in `_compact_execution_summary` and make the function rely only on the provided `execution` payload.
- Derive the exit wording from `execution["planned_exit"]` via a small helper ` _extract_planned_exit_days` and produce `exit_phrase` accordingly, preserving the compact wording and mode handling.
- Trim trailing periods from the extracted `entry_reference` with `rstrip(".")` to avoid double punctuation in the composed sentence.
- Add a regression test `test_compact_execution_summary_ignores_deviation_type_without_row_context` in `tests/test_portfolio_ui.py` to ensure the compact summary does not depend on an outer `row` context.

### Testing
- Ran `pytest -q tests/test_portfolio_ui.py -k compact_execution_summary`, which passed (compact-summary-focused tests: 5 passed, 18 deselected). 
- Ran full `pytest -q tests/test_portfolio_ui.py` earlier and observed unrelated pre-existing failures (3 failing) in review-audit translation (`_translate_review_row` missing) and a holding-window label expectation mismatch, which are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4b679e2c83228d2e30de63ac856e)