### PR TITLE
docs: final beta docs polish for README and portfolio case study

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,57 @@
 # JSE Market Lab
 
-JSE Market Lab is a **public-beta decision-support product** for retail investors in the Jamaican Stock Exchange. It helps users make clearer portfolio decisions by turning market signals, costs, and risk context into a transparent workflow they can review and challenge.
+JSE Market Lab is a **public-beta decision-support product** for self-directed investors in the Jamaican Stock Exchange (JSE). It turns market signals, cost assumptions, and risk context into a transparent workflow users can review, challenge, and use in their own decision process.
 
 ## Beta status
-This repository is a **public beta**: stable enough for evaluation, still evolving through documented iteration and user feedback.
+This repository is in **public beta**: stable enough for evaluation, still improving through documented iteration and UAT feedback.
 
-## What problem it solves
-Many retail investors can access market data but still struggle to:
+## Problem it addresses
+Many retail investors can access prices and market commentary, but still struggle to:
 - compare opportunities consistently,
 - account for costs and liquidity,
 - handle earnings-related uncertainty,
-- convert signals into disciplined portfolio actions.
+- convert analysis into disciplined portfolio actions.
 
 ## What the product does
-For each instrument, JSE Market Lab:
+For each JSE instrument, JSE Market Lab:
 - ingests price behavior, earnings context, liquidity conditions, and fee assumptions,
 - applies explicit rules to detect and score setups,
 - surfaces risk flags and confidence levels,
-- translates output into allocation guidance and portfolio plan options.
+- translates outputs into allocation guidance and a portfolio plan.
 
 Workflow:
 
 `Data -> Signal -> Score -> Risk Flags -> Confidence -> Allocation -> Portfolio Plan`
 
-## Core features
-- Identifies rule-based setups for listed JSE instruments.
-- Scores opportunities with a transparent Tier A/B/C quality model.
-- Estimates net outcomes using Jamaican broker-fee and CESS assumptions.
-- Flags earnings phases and event-related risk conditions.
-- Prioritizes candidates by confidence and decision relevance.
-- Generates allocation plans within cash and exposure constraints.
-- Supports post-decision review for consistency and discipline.
+## Product scope
+### In scope
+- Rule-based setup detection for listed JSE instruments.
+- Tier A/B/C quality scoring with transparent logic.
+- Cost-aware framing using Jamaican broker-fee and CESS assumptions.
+- Earnings-phase and event-risk warning context.
+- Allocation planning under cash and exposure constraints.
+- Decision review outputs to support consistency and discipline.
 
-## Why it is different
-- Prioritizes **explainability**: outputs are tied to explicit logic, not black-box predictions.
-- Prioritizes **clarity**: signals, scores, and risk flags are structured for fast interpretation.
-- Prioritizes **user judgment**: the product supports decisions; it does not replace investor discretion.
-- Reflects Jamaican market realities, including trading frictions, liquidity, and event risk.
-
-## Positioning and non-goals
-This project is:
-- a structured decision-support tool,
-- a product portfolio artifact that shows end-to-end product thinking from framing to iteration.
-
-This project is **not**:
+### Non-goals
+JSE Market Lab is **not**:
 - financial advice,
 - a prediction engine,
 - an auto-trading or signal-selling service.
 
+## Why this product is useful
+- **Explainable:** outputs map to explicit rules rather than black-box predictions.
+- **Decision-oriented:** the product supports judgment; it does not replace investor discretion.
+- **Jamaican-market aware:** framing reflects local trading frictions, liquidity realities, and event risk.
+- **Portfolio-ready artifact:** documentation shows end-to-end product thinking from problem framing through beta hardening.
+
 ## Key docs
-- [Product Brief](docs/product_brief.md)
-- [Feature Breakdown](docs/feature_breakdown.md)
-- [Product Decisions](docs/product_decisions.md)
-- [Iteration Log](docs/iteration_log.md)
-- [Portfolio Case Study](docs/portfolio_case_study.md)
-- [User Flow](docs/user_flow.md)
-- [UAT](docs/uat/README.md)
+- [Product brief](./docs/product_brief.md)
+- [Feature breakdown](./docs/feature_breakdown.md)
+- [Product decisions](./docs/product_decisions.md)
+- [Iteration log](./docs/iteration_log.md)
+- [Portfolio case study](./docs/portfolio_case_study.md)
+- [User flow](./docs/user_flow.md)
+- [UAT summary and links](./docs/uat/README.md)
 
 ## Run locally
 ```bash

--- a/docs/portfolio_case_study.md
+++ b/docs/portfolio_case_study.md
@@ -1,67 +1,70 @@
 # Portfolio Case Study — JSE Market Lab
 
+## Product summary
+JSE Market Lab is a beta-stage decision-support product designed for retail investors in the Jamaican Stock Exchange. The product does not attempt to predict outcomes or automate trades. It helps users run a clearer, repeatable portfolio decision process with visible assumptions and constraints.
+
 ## Problem
 Retail investors often have access to prices and headlines but lack a reliable process for deciding:
-- which opportunities are truly actionable,
+- which opportunities are actionable,
 - how much risk is acceptable,
-- and how to size positions under real constraints.
+- and how positions should be sized under real constraints.
 
-In the Jamaican market, lower liquidity, uneven coverage, and execution friction make weak decision processes materially more expensive.
+In the Jamaican market, thinner liquidity, uneven coverage, and execution friction increase the cost of weak decision processes.
 
-## Target users
+## Users
 - **Primary:** self-directed beginner and intermediate retail investors.
-- **Secondary:** analyst-minded users who want transparent, rule-based evaluation before committing capital.
+- **Secondary:** analyst-oriented users who want transparent, rule-based evaluation before committing capital.
 
 ## Product goal
-Build a decision-support product that turns noisy market information into a consistent portfolio process, without presenting certainty or pretending to predict outcomes.
+Turn noisy market information into a consistent decision workflow that improves clarity and discipline without overstating certainty.
 
-## System overview
-The product flow is intentionally explicit:
+## Solution approach
+The core flow is intentionally explicit:
 
 `Data -> Signal -> Quality Score -> Risk Context -> Confidence -> Allocation -> Plan/Review`
 
-Key layers:
+Key system layers:
 - signal detection,
 - tiered quality scoring,
 - earnings- and liquidity-aware risk context,
 - cost-aware return framing,
-- allocation constraints and portfolio planning,
-- post-decision review for discipline and accountability.
+- allocation constraints and planner outputs,
+- post-decision review for behavior and discipline.
 
 ## Key product decisions
-- The product remained positioned as **decision support**, not signal-selling.
-- Tier C setups stayed visible but were generally not funded.
-- Hard-stop constraints (for example, quality/liquidity failures) prevented forced allocation.
-- Costs were embedded so outputs reflected realistic outcomes.
-- Warnings were informative rather than blocking, preserving user agency.
-- Language and UI were tuned for Jamaican readability while staying credible to a broader audience.
+- Keep the product positioned as **decision support**, not signal-selling.
+- Keep Tier C visible for context, while generally not funding it.
+- Use hard-stop constraints for quality and liquidity failures.
+- Embed costs so outputs reflect more realistic outcomes.
+- Use informative warnings instead of blocking actions to preserve user agency.
+- Tune language for Jamaican readability while remaining globally understandable.
 
-(See full decision history in [Product Decisions](product_decisions.md).)
+Decision history: [Product decisions](./product_decisions.md).
 
-## Product evolution across phases
-- **Phase 1:** established a credible baseline for signal detection and ranking.
-- **Phase 2:** added market realism through costs, liquidity, and event-aware context.
-- **Phase 3:** shifted from analysis to clearer decision-making with guidance, confidence, and prioritization.
-- **Phase 4:** translated insight into action through allocation and planner surfaces.
-- **Phase 5:** closed the loop with review-and-discipline feedback, then hardened the experience for public beta.
+## Product evolution (phase view)
+- **Phase 1:** baseline signal detection and ranking.
+- **Phase 2:** market realism through costs, liquidity, and event context.
+- **Phase 3:** decision clarity via guidance, confidence, and prioritization.
+- **Phase 4:** translation into action through allocation and planner surfaces.
+- **Phase 5:** review-and-discipline loop, then public-beta hardening.
 
-## UAT and iteration highlights
-Selected UAT checkpoints show progression from feature validation to product readiness:
-- baseline validation to confirm core logic and identify early trust gaps ([Sprint 1 UAT](uat/uat_sprint_1.md)),
-- mid-cycle usability checks to tighten structure, navigation, and decision flow ([Sprint 7 UAT](uat/uat_sprint_7.md)),
-- pre-beta readiness checks to verify consistency, clarity, and release confidence ([Sprint 13 UAT](uat/uat_sprint_13.md)).
+## UAT evidence and iteration quality
+Three UAT checkpoints capture progression from correctness to product readiness:
+- [Sprint 1 UAT](./uat/uat_sprint_1.md): baseline logic validation and early trust gaps.
+- [Sprint 7 UAT](./uat/uat_sprint_7.md): usability tightening for structure, navigation, and flow.
+- [Sprint 13 UAT](./uat/uat_sprint_13.md): pre-beta consistency, clarity, and release confidence checks.
 
-The broader sprint history remains available for traceability, while these milestones capture how feedback shaped product direction.
+These checkpoints are representative milestones; the full sprint record remains available for traceability.
 
-## Beta launch context
-At beta launch, the project is framed as a focused product portfolio in a real market context:
-- public-facing docs highlight decision logic and user value,
-- sprint-heavy operational artifacts are archived,
-- core artifacts remain visible for recruiters, collaborators, and beta users evaluating stage-appropriate maturity.
+## Beta-stage launch framing
+At public beta, the repo is structured to support external evaluation:
+- product-facing docs emphasize user value, decision logic, and trade-offs,
+- sprint-heavy operational artifacts are archived for reference,
+- core materials remain readable for recruiters, collaborators, and beta users.
 
-## What this demonstrates as a portfolio artifact
-JSE Market Lab demonstrates:
-- end-to-end product ownership from framing the problem to shaping beta scope,
-- product judgment through explicit trade-offs under market and data constraints,
-- iterative refinement that connects analytics to a usable investor decision workflow,
-- disciplined documentation that translates internal build history into a recruiter-readable product narrative.
+## Portfolio artifact value
+As a portfolio artifact, JSE Market Lab demonstrates:
+- end-to-end product ownership from framing to beta release quality,
+- product judgment through explicit trade-offs under market constraints,
+- iteration discipline that connects analytics to practical decision workflows,
+- documentation quality aimed at both local relevance and global readability.


### PR DESCRIPTION
### Motivation
- Improve the repo’s public-beta presentation so it reads like a launched beta product and a recruiter-friendly portfolio artifact. 
- Make top-level product docs clearer and more actionable by fixing link targets and ensuring the local run steps are easy to follow. 
- Preserve key product constraints: beta-stage status, decision-support positioning, non-goals, Jamaican market context, and recruiter readability.

### Description
- Polished `README.md` for clearer public-beta positioning, tightened problem/scope language, and a concise value statement for decision-support users. 
- Converted the README "Key docs" entries to explicit relative markdown links (using `./docs/...`) and ensured the local run command is shown in a fenced code block. 
- Rewrote `docs/portfolio_case_study.md` into a sharper product case study (problem, users, goal, solution layers, decisions, phase evolution, UAT evidence, beta framing) while preserving non-goals and Jamaican-market context. 
- Limited changes to the requested scope only: `README.md` and `docs/portfolio_case_study.md` (no file moves, renames, or new files).

### Testing
- Ran a repository link-check script (`python - <<'PY' ...`) that validated relative markdown links across `README.md` and the top-level docs surface and reported `BROKEN 0`, confirming no broken relative links in scope. 
- Manually inspected the updated files to confirm the run instructions appear in a fenced `bash` code block and the requested content constraints were preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6e925d988322ae6d2f9da5038668)