### PR TITLE
Skip non-positive holding-window candidates during fallback scanning

### DIFF
--- a/app/shell.py
+++ b/app/shell.py
@@ -41,12 +41,16 @@ def _coerce_holding_window(*values: object) -> int | None:
         if value is None or isinstance(value, bool):
             continue
         if isinstance(value, int):
-            return value if value > 0 else None
+            if value > 0:
+                return value
+            continue
         if isinstance(value, float):
             if pd.isna(value) or not value.is_integer():
                 continue
             integer_value = int(value)
-            return integer_value if integer_value > 0 else None
+            if integer_value > 0:
+                return integer_value
+            continue
 
         match = _HOLDING_WINDOW_PATTERN.search(str(value).strip())
         if match is None:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -161,3 +161,23 @@ def test_coerce_trade_rows_from_ranked_preserves_holding_window_values():
     assert rows[1]["holding_window"] == 20
     assert rows[2]["holding_window"] == 30
     assert rows[3]["holding_window"] is None
+
+
+def test_coerce_trade_rows_from_ranked_skips_non_positive_holding_window_for_fallback_fields():
+    ranked_df = pd.DataFrame(
+        {
+            "instrument": ["AAA", "BBB", "CCC", "DDD"],
+            "tier": ["A", "B", "A", "B"],
+            "holding_window": [0, -1, None, 0],
+            "best_window": ["20D", None, None, "0D"],
+            "window": [None, 30, None, None],
+            "holding_period": [None, None, "10 trading days", "0 trading days"],
+        }
+    )
+
+    rows = coerce_trade_rows_from_ranked(ranked_df)
+
+    assert rows[0]["holding_window"] == 20
+    assert rows[1]["holding_window"] == 30
+    assert rows[2]["holding_window"] == 10
+    assert rows[3]["holding_window"] is None


### PR DESCRIPTION
### Motivation
- Ensure holding-window fallback scanning does not stop when encountering non-positive numeric candidates so later fallback fields (e.g., `best_window`, `window`, `holding_period`) can be considered.
- Fix a regression where `_coerce_holding_window(...)` returned `None` immediately for `0` or negative numeric values, preventing valid parsed fallbacks from being used in the UI.

### Description
- Files updated: `app/shell.py` and `tests/test_app_shell.py`.
- Exact fallback-scanning logic changed: `_coerce_holding_window(...)` now skips non-positive numeric candidates (`int` and integer-like `float`) with `continue` instead of returning `None` immediately, allowing subsequent fallback fields to be scanned; the function still returns the first valid positive parsed value and returns `None` only after all candidates are exhausted.
- Tests added/updated: added `test_coerce_trade_rows_from_ranked_skips_non_positive_holding_window_for_fallback_fields` in `tests/test_app_shell.py` to assert fallback resolution in these cases (`holding_window=0` → `best_window='20D'` yields `20`, `holding_window=-1` → `window=30` yields `30`, `holding_window=None` → `holding_period='10 trading days'` yields `10`, and all invalid candidates → `None`).
- Key diff excerpts: changed `return value if value > 0 else None` to `if value > 0: return value; continue` and `return integer_value if integer_value > 0 else None` to `if integer_value > 0: return integer_value; continue` in `app/shell.py`.
- Confirmation: no ranking, allocation, execution, or wording logic was changed beyond this coercion helper and the focused test addition.

### Testing
- Ran `pytest -q tests/test_app_shell.py tests/test_portfolio_ui.py` to validate changes.
- Result: `33 passed` (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc55b1f9a48322903e539ca408d81a)