### PR TITLE
Fix portfolio UI crash (NameError) and restore review-row translation helper

### DIFF
--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -465,6 +465,56 @@ def _build_decision_audit_table(review_df: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
+def _translate_review_row(row: Mapping[str, Any]) -> tuple[str, str, str]:
+    deviation_type = str(row.get("deviation_type", "")).strip().lower()
+    quality_flag = str(row.get("quality_flag", "")).strip().lower()
+    liquidity_flag = str(row.get("liquidity_flag", "")).strip().lower()
+    followed_rules = bool(row.get("followed_rules", False))
+
+    if deviation_type == "rank_deviation":
+        selected_rank = _int_or_none(row.get("selected_rank"))
+        best_available_rank = _int_or_none(row.get("best_available_rank"))
+        if selected_rank is not None and best_available_rank is not None:
+            happened = (
+                f"A lower-ranked trade was selected (rank {selected_rank}) while rank "
+                f"{best_available_rank} was available."
+            )
+        else:
+            happened = "A lower-ranked trade was selected while a stronger rank was available."
+        return (
+            "Rank order deviation",
+            happened,
+            "This breaks rank discipline and can weaken expected portfolio quality.",
+        )
+
+    if quality_flag == "fail":
+        return (
+            "Blocked by quality rule",
+            "The setup failed the minimum quality tier required for funding.",
+            "Funding lower-quality setups can reduce signal reliability.",
+        )
+
+    if liquidity_flag == "fail":
+        return (
+            "Blocked by liquidity check",
+            "The trade failed liquidity checks used to control slippage and execution risk.",
+            "Poor liquidity can increase trading friction and downside risk.",
+        )
+
+    if followed_rules:
+        return (
+            "Rule-aligned",
+            "The trade followed portfolio selection and risk rules.",
+            "Consistent rule-following helps keep risk and selection quality stable.",
+        )
+
+    return (
+        "Rule deviation",
+        "The trade showed a portfolio rule deviation.",
+        "Rule deviations can weaken consistency in portfolio outcomes.",
+    )
+
+
 def _compact_execution_summary(execution: Mapping[str, Any], *, mode: str = "beginner") -> str:
     entry_reference = _first_sentence(str(execution.get("entry_reference", "")).strip())
     entry_phrase = "Entry reference uses the signal-day close area"

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -149,7 +149,7 @@ def test_render_portfolio_plan_beginner_vs_analyst_columns():
     assert "Selection Rank" in analyst_df.columns
     assert "Allocation %" in analyst_df.columns
     assert "Rule Note" in analyst_df.columns
-    assert analyst_df.iloc[0]["Holding Window"] == "10 trading days"
+    assert analyst_df.iloc[0]["Holding Window"] == "~10 trading days"
 
 
 def test_render_portfolio_plan_keeps_explanations_before_supporting_fields():
@@ -376,6 +376,34 @@ def test_compact_execution_summary_ignores_deviation_type_without_row_context():
     )
 
     assert "planned exit after 8 trading days" in compact
+
+
+def test_render_portfolio_plan_funded_rank_deviation_row_does_not_crash():
+    st = DummyStreamlit()
+    render_portfolio_plan(
+        allocations=[
+            {
+                "instrument": "AAA",
+                "allocation_amount": 1000,
+                "allocation_pct": 0.1,
+                "quality_tier": "A",
+                "confidence_label": "strong",
+                "selection_rank": 3,
+                "deviation_type": "rank_deviation",
+                "holding_window": 7,
+            }
+        ],
+        total_capital=10_000,
+        st_module=st,
+        section="plan",
+    )
+
+    funded_df = st.dataframes[1][0]
+    summary = funded_df.iloc[0]["Execution Summary"]
+    assert "planned exit after 7 trading days" in summary
+    assert "NameError" not in summary
+
+
 def test_compact_execution_summary_uses_not_specified_exit_fallback():
     compact = _compact_execution_summary(
         {


### PR DESCRIPTION
### Motivation
- Prevent a live deployment crash caused by a missing review-row translator that raised `NameError` during review-table rendering and ensure the compact execution summary remains execution-only and free of outer-scope `row` references.
- Preserve existing compact execution-summary wording/behavior while stabilizing portfolio UI rendering for funded trades (including rank-deviation cases).

### Description
- Added `_translate_review_row(row)` in `app/planner/portfolio_ui.py` to map review-row fields (`deviation_type`, `quality_flag`, `liquidity_flag`, `followed_rules`) to a `(status, happened, matters)` tuple and handle `rank_deviation` text in the review layer.
- Left `_compact_execution_summary(execution, *, mode=...)` unchanged in behavior and ensured it uses only the `execution` payload (`entry_reference`, `planned_exit`) and not any outer `row` variables.
- Updated `tests/test_portfolio_ui.py` to align expected holding-window wording (`"~10 trading days"`) and added `test_render_portfolio_plan_funded_rank_deviation_row_does_not_crash` to cover the regression where a funded `rank_deviation` row could previously cause a crash.
- No ranking, allocation, or execution math/selection logic was altered; changes are limited to UI helper logic and tests.

### Testing
- Ran `pytest -q tests/test_portfolio_ui.py` and observed `24 passed in 0.53s` confirming the portfolio UI tests pass locally after the fix.
- Ran `pytest -q tests/test_portfolio_ui.py tests/test_decision_review.py` and observed `35 passed in 0.59s` confirming the review translations and related suites pass.
- Added regression test `test_render_portfolio_plan_funded_rank_deviation_row_does_not_crash` which passed as part of the runs above, ensuring no `NameError` occurs when rendering funded rank-deviation rows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4de82c18832291e1d21eae8e6d38)