### PR TITLE
Restore holding-window propagation and display in Portfolio UI

### DIFF
--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -424,7 +424,7 @@ def _format_holding_window_label(value: Any) -> str:
     window = _extract_holding_days(value)
     if window is None:
         return "Not specified"
-    return f"~{window} trading days"
+    return f"{window} trading days"
 
 
 def _extract_holding_days(value: Any) -> int | None:
@@ -523,6 +523,8 @@ def _compact_execution_summary(execution: Mapping[str, Any], *, mode: str = "beg
 
     planned_exit = str(execution.get("planned_exit", "")).strip()
     holding_days = _extract_planned_exit_days(planned_exit)
+    if holding_days is None:
+        holding_days = _extract_holding_days(execution.get("holding_window"))
     analyst_mode = str(mode or "beginner").strip().lower() == "analyst"
 
     if holding_days is None:

--- a/app/shell.py
+++ b/app/shell.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import re
+
 import pandas as pd
 
 from app.costs.engine import run_cost_engine
+
+_HOLDING_WINDOW_PATTERN = re.compile(r"([+-]?\d+)")
 
 
 def coerce_trade_rows_from_ranked(ranked_df: pd.DataFrame) -> list[dict]:
@@ -12,6 +16,12 @@ def coerce_trade_rows_from_ranked(ranked_df: pd.DataFrame) -> list[dict]:
     trade_rows: list[dict] = []
     for row in ranked_df.to_dict("records"):
         quality_tier = str(row.get("tier", "B") or "B")
+        holding_window = _coerce_holding_window(
+            row.get("holding_window"),
+            row.get("best_window"),
+            row.get("window"),
+            row.get("holding_period"),
+        )
         trade_rows.append(
             {
                 "instrument": row.get("instrument", "Unknown"),
@@ -20,9 +30,34 @@ def coerce_trade_rows_from_ranked(ranked_df: pd.DataFrame) -> list[dict]:
                 "volatility_bucket": "medium",
                 "earnings_warning_severity": "info",
                 "confidence_label": "strong" if quality_tier.upper() == "A" else "moderate",
+                "holding_window": holding_window,
             }
         )
     return trade_rows
+
+
+def _coerce_holding_window(*values: object) -> int | None:
+    for value in values:
+        if value is None or isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return value if value > 0 else None
+        if isinstance(value, float):
+            if pd.isna(value) or not value.is_integer():
+                continue
+            integer_value = int(value)
+            return integer_value if integer_value > 0 else None
+
+        match = _HOLDING_WINDOW_PATTERN.search(str(value).strip())
+        if match is None:
+            continue
+        try:
+            parsed = int(match.group(1))
+        except (TypeError, ValueError):
+            continue
+        if parsed > 0:
+            return parsed
+    return None
 
 
 def build_analyst_dataset(canonical_df: pd.DataFrame, ranked_df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -7,7 +7,7 @@ import pandas as pd
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-from app.shell import build_analyst_dataset
+from app.shell import build_analyst_dataset, coerce_trade_rows_from_ranked
 
 
 def test_build_analyst_dataset_returns_return_bearing_trades_with_quality_tier(monkeypatch):
@@ -143,3 +143,21 @@ def test_extract_ticker_options_does_not_split_marker_variants():
     ticker_options = app_main._extract_ticker_options(canonical_df)
 
     assert ticker_options == ["CAR", "GK"]
+
+
+def test_coerce_trade_rows_from_ranked_preserves_holding_window_values():
+    ranked_df = pd.DataFrame(
+        {
+            "instrument": ["AAA", "BBB", "CCC", "DDD"],
+            "tier": ["A", "B", "A", "B"],
+            "holding_window": [10, None, None, -5],
+            "best_window": [None, "20D", "30 trading days", None],
+        }
+    )
+
+    rows = coerce_trade_rows_from_ranked(ranked_df)
+
+    assert rows[0]["holding_window"] == 10
+    assert rows[1]["holding_window"] == 20
+    assert rows[2]["holding_window"] == 30
+    assert rows[3]["holding_window"] is None

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -149,7 +149,7 @@ def test_render_portfolio_plan_beginner_vs_analyst_columns():
     assert "Selection Rank" in analyst_df.columns
     assert "Allocation %" in analyst_df.columns
     assert "Rule Note" in analyst_df.columns
-    assert analyst_df.iloc[0]["Holding Window"] == "~10 trading days"
+    assert analyst_df.iloc[0]["Holding Window"] == "10 trading days"
 
 
 def test_render_portfolio_plan_keeps_explanations_before_supporting_fields():
@@ -484,7 +484,55 @@ def test_extract_holding_days_accepts_positive_values_only():
 
 
 def test_format_holding_window_label_falls_back_for_invalid_or_non_positive_values():
-    assert _format_holding_window_label(10) == "~10 trading days"
+    assert _format_holding_window_label(10) == "10 trading days"
     assert _format_holding_window_label("0 trading days") == "Not specified"
     assert _format_holding_window_label("-5 trading days") == "Not specified"
     assert _format_holding_window_label("invalid window") == "Not specified"
+
+
+def test_render_portfolio_plan_shows_explicit_holding_window_for_funded_and_unfunded_rows():
+    st = DummyStreamlit()
+    render_portfolio_plan(
+        allocations=[
+            {
+                "instrument": "AAA",
+                "allocation_amount": 1000,
+                "allocation_pct": 0.1,
+                "quality_tier": "A",
+                "confidence_label": "strong",
+                "selection_rank": 1,
+                "holding_window": 10,
+            },
+            {
+                "instrument": "BBB",
+                "allocation_amount": 0,
+                "allocation_pct": 0.0,
+                "quality_tier": "B",
+                "confidence_label": "moderate",
+                "selection_rank": 4,
+                "holding_window": 20,
+                "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
+            },
+        ],
+        total_capital=10_000,
+        st_module=st,
+        section="plan",
+        mode="beginner",
+    )
+
+    funded_df = st.dataframes[1][0]
+    unfunded_df = st.dataframes[2][0]
+
+    assert funded_df.iloc[0]["Holding Window"] == "10 trading days"
+    assert unfunded_df.iloc[0]["Holding Window"] == "20 trading days"
+
+
+def test_compact_execution_summary_uses_holding_window_when_planned_exit_missing():
+    compact = _compact_execution_summary(
+        {
+            "entry_reference": "Use the signal-day close area as a reference, not an exact guaranteed fill.",
+            "holding_window": 30,
+        }
+    )
+
+    assert "planned exit after 30 trading days" in compact


### PR DESCRIPTION
### Motivation
- The Portfolio Plan tables and compact execution summary were showing `Not specified` for trades with valid holding windows because the planner rows lost `holding_window` during recent row-shaping changes.
- The goal is to ensure the UI shows explicit holding-window text (e.g. `5 trading days`, `10 trading days`) and to use that value in compact summaries when `planned_exit` is not present.

### Description
- Preserve and derive `holding_window` when shaping ranked rows by extending `coerce_trade_rows_from_ranked` in `app/shell.py` and adding a parsing helper `_coerce_holding_window(...)` that accepts `holding_window`, `best_window`, `window`, and `holding_period` variants.
- Render holding-window labels explicitly by changing `_format_holding_window_label` in `app/planner/portfolio_ui.py` to return `"<N> trading days"` (no `~` prefix). 
- Make compact execution summary fall back to `execution["holding_window"]` when `planned_exit` text does not include explicit days by updating `_compact_execution_summary` in `app/planner/portfolio_ui.py`.
- Update and add tests to validate funded/unfunded rows and compact summaries, and ensure the shell shaping preserves/derives holding windows.

### Testing
- Added/updated unit tests in `tests/test_portfolio_ui.py` and `tests/test_app_shell.py` covering funded and unfunded rows with `holding_window`, the compact-summary fallback, and the shell coercion behavior. 
- Ran `pytest -q tests/test_portfolio_ui.py tests/test_app_shell.py` and observed all tests passed (`32 passed`).
- Confirmed no changes were made to ranking, allocation math, or execution math; changes are limited to row-shaping propagation, UI label formatting, and compact-summary fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc52e9b66483229ce4ca6db27b20d4)