### PR TITLE
Docs: clarify README and portfolio case study language and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,40 @@
 # JSE Market Lab
 
-A beta-stage decision-support product that helps retail investors evaluate Jamaican Stock Exchange opportunities using structured rules instead of guesswork.
+JSE Market Lab is a public-beta decision-support product that helps retail investors evaluate Jamaican Stock Exchange opportunities with explicit rules, constraints, and trade-offs.
 
 ## Beta status
-This repository reflects a **public beta** release: stable enough to explore, still evolving through documented iteration.
+This repository is a **public beta**: stable enough for evaluation, still evolving through documented iteration and user feedback.
 
 ## What problem it solves
-Many retail investors can see market data but still struggle to:
+Many retail investors can access market data but still struggle to:
 - compare opportunities consistently,
 - account for costs and liquidity,
 - handle earnings-related uncertainty,
-- turn signals into disciplined portfolio actions.
+- convert signals into disciplined portfolio actions.
 
 ## What the product does
-JSE Market Lab converts market inputs into a structured decision workflow:
+JSE Market Lab converts price action, earnings context, liquidity signals, and trading costs into a repeatable decision workflow:
 
 `Data -> Signal -> Score -> Risk Flags -> Confidence -> Allocation -> Portfolio Plan`
 
 ## Core features
-- Rule-based signal detection for JSE instruments.
-- Trade quality scoring (Tier A/B/C).
-- Cost-aware outputs (broker fee + CESS assumptions).
-- Earnings phase tagging and warning context.
-- Confidence and prioritization layer.
-- Portfolio allocation planner with cash/exposure constraints.
-- Review layer for post-decision discipline feedback.
+- Detects rule-based signals for JSE instruments.
+- Scores each setup using a Tier A/B/C quality model.
+- Applies broker-fee and CESS assumptions to frame net outcomes.
+- Tags earnings phases and surfaces relevant risk warnings.
+- Ranks candidates with confidence and prioritization signals.
+- Plans allocations with cash and exposure constraints.
+- Supports post-decision review to reinforce discipline.
 
 ## Why it is different
 - Built as a **decision-support system**, not a pick-selling feed.
-- Emphasizes explainability and product clarity over prediction claims.
-- Anchored in Jamaican market context while using globally understandable product design.
+- Shows how each output is derived, so users can audit the logic.
+- Models Jamaican market frictions directly (costs, liquidity, and event risk).
 
 ## Positioning and non-goals
 This project is:
 - a structured decision-support tool,
-- a product portfolio artifact showing end-to-end product thinking.
+- a product portfolio artifact that shows end-to-end product thinking from framing to iteration.
 
 This project is **not**:
 - financial advice,
@@ -42,13 +42,13 @@ This project is **not**:
 - an auto-trading or signal-selling service.
 
 ## Key docs
-- [Product Brief](docs/product_brief.md)
-- [Feature Breakdown](docs/feature_breakdown.md)
-- [Product Decisions](docs/product_decisions.md)
-- [Iteration Log](docs/iteration_log.md)
-- [Portfolio Case Study](docs/portfolio_case_study.md)
-- [User Flow](docs/user_flow.md)
-- [Selected UAT Samples](docs/uat/)
+- [Product Brief](./docs/product_brief.md)
+- [Feature Breakdown](./docs/feature_breakdown.md)
+- [Product Decisions](./docs/product_decisions.md)
+- [Iteration Log](./docs/iteration_log.md)
+- [Portfolio Case Study](./docs/portfolio_case_study.md)
+- [User Flow](./docs/user_flow.md)
+- [Selected UAT Samples](./docs/uat/)
 
 ## Run locally
 ```bash

--- a/docs/portfolio_case_study.md
+++ b/docs/portfolio_case_study.md
@@ -1,32 +1,32 @@
 # Portfolio Case Study — JSE Market Lab
 
 ## Problem
-Retail investors often have access to prices and headlines but lack a reliable framework for deciding:
+Retail investors often have prices and headlines but lack a reliable framework for deciding:
 - which opportunities are actionable,
 - how much risk is acceptable,
 - and how to size positions under real constraints.
 
-In the JSE context, this is amplified by lower liquidity, uneven coverage, and execution friction.
+In the JSE, lower liquidity, uneven coverage, and execution friction make this gap more costly.
 
 ## Target users
 - **Primary:** self-directed beginner and intermediate retail investors.
 - **Secondary:** analyst-minded users who want transparent, rule-based evaluation before deploying capital.
 
 ## Product goal
-Build a decision-support product that turns noisy market information into a consistent portfolio decision process without pretending to predict outcomes.
+Build a decision-support product that turns noisy market information into a consistent portfolio process without claiming to predict outcomes.
 
 ## System overview
-The product flow is intentionally simple:
+The product flow is intentionally explicit:
 
 `Data -> Signal -> Quality Score -> Risk Context -> Confidence -> Allocation -> Plan/Review`
 
 Key layers:
 - signal detection,
 - tiered quality scoring,
-- earnings and liquidity-aware risk context,
+- earnings- and liquidity-aware risk context,
 - cost-aware return framing,
 - allocation constraints and portfolio planning,
-- post-decision review for user discipline.
+- post-decision review for discipline and accountability.
 
 ## Key product decisions
 - Positioning stayed firmly in **decision support**, not signal-selling.
@@ -34,28 +34,28 @@ Key layers:
 - Hard-stop constraints (for example, quality/liquidity failures) prevent forced allocation.
 - Costs are included so output reflects realistic outcomes.
 - Warnings are informative rather than blocking, preserving user agency.
-- Language and UI are tuned for Jamaican readability while remaining professional for a broader audience.
+- Language and UI are tuned for Jamaican readability while remaining credible to a broader audience.
 
 (See full decision history in [Product Decisions](product_decisions.md).)
 
 ## Product evolution across sprints/phases
-- **Phase 1:** signal and ranking foundation.
-- **Phase 2:** realism upgrades (costs, liquidity, event-aware context).
-- **Phase 3:** decision clarity layers (guidance, confidence, prioritization).
-- **Phase 4:** allocation and planner surfaces.
-- **Phase 5:** review-and-discipline feedback plus beta hardening and deployment framing.
+- **Phase 1:** established the signal and ranking foundation.
+- **Phase 2:** added realism through costs, liquidity, and event-aware context.
+- **Phase 3:** improved decision clarity with guidance, confidence, and prioritization.
+- **Phase 4:** introduced allocation and planner surfaces for portfolio action.
+- **Phase 5:** added review-and-discipline feedback, then hardened for public beta.
 
 ## UAT and iteration highlights
-Selected UAT checkpoints were preserved to show product maturity over time:
-- early baseline validation ([Sprint 1 UAT](uat/uat_sprint_1.md)),
-- middle-phase usability and structure checks ([Sprint 7 UAT](uat/uat_sprint_7.md)),
-- late-stage beta readiness and quality checks ([Sprint 13 UAT](uat/uat_sprint_13.md)).
+Selected UAT checkpoints show how the product matured from concept to beta:
+- early baseline validation to confirm core logic ([Sprint 1 UAT](uat/uat_sprint_1.md)),
+- mid-cycle usability and structure checks to improve decision flow ([Sprint 7 UAT](uat/uat_sprint_7.md)),
+- late-stage readiness checks to verify beta quality and consistency ([Sprint 13 UAT](uat/uat_sprint_13.md)).
 
-Broader sprint history remains archived for traceability.
+The broader sprint history is retained for traceability and context.
 
 ## Beta launch context
-This repo now represents a cleaner beta-stage product portfolio:
-- public-facing docs emphasize product value and system logic,
+At beta launch, the project is presented as a focused product portfolio:
+- public-facing docs emphasize product logic and decision value,
 - sprint-heavy operational artifacts are archived,
 - core artifacts remain visible for recruiters, collaborators, and beta users.
 
@@ -63,5 +63,5 @@ This repo now represents a cleaner beta-stage product portfolio:
 JSE Market Lab demonstrates:
 - end-to-end product ownership,
 - iterative decision-making under constraints,
-- practical translation of analytics into user-facing workflow,
+- practical translation of analytics into a user-facing decision workflow,
 - documentation discipline from internal build history to public product narrative.


### PR DESCRIPTION
### Motivation
- Improve clarity and tone across public-facing docs to better describe the product as a public beta decision-support tool. 
- Emphasize explainability, market frictions (costs, liquidity, events), and the repeatable decision workflow rather than prediction claims. 
- Make links and list formatting more consistent for easier consumption and navigation.

### Description
- Rewrote and tightened language in `README.md` to emphasize public-beta status, explicit rules/constraints, and a clearer pipeline (`Data -> Signal -> Score -> Risk Flags -> Confidence -> Allocation -> Portfolio Plan`).
- Expanded and reordered the feature list to explicitly call out signal detection, tiered scoring, cost assumptions, earnings risk tagging, prioritization, allocation planning, and review flows.
- Adjusted phrasing in `docs/portfolio_case_study.md` to make the problem statement, system overview, and product evolution more explicit and readable, and harmonized phase summaries into consistent tense and tone.
- Normalized list markers and fixed several relative links to the `docs/` folder for consistency across the repository.

### Testing
- No automated tests were required or run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6b88dc748322a240115d30593596)