### PR TITLE
Add 'Start Here' Loom embed and section-specific help video links

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,15 @@ from app.ui.display_labels import clean_dataframe_labels
 _BEGINNER_TABS = ["Portfolio", "Review", "Ticker Analysis"]
 _ANALYST_TABS = [*_BEGINNER_TABS, "Analyst Insights", "Data"]
 
+_START_HERE_EMBED_HTML = """<div style="position: relative; padding-bottom: 62.7177700348432%; height: 0;"><iframe src="https://www.loom.com/embed/7429a995143a4bf498b640b5371309bc" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>"""
+_HELP_VIDEO_URLS = {
+    "portfolio": "https://www.loom.com/share/3b02f12dc1704595a2a717a0253b901b",
+    "read_trade": "https://www.loom.com/share/58636a4aef5e4592a605efa8bb5c20d2",
+    "ticker_analysis": "https://www.loom.com/share/c963e49ea0874277a5973ffec9d8a8f0",
+    "review": "https://www.loom.com/share/6e2058d50c5d447b98d9031b4e1050cf",
+    "analyst_mode": "https://www.loom.com/share/399c4760e90744c49fd4aadcf172f4a3",
+}
+
 
 def _has_analyst_insight_content(trades_df: pd.DataFrame, *, analyst_mode: bool) -> bool:
     if not analyst_mode or trades_df.empty:
@@ -261,6 +270,16 @@ def _render_data_status_summary(
         st_module.caption("No ingestion errors were reported for this dataset.")
 
 
+def _render_video_link(st_module, *, label: str, url: str) -> None:
+    st_module.markdown(f'<a href="{url}" target="_blank" rel="noopener noreferrer">{label}</a>', unsafe_allow_html=True)
+
+
+def _render_start_here_video(st_module) -> None:
+    st_module.markdown("### New here? Start with this video")
+    st_module.caption("This quick walkthrough shows how to use the dashboard and where to start.")
+    st_module.components.v1.html(_START_HERE_EMBED_HTML, height=460)
+
+
 def main() -> None:
     """Run the Streamlit shell with Analyst Insights and Portfolio Plan sections."""
     import streamlit as st
@@ -345,6 +364,7 @@ def main() -> None:
         insights_payload = generate_embedded_insights([], [], mode=mode_token)
 
     _render_first_run_header(st, mode=mode_token)
+    _render_start_here_video(st)
     render_embedded_insights(insights_payload, st_module=st)
 
     tabs = st.tabs(_resolve_tabs_for_mode(mode_token))
@@ -352,6 +372,8 @@ def main() -> None:
 
     with tab_map["Portfolio"]:
         st.markdown("### Portfolio Plan")
+        _render_video_link(st, label="▶ Watch: Understanding the Portfolio", url=_HELP_VIDEO_URLS["portfolio"])
+        _render_video_link(st, label="▶ Watch: How to Read a Trade", url=_HELP_VIDEO_URLS["read_trade"])
         selected_capital = st.number_input(
             "Total capital",
             min_value=0.0,
@@ -374,6 +396,7 @@ def main() -> None:
 
     with tab_map["Review"]:
         st.markdown("### Review")
+        _render_video_link(st, label="▶ Watch: Understanding Review", url=_HELP_VIDEO_URLS["review"])
         if ranked_df.empty:
             st.info("Review unavailable: ranked outputs were not generated.")
         else:
@@ -389,6 +412,7 @@ def main() -> None:
 
     with tab_map["Ticker Analysis"]:
         st.markdown("### Ticker Analysis")
+        _render_video_link(st, label="▶ Watch: Understanding Ticker Analysis", url=_HELP_VIDEO_URLS["ticker_analysis"])
         ticker_options = _cached_extract_ticker_options(canonical_df)
         if not ticker_options:
             st.info("Ticker Analysis is unavailable because no ticker rows are loaded.")
@@ -500,6 +524,7 @@ def main() -> None:
     if "Analyst Insights" in tab_map:
         with tab_map["Analyst Insights"]:
             st.markdown("### Analyst Insights")
+            _render_video_link(st, label="▶ Watch: How to Use Analyst Mode", url=_HELP_VIDEO_URLS["analyst_mode"])
             if _has_analyst_insight_content(analyst_df, analyst_mode=mode_token == "analyst"):
                 render_analyst_insights(analyst_df, st_module=st, analyst_mode=True)
             else:

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -32,6 +32,19 @@ class DummyTab:
         return False
 
 
+class DummyComponentsV1:
+    def __init__(self, st_module):
+        self._st = st_module
+
+    def html(self, html, **kwargs):
+        self._st.html_blocks.append((self._st.current_tab, html, kwargs))
+
+
+class DummyComponents:
+    def __init__(self, st_module):
+        self.v1 = DummyComponentsV1(st_module)
+
+
 class DummyStreamlit:
     def __init__(self, *, mode_choice="Analyst"):
         self.session_state = {}
@@ -44,6 +57,8 @@ class DummyStreamlit:
         self.dataframes = []
         self.captions = []
         self.selectbox_calls = []
+        self.html_blocks = []
+        self.components = DummyComponents(self)
 
     def set_page_config(self, **_kwargs):
         return None
@@ -56,6 +71,12 @@ class DummyStreamlit:
             return self.mode_choice
         return options[0]
 
+    def cache_data(self, **_kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
     def markdown(self, text, **_kwargs):
         self.markdowns.append((self.current_tab, text))
 
@@ -63,6 +84,9 @@ class DummyStreamlit:
         self.captions.append((self.current_tab, text))
 
     def info(self, text):
+        self.info_messages.append((self.current_tab, text))
+
+    def warning(self, text):
         self.info_messages.append((self.current_tab, text))
 
     def write(self, _payload):
@@ -184,6 +208,60 @@ def test_analyst_mode_keeps_all_tabs_visible(monkeypatch):
 
     assert dummy_st.tabs_requested[0] == ["Portfolio", "Review", "Ticker Analysis", "Analyst Insights", "Data"]
 
+
+
+
+def test_help_video_labels_and_links_render_in_expected_sections(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit(mode_choice="Analyst")
+
+    canonical_df = pd.DataFrame({"instrument": ["AAA"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo-v1"}, {"errors": [], "warnings": []}),
+    )
+    monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
+    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
+
+    app_main.main()
+
+    all_markdowns = [text for _, text in dummy_st.markdowns]
+    assert "### New here? Start with this video" in all_markdowns
+    assert any("▶ Watch: Understanding the Portfolio" in text for tab, text in dummy_st.markdowns if tab == "Portfolio")
+    assert any("▶ Watch: How to Read a Trade" in text for tab, text in dummy_st.markdowns if tab == "Portfolio")
+    assert any("▶ Watch: Understanding Ticker Analysis" in text for tab, text in dummy_st.markdowns if tab == "Ticker Analysis")
+    assert any("▶ Watch: Understanding Review" in text for tab, text in dummy_st.markdowns if tab == "Review")
+    assert any("▶ Watch: How to Use Analyst Mode" in text for tab, text in dummy_st.markdowns if tab == "Analyst Insights")
+    assert any("loom.com/embed/7429a995143a4bf498b640b5371309bc" in html for _, html, _ in dummy_st.html_blocks)
+
+
+def test_analyst_help_video_hidden_from_beginner_mode(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit(mode_choice="Beginner")
+
+    canonical_df = pd.DataFrame({"instrument": ["AAA"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo-v1"}, {"errors": [], "warnings": []}),
+    )
+    monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
+    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
+
+    app_main.main()
+
+    assert not any("▶ Watch: How to Use Analyst Mode" in text for _, text in dummy_st.markdowns)
 
 def test_review_excludes_data_status_and_data_tab_contains_raw_preview(monkeypatch):
     app_main = _load_app_module()


### PR DESCRIPTION
### Motivation
- Provide a lightweight, beginner-friendly help-video system so users can quickly learn where to start and get context for each major section without leaving the app. 
- Keep the UI lightweight by embedding only a single Start Here video inline and exposing section-specific videos as links that open in a new tab. 

### Description
- Added constants `_START_HERE_EMBED_HTML` and `_HELP_VIDEO_URLS` containing the exact Loom embed block and the five requested Loom share URLs. 
- Added `_render_start_here_video` to embed the Start Here video via `st.components.v1.html(...)` (safe Streamlit HTML rendering) and `_render_video_link` to render section links as anchor tags with `target="_blank"` and `rel="noopener noreferrer"`. 
- Inserted the Start Here embed immediately after the first-run orientation (`_render_first_run_header(...)`) and before `render_embedded_insights(...)`, and added section-specific links in the Portfolio (two links), Review (one), Ticker Analysis (one) tabs, plus an analyst-only link in the Analyst Insights tab. 
- Kept all existing dashboard, ranking, portfolio, and execution logic unchanged and limited changes to UI help-video integration and test scaffolding. 

### Testing
- Updated the test double in `tests/test_app_information_architecture.py` to support `st.components.v1.html` and `st.cache_data` so the new UI pieces can be validated. 
- Added tests that assert the Start Here label/embed renders, that portfolio/review/ticker/analyst links appear in the expected tabs, and that the analyst video link is hidden in Beginner mode. 
- Ran `pytest -q tests/test_app_information_architecture.py`, and all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd72f35be88322b3dd6c9b1a299dd6)