### PR TITLE
Refine README to present JSE Market Lab as a beta product front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSE Market Lab
 
-JSE Market Lab is a public-beta decision-support product that helps retail investors evaluate Jamaican Stock Exchange opportunities with explicit rules, constraints, and trade-offs.
+JSE Market Lab is a **public-beta decision-support product** for retail investors in the Jamaican Stock Exchange. It helps users make clearer portfolio decisions by turning market signals, costs, and risk context into a transparent workflow they can review and challenge.
 
 ## Beta status
 This repository is a **public beta**: stable enough for evaluation, still evolving through documented iteration and user feedback.
@@ -13,23 +13,30 @@ Many retail investors can access market data but still struggle to:
 - convert signals into disciplined portfolio actions.
 
 ## What the product does
-JSE Market Lab converts price action, earnings context, liquidity signals, and trading costs into a repeatable decision workflow:
+For each instrument, JSE Market Lab:
+- ingests price behavior, earnings context, liquidity conditions, and fee assumptions,
+- applies explicit rules to detect and score setups,
+- surfaces risk flags and confidence levels,
+- translates output into allocation guidance and portfolio plan options.
+
+Workflow:
 
 `Data -> Signal -> Score -> Risk Flags -> Confidence -> Allocation -> Portfolio Plan`
 
 ## Core features
-- Detects rule-based signals for JSE instruments.
-- Scores each setup using a Tier A/B/C quality model.
-- Applies broker-fee and CESS assumptions to frame net outcomes.
-- Tags earnings phases and surfaces relevant risk warnings.
-- Ranks candidates with confidence and prioritization signals.
-- Plans allocations with cash and exposure constraints.
-- Supports post-decision review to reinforce discipline.
+- Identifies rule-based setups for listed JSE instruments.
+- Scores opportunities with a transparent Tier A/B/C quality model.
+- Estimates net outcomes using Jamaican broker-fee and CESS assumptions.
+- Flags earnings phases and event-related risk conditions.
+- Prioritizes candidates by confidence and decision relevance.
+- Generates allocation plans within cash and exposure constraints.
+- Supports post-decision review for consistency and discipline.
 
 ## Why it is different
-- Built as a **decision-support system**, not a pick-selling feed.
-- Shows how each output is derived, so users can audit the logic.
-- Models Jamaican market frictions directly (costs, liquidity, and event risk).
+- Prioritizes **explainability**: outputs are tied to explicit logic, not black-box predictions.
+- Prioritizes **clarity**: signals, scores, and risk flags are structured for fast interpretation.
+- Prioritizes **user judgment**: the product supports decisions; it does not replace investor discretion.
+- Reflects Jamaican market realities, including trading frictions, liquidity, and event risk.
 
 ## Positioning and non-goals
 This project is:
@@ -42,13 +49,13 @@ This project is **not**:
 - an auto-trading or signal-selling service.
 
 ## Key docs
-- [Product Brief](./docs/product_brief.md)
-- [Feature Breakdown](./docs/feature_breakdown.md)
-- [Product Decisions](./docs/product_decisions.md)
-- [Iteration Log](./docs/iteration_log.md)
-- [Portfolio Case Study](./docs/portfolio_case_study.md)
-- [User Flow](./docs/user_flow.md)
-- [Selected UAT Samples](./docs/uat/)
+- [Product Brief](docs/product_brief.md)
+- [Feature Breakdown](docs/feature_breakdown.md)
+- [Product Decisions](docs/product_decisions.md)
+- [Iteration Log](docs/iteration_log.md)
+- [Portfolio Case Study](docs/portfolio_case_study.md)
+- [User Flow](docs/user_flow.md)
+- [UAT](docs/uat/)
 
 ## Run locally
 ```bash


### PR DESCRIPTION
### Motivation
- Make the repository README act as a clear front door for a launched-feeling public beta decision-support product for Jamaican retail investors.
- Clarify product value by making the workflow and outputs auditable and reviewable to support user judgment rather than black-box signals.
- Improve readability and product focus so the README can serve as a concise portfolio artifact while preserving beta status, Jamaican market context, decision-support positioning, and non-goals.

### Description
- Tightened the opening value proposition to frame JSE Market Lab as a `public-beta decision-support product` for the Jamaican Stock Exchange and emphasize transparent, reviewable outputs.
- Rewrote “What the product does” into explicit per-instrument steps and preserved the workflow line `Data -> Signal -> Score -> Risk Flags -> Confidence -> Allocation -> Portfolio Plan`.
- Reworked core feature bullets into parallel, concise, product-facing statements and updated the “Why it is different” bullets to prioritize `explainability`, `clarity`, and `user judgment` while keeping Jamaican market frictions visible.
- Converted the “Key docs” section into direct markdown links to `docs/product_brief.md`, `docs/feature_breakdown.md`, `docs/product_decisions.md`, `docs/iteration_log.md`, `docs/portfolio_case_study.md`, `docs/user_flow.md`, and `docs/uat/`, and ensured the `Run locally` section is in a fenced code block.

### Testing
- This is a documentation-only change so no runtime or unit tests were required or run.
- Confirmed the updated `README.md` renders with the fenced `Run locally` block and the requested doc links present.
- Verified there are no outstanding local changes after the update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6d43abbc8322b804f6e5bd12dab8)