### PR TITLE
Fix top-level UAT markdown link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This project is **not**:
 - [Iteration Log](docs/iteration_log.md)
 - [Portfolio Case Study](docs/portfolio_case_study.md)
 - [User Flow](docs/user_flow.md)
-- [UAT](docs/uat/)
+- [UAT](docs/uat/README.md)
 
 ## Run locally
 ```bash


### PR DESCRIPTION
### Motivation
- Ensure top-level documentation links remain valid after the docs cleanup by making the `README.md` UAT link point directly to the intended document.

### Description
- Updated the `README.md` UAT link from `docs/uat/` to `docs/uat/README.md` so the relative path resolves to the README inside the UAT folder.

### Testing
- Ran a local markdown link resolution check (Python script) across `README.md` and the main docs (`docs/product_brief.md`, `docs/feature_breakdown.md`, `docs/product_decisions.md`, `docs/iteration_log.md`, `docs/portfolio_case_study.md`, `docs/user_flow.md`) and observed `BROKEN 0` indicating no remaining broken internal links.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6de87de083229b207b7426deb920)