### PR TITLE
Cache heavy Streamlit steps and limit Beginner unfunded table to improve performance

### DIFF
--- a/app.py
+++ b/app.py
@@ -187,6 +187,15 @@ def _run_demo_with_active_dataset(
     return run_demo()
 
 
+def _freeze_issues(issues: dict | None) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    safe_issues = issues or {}
+    return tuple(sorted((str(key), tuple(str(item) for item in value)) for key, value in safe_issues.items()))
+
+
+def _unfreeze_issues(frozen_issues: tuple[tuple[str, tuple[str, ...]], ...]) -> dict[str, list[str]]:
+    return {key: list(values) for key, values in frozen_issues}
+
+
 def _render_visual_polish(st_module) -> None:
     st_module.markdown(
         """
@@ -267,7 +276,44 @@ def main() -> None:
     mode = st.radio("Mode", options=["Beginner", "Analyst"], horizontal=True, index=0)
     mode_token = mode.lower()
 
-    canonical_df, meta, issues = ingest_dataset("demo")
+    @st.cache_data(show_spinner=False)
+    def _cached_ingest_dataset() -> tuple[pd.DataFrame, dict, tuple[tuple[str, tuple[str, ...]], ...]]:
+        canonical_df_value, meta_value, issues_value = ingest_dataset("demo")
+        return canonical_df_value, meta_value, _freeze_issues(issues_value)
+
+    @st.cache_data(show_spinner=False)
+    def _cached_run_demo_payload(
+        canonical_df_value: pd.DataFrame,
+        meta_value: dict,
+        frozen_issues: tuple[tuple[str, tuple[str, ...]], ...],
+    ) -> pd.DataFrame:
+        payload = _run_demo_with_active_dataset(
+            canonical_df=canonical_df_value,
+            meta=meta_value,
+            issues=_unfreeze_issues(frozen_issues),
+        )
+        return payload.get("ranked", pd.DataFrame())
+
+    @st.cache_data(show_spinner=False)
+    def _cached_build_analyst_dataset(canonical_df_value: pd.DataFrame, ranked_df_value: pd.DataFrame) -> pd.DataFrame:
+        return build_analyst_dataset(canonical_df_value, ranked_df_value)
+
+    @st.cache_data(show_spinner=False)
+    def _cached_extract_ticker_options(canonical_df_value: pd.DataFrame) -> list[str]:
+        return _extract_ticker_options(canonical_df_value)
+
+    @st.cache_data(show_spinner=False)
+    def _cached_ticker_payloads(
+        analyst_df_value: pd.DataFrame,
+        ticker: str,
+        mode_value: str,
+    ) -> tuple[dict, dict]:
+        payload = build_ticker_drilldown(analyst_df_value, ticker)
+        metrics = compute_ticker_metrics(analyst_df_value, ticker, mode=mode_value)
+        return payload, metrics
+
+    canonical_df, meta, frozen_issues = _cached_ingest_dataset()
+    issues = _unfreeze_issues(frozen_issues)
     dataset_source_label = str(meta.get("dataset_source_label") or "unknown_dataset")
     st.caption(f"Data source: {dataset_source_label}")
     st.caption("Using historical data from the Jamaican stock market.")
@@ -279,13 +325,8 @@ def main() -> None:
         st.warning("No rows were loaded from the data layer. Please verify the internal sample data file.")
         return
 
-    demo_payload = _run_demo_with_active_dataset(
-        canonical_df=canonical_df,
-        meta=meta,
-        issues=issues,
-    )
-    ranked_df = demo_payload.get("ranked", pd.DataFrame())
-    analyst_df = build_analyst_dataset(canonical_df, ranked_df)
+    ranked_df = _cached_run_demo_payload(canonical_df, meta, frozen_issues)
+    analyst_df = _cached_build_analyst_dataset(canonical_df, ranked_df)
     trade_rows = coerce_trade_rows_from_ranked(ranked_df) if not ranked_df.empty else []
 
     default_capital = 100_000.0
@@ -348,13 +389,12 @@ def main() -> None:
 
     with tab_map["Ticker Analysis"]:
         st.markdown("### Ticker Analysis")
-        ticker_options = _extract_ticker_options(canonical_df)
+        ticker_options = _cached_extract_ticker_options(canonical_df)
         if not ticker_options:
             st.info("Ticker Analysis is unavailable because no ticker rows are loaded.")
         else:
             selected_ticker = st.selectbox("Select ticker", ticker_options)
-            ticker_payload = build_ticker_drilldown(analyst_df, selected_ticker)
-            ticker_metrics = compute_ticker_metrics(analyst_df, selected_ticker, mode=mode_token)
+            ticker_payload, ticker_metrics = _cached_ticker_payloads(analyst_df, selected_ticker, mode_token)
             analyst_mode = mode_token == "analyst"
             metrics_stats = ticker_metrics.get("stats", {})
             metrics_behavior = ticker_metrics.get("behavior", {})

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -43,6 +43,7 @@ _HOLDING_WINDOW_PATTERN = re.compile(
     r"^\s*([+-]?\d+)\s*(?:trading\s+days?|days?|d)?\s*$",
     re.IGNORECASE,
 )
+_BEGINNER_UNFUNDED_ROW_LIMIT = 12
 
 
 def build_portfolio_summary(
@@ -216,10 +217,22 @@ def render_portfolio_plan(
 
         st_module.markdown("#### Unfunded Trades")
         if unfunded_trades:
-            unfunded_df = pd.DataFrame(
-                [_portfolio_plan_row(trade, funded=False) for trade in unfunded_trades]
-            )
+            visible_unfunded = unfunded_trades
+            hidden_unfunded_count = 0
+            if not analyst_mode and len(unfunded_trades) > _BEGINNER_UNFUNDED_ROW_LIMIT:
+                visible_unfunded = sorted(
+                    unfunded_trades,
+                    key=lambda trade: float(trade.get("selection_rank", 10_000) or 10_000),
+                )[:_BEGINNER_UNFUNDED_ROW_LIMIT]
+                hidden_unfunded_count = len(unfunded_trades) - len(visible_unfunded)
+
+            unfunded_df = pd.DataFrame([_portfolio_plan_row(trade, funded=False) for trade in visible_unfunded])
             st_module.dataframe(unfunded_df, use_container_width=True)
+            if hidden_unfunded_count > 0:
+                st_module.caption(
+                    f"Showing top {_BEGINNER_UNFUNDED_ROW_LIMIT} unfunded trades for speed. "
+                    f"Switch to Analyst mode to view all {len(unfunded_trades)} rows."
+                )
         else:
             st_module.info("No unfunded trades for the selected inputs.")
 

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -181,3 +181,17 @@ def test_coerce_trade_rows_from_ranked_skips_non_positive_holding_window_for_fal
     assert rows[1]["holding_window"] == 30
     assert rows[2]["holding_window"] == 10
     assert rows[3]["holding_window"] is None
+
+
+def test_freeze_and_unfreeze_issues_round_trip():
+    spec = importlib.util.spec_from_file_location("app_main", ROOT / "app.py")
+    app_main = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_main)
+
+    issues = {"warnings": ["w1", "w2"], "errors": ["e1"]}
+
+    frozen = app_main._freeze_issues(issues)
+    restored = app_main._unfreeze_issues(frozen)
+
+    assert restored == issues

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -258,6 +258,43 @@ def test_render_portfolio_plan_reframes_rules_and_analyst_override_copy():
     assert "may include lower-ranked setups and reduce reserve discipline" in combined
 
 
+def test_render_portfolio_plan_limits_unfunded_rows_in_beginner_mode():
+    st = DummyStreamlit()
+    allocations = [
+        {
+            "instrument": "AAA",
+            "allocation_amount": 1000,
+            "allocation_pct": 0.1,
+            "quality_tier": "A",
+            "confidence_label": "strong",
+            "selection_rank": 1,
+        }
+    ]
+    allocations.extend(
+        {
+            "instrument": f"U{i:02d}",
+            "allocation_amount": 0,
+            "quality_tier": "B",
+            "confidence_label": "moderate",
+            "selection_rank": i,
+            "allocation_reason_clear": "Final allocation is 0% because max funded trades reached (3).",
+        }
+        for i in range(2, 22)
+    )
+
+    render_portfolio_plan(
+        allocations=allocations,
+        total_capital=10_000,
+        st_module=st,
+        section="plan",
+        mode="beginner",
+    )
+
+    unfunded_df = st.dataframes[2][0]
+    assert len(unfunded_df) == 12
+    assert any("Showing top 12 unfunded trades for speed." in caption for caption in st.captions)
+
+
 def test_render_review_tab_uses_human_readable_decision_audit_table():
     st = DummyStreamlit()
     render_portfolio_plan(


### PR DESCRIPTION
### Motivation
- The app experienced slow reruns and heavy page loads due to repeated expensive deterministic computations and large table rendering. 
- The goal is to reduce perceived and actual latency without changing ranking/allocation logic or user-visible copy. 

### Description
- Added Streamlit `@st.cache_data` wrappers in `app.py` for deterministic heavy steps: ingestion, ranked/demo payload generation, analyst-dataset construction, ticker-option extraction, and ticker drilldown/metrics generation. 
- Introduced `_freeze_issues` / `_unfreeze_issues` helpers so ingestion `issues` can be used as cache-safe, hashable inputs without changing behavior. 
- Reduced default rendering cost in `app/planner/portfolio_ui.py` by limiting Beginner-mode unfunded trades to the top 12 rows (by selection rank) and showing a caption that Analyst mode exposes the full table. 
- Added focused tests covering the unfunded-row cap and the issues freeze/unfreeze round trip. 

### Testing
- Ran the focused automated test suite: `pytest -q tests/test_portfolio_ui.py tests/test_app_shell.py`, which completed successfully (`35 passed`). 
- Added/updated tests: `test_render_portfolio_plan_limits_unfunded_rows_in_beginner_mode` and `test_freeze_and_unfreeze_issues_round_trip`, both included in the run and passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc56e17fcc832285e1600dcf01bb2c)