### PR TITLE
Refactor UI flows and messaging: Guided/Advanced views, onboarding, and dashboard polish

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,20 +8,24 @@ import pandas as pd
 
 from app.analysis.ticker_drilldown import build_ticker_drilldown
 from app.analysis.ticker_intelligence import compute_ticker_metrics
-from app.data.processor import canonicalize_symbol
 from app.data.ingest import ingest_dataset
+from app.data.processor import canonicalize_symbol
 from app.demo.run_demo import run_demo
 from app.insights.analyst import render_analyst_insights
-from app.insights.embedded import generate_embedded_insights, render_embedded_insights
 from app.planner.allocation import generate_portfolio_allocation
 from app.planner.portfolio_ui import render_portfolio_plan
 from app.shell import build_analyst_dataset, coerce_trade_rows_from_ranked
 from app.ui.display_labels import clean_dataframe_labels
 
-_BEGINNER_TABS = ["Portfolio", "Review", "Ticker Analysis"]
-_ANALYST_TABS = [*_BEGINNER_TABS, "Analyst Insights", "Data"]
+_GUIDED_TABS = ["Portfolio", "Review", "Ticker Analysis", "Data"]
+_ADVANCED_TABS = ["Portfolio", "Review", "Ticker Analysis", "Analyst Insights", "Data"]
 
-_START_HERE_EMBED_HTML = """<div style="position: relative; padding-bottom: 62.7177700348432%; height: 0;"><iframe src="https://www.loom.com/embed/7429a995143a4bf498b640b5371309bc" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>"""
+_MODE_OPTIONS = {
+    "Guided View": "beginner",
+    "Advanced View": "analyst",
+}
+
+_START_HERE_EMBED_HTML = """<div style=\"position: relative; padding-bottom: 62.7177700348432%; height: 0;\"><iframe src=\"https://www.loom.com/embed/7429a995143a4bf498b640b5371309bc\" frameborder=\"0\" webkitallowfullscreen mozallowfullscreen allowfullscreen style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%;\"></iframe></div>"""
 _HELP_VIDEO_URLS = {
     "portfolio": "https://www.loom.com/share/3b02f12dc1704595a2a717a0253b901b",
     "read_trade": "https://www.loom.com/share/58636a4aef5e4592a605efa8bb5c20d2",
@@ -38,11 +42,10 @@ def _has_analyst_insight_content(trades_df: pd.DataFrame, *, analyst_mode: bool)
 
 
 def _resolve_tabs_for_mode(mode: str) -> list[str]:
-    return _ANALYST_TABS if str(mode).lower() == "analyst" else _BEGINNER_TABS
+    return _ADVANCED_TABS if str(mode).lower() == "analyst" else _GUIDED_TABS
 
 
 def _extract_ticker_options(df: pd.DataFrame) -> list[str]:
-    """Build sorted ticker options from the active canonical dataset."""
     if df.empty:
         return []
 
@@ -91,10 +94,10 @@ def _build_quick_take(*, stats: dict, holding_window_stats: dict[str, dict]) -> 
         best_label = sorted_windows[0][0]
         hold_line = f"{best_label} has looked better than shorter alternatives in this sample."
     else:
-        hold_line = "There is not enough history yet to compare short and long holding styles."
+        hold_line = "Holding-window comparison will sharpen as more 5D and 20D observations are added."
 
     return [
-        f"This stock looks {strength} based on past signals.",
+        f"This stock currently reads as {strength} from the signal sample.",
         f"It closed positive about {win_rate:.0%} of the time.",
         f"Typical outcome centers around median return near {median_return:.2%}; {consistency}.",
         hold_line,
@@ -110,12 +113,7 @@ def _build_holding_window_table(holding_window_stats: dict[str, dict], *, analys
         median_return = float(values.get("median_return", 0.0))
         avg_return = float(values.get("avg_return", 0.0))
         count = int(values.get("count", 0))
-        if win_rate >= 0.6 and median_return > 0:
-            verdict = "More steady"
-        elif win_rate >= 0.5:
-            verdict = "Mixed"
-        else:
-            verdict = "Less steady"
+        verdict = "More steady" if win_rate >= 0.6 and median_return > 0 else "Mixed" if win_rate >= 0.5 else "Less steady"
         row = {
             "holding_window": window,
             "win_rate": f"{win_rate:.0%}",
@@ -126,18 +124,12 @@ def _build_holding_window_table(holding_window_stats: dict[str, dict], *, analys
         if analyst_mode:
             row["count"] = count
         else:
-            row["sample_note"] = f"Based on ~{count} historical trades"
+            row["sample_note"] = f"Built from about {count} completed trades"
         rows.append(row)
     return pd.DataFrame(rows)
 
 
-def _build_execution_behavior_lines(
-    *,
-    execution_summary: dict,
-    behavior: dict,
-    stats: dict,
-    analyst_mode: bool,
-) -> list[str]:
+def _build_execution_behavior_lines(*, execution_summary: dict, behavior: dict, stats: dict, analyst_mode: bool) -> list[str]:
     lines = [
         f"Entry framing: {execution_summary.get('entry_reference', '')}",
         f"Exit framing: {execution_summary.get('planned_exit', '')}",
@@ -156,7 +148,6 @@ def _build_execution_behavior_lines(
 
 
 def _extract_unique_ticker_count(df: pd.DataFrame) -> int:
-    """Count unique tickers/instruments from a dataframe."""
     if df.empty:
         return 0
     for candidate in ("instrument", "ticker"):
@@ -168,7 +159,6 @@ def _extract_unique_ticker_count(df: pd.DataFrame) -> int:
 
 
 def _extract_ticker_preview(df: pd.DataFrame, *, limit: int = 20) -> list[str]:
-    """Return a small preview of distinct tickers/instruments."""
     if df.empty:
         return []
     for candidate in ("instrument", "ticker"):
@@ -179,13 +169,7 @@ def _extract_ticker_preview(df: pd.DataFrame, *, limit: int = 20) -> list[str]:
     return []
 
 
-def _run_demo_with_active_dataset(
-    *,
-    canonical_df: pd.DataFrame,
-    meta: dict,
-    issues: dict,
-) -> dict:
-    """Run demo pipeline while preferring the active app dataset when supported."""
+def _run_demo_with_active_dataset(*, canonical_df: pd.DataFrame, meta: dict, issues: dict) -> dict:
     run_demo_signature = inspect.signature(run_demo)
     supports_context_injection = all(
         param_name in run_demo_signature.parameters
@@ -219,16 +203,56 @@ def _render_visual_polish(st_module) -> None:
         }
         .jse-eyebrow { color: var(--jse-accent); font-size: 0.82rem; letter-spacing: 0.03em; text-transform: uppercase; margin-bottom: 0.35rem; }
         .jse-muted { color: var(--jse-muted); }
-        .jse-metric-grid { display: grid; grid-template-columns: repeat(4, minmax(90px, 1fr)); gap: 0.6rem; margin-top: 0.5rem; }
-        .jse-metric { border: 1px solid var(--jse-border); border-radius: 10px; padding: 0.55rem 0.65rem; background: rgba(24, 32, 49, 0.75); }
-        .jse-metric-label { color: var(--jse-muted); font-size: 0.74rem; }
-        .jse-metric-value { color: #eaf0ff; font-size: 1rem; font-weight: 600; }
         .stTabs [data-baseweb="tab-list"] button [data-testid="stMarkdownContainer"] p { font-weight: 600; }
         .stTabs [data-baseweb="tab-list"] button[aria-selected="true"] { border-bottom-color: var(--jse-accent) !important; }
         </style>
         """,
         unsafe_allow_html=True,
     )
+
+
+def _render_video_link(st_module, *, label: str, url: str) -> None:
+    st_module.markdown(f'<a href="{url}" target="_blank" rel="noopener noreferrer">{label}</a>', unsafe_allow_html=True)
+
+
+def _render_start_here_video(st_module) -> None:
+    st_module.markdown("### New here? Start with this video")
+    st_module.caption("This quick walkthrough shows how to use the dashboard and where to start.")
+    st_module.components.v1.html(_START_HERE_EMBED_HTML, height=460)
+
+
+def _render_onboarding(st_module) -> None:
+    st_module.caption(
+        "Decision-support for JSE trades, using price action, volume participation, volatility, liquidity, and realized outcomes from the JSE sample (since 2018 where available)."
+    )
+    _render_start_here_video(st_module)
+
+    st_module.markdown("### Where to start")
+    portfolio_col, ticker_col, review_col = st_module.columns(3)
+    with portfolio_col:
+        st_module.info("**Portfolio**\n\nSee strongest setups and how capital is being handled.")
+    with ticker_col:
+        st_module.info("**Ticker Analysis**\n\nUnderstand one stock through price, volume, volatility, liquidity, and outcome patterns.")
+    with review_col:
+        st_module.info("**Review**\n\nCheck whether the plan followed its rules.")
+
+    with st_module.expander("What this dashboard does"):
+        st_module.markdown("- Highlights stronger and weaker setups.")
+        st_module.markdown("- Helps compare trades more clearly.")
+        st_module.markdown("- Shows how long setups typically take to play out.")
+        st_module.markdown("- Helps frame risk, not just returns.")
+
+    with st_module.expander("How this dashboard supports decisions"):
+        st_module.markdown("- Structures trade review with consistent rules.")
+        st_module.markdown("- Keeps portfolio discipline visible before and after selection.")
+        st_module.markdown("- Helps compare opportunities with a shared, repeatable framework.")
+
+    with st_module.expander("What the system looks at"):
+        st_module.markdown("- Price behavior.")
+        st_module.markdown("- Volume / participation.")
+        st_module.markdown("- Volatility / risk.")
+        st_module.markdown("- Liquidity.")
+        st_module.markdown("- Historical outcomes like win rate and median return.")
 
 
 def _render_data_status_summary(
@@ -245,55 +269,38 @@ def _render_data_status_summary(
     warnings = issues.get("warnings", [])
 
     st_module.markdown("#### Data Status")
-    status_col, quality_col = st_module.columns(2)
-    with status_col:
-        st_module.markdown(f"**Source:** {source or 'Unknown'}")
-        st_module.markdown(f"**Rows loaded:** {row_count}")
-        st_module.markdown(f"**Errors:** {len(errors)}")
-    with quality_col:
-        st_module.markdown(f"**Warnings:** {len(warnings)}")
-        if analyst_mode:
-            st_module.markdown(f"**Dataset ID:** {dataset_id or 'N/A'}")
+    c1, c2, c3 = st_module.columns(3)
+    c1.metric("Rows loaded", row_count)
+    c2.metric("Warnings", len(warnings))
+    c3.metric("Errors", len(errors))
+    st_module.caption(f"Source: {source or 'Unknown'}")
+
+    if analyst_mode:
+        st_module.caption(f"Dataset ID: {dataset_id or 'N/A'}")
 
     if warnings:
-        st_module.markdown("**Warning details**")
-        for warning in warnings:
-            st_module.markdown(f"- {warning}")
-    else:
-        st_module.caption("No ingestion warnings were reported for this dataset.")
-
+        st_module.warning("Warnings were reported during ingestion.")
+        with st_module.expander("Warning details"):
+            for warning in warnings:
+                st_module.markdown(f"- {warning}")
     if errors:
-        st_module.markdown("**Error details**")
-        for error in errors:
-            st_module.markdown(f"- {error}")
-    else:
-        st_module.caption("No ingestion errors were reported for this dataset.")
-
-
-def _render_video_link(st_module, *, label: str, url: str) -> None:
-    st_module.markdown(f'<a href="{url}" target="_blank" rel="noopener noreferrer">{label}</a>', unsafe_allow_html=True)
-
-
-def _render_start_here_video(st_module) -> None:
-    st_module.markdown("### New here? Start with this video")
-    st_module.caption("This quick walkthrough shows how to use the dashboard and where to start.")
-    st_module.components.v1.html(_START_HERE_EMBED_HTML, height=460)
+        st_module.warning("Errors were reported during ingestion.")
+        with st_module.expander("Error details"):
+            for error in errors:
+                st_module.markdown(f"- {error}")
 
 
 def main() -> None:
-    """Run the Streamlit shell with Analyst Insights and Portfolio Plan sections."""
     import streamlit as st
 
-    st.set_page_config(
-        page_title="JSE Decision Support Dashboard",
-        page_icon="📈",
-        layout="wide",
-    )
+    st.set_page_config(page_title="JSE Decision Support Dashboard", page_icon="📈", layout="wide")
     _render_visual_polish(st)
 
     st.title("JSE Market Lab")
-    mode = st.radio("Mode", options=["Beginner", "Analyst"], horizontal=True, index=0)
-    mode_token = mode.lower()
+    mode_label = st.radio("View", options=list(_MODE_OPTIONS.keys()), horizontal=True, index=0)
+    mode_token = _MODE_OPTIONS[mode_label]
+    st.caption("Guided View: simpler explanations and lighter detail")
+    st.caption("Advanced View: deeper breakdowns and fuller analysis")
 
     @st.cache_data(show_spinner=False)
     def _cached_ingest_dataset() -> tuple[pd.DataFrame, dict, tuple[tuple[str, tuple[str, ...]], ...]]:
@@ -322,11 +329,7 @@ def main() -> None:
         return _extract_ticker_options(canonical_df_value)
 
     @st.cache_data(show_spinner=False)
-    def _cached_ticker_payloads(
-        analyst_df_value: pd.DataFrame,
-        ticker: str,
-        mode_value: str,
-    ) -> tuple[dict, dict]:
+    def _cached_ticker_payloads(analyst_df_value: pd.DataFrame, ticker: str, mode_value: str) -> tuple[dict, dict]:
         payload = build_ticker_drilldown(analyst_df_value, ticker)
         metrics = compute_ticker_metrics(analyst_df_value, ticker, mode=mode_value)
         return payload, metrics
@@ -334,8 +337,6 @@ def main() -> None:
     canonical_df, meta, frozen_issues = _cached_ingest_dataset()
     issues = _unfreeze_issues(frozen_issues)
     dataset_source_label = str(meta.get("dataset_source_label") or "unknown_dataset")
-    st.caption(f"Data source: {dataset_source_label}")
-    st.caption("Using historical data from the Jamaican stock market.")
 
     if dataset_source_label == "legacy_demo_dataset":
         st.warning("Internal JSE dataset not found. Using fallback dataset.")
@@ -358,31 +359,18 @@ def main() -> None:
         base_allocations = allocation_payload.get("allocations", [])
         enriched_allocations = [{**allocation, **row} for row, allocation in zip(trade_rows, base_allocations)]
 
-    if trade_rows:
-        insights_payload = generate_embedded_insights(trade_rows, enriched_allocations, mode=mode_token)
-    else:
-        insights_payload = generate_embedded_insights([], [], mode=mode_token)
-
-    _render_first_run_header(st, mode=mode_token)
-    _render_start_here_video(st)
-    render_embedded_insights(insights_payload, st_module=st)
+    _render_onboarding(st)
 
     tabs = st.tabs(_resolve_tabs_for_mode(mode_token))
     tab_map = {name: tab for name, tab in zip(_resolve_tabs_for_mode(mode_token), tabs)}
 
     with tab_map["Portfolio"]:
-        st.markdown("### Portfolio Plan")
+        st.markdown("### Portfolio")
         _render_video_link(st, label="▶ Watch: Understanding the Portfolio", url=_HELP_VIDEO_URLS["portfolio"])
         _render_video_link(st, label="▶ Watch: How to Read a Trade", url=_HELP_VIDEO_URLS["read_trade"])
-        selected_capital = st.number_input(
-            "Total capital",
-            min_value=0.0,
-            value=selected_capital,
-            step=5_000.0,
-            key="total_capital",
-        )
+        selected_capital = st.number_input("Total capital", min_value=0.0, value=selected_capital, step=5_000.0, key="total_capital")
         if ranked_df.empty:
-            st.info("Portfolio Plan unavailable: ranked outputs were not generated.")
+            st.info("Portfolio Plan will appear after ranked outputs are generated for the current run.")
         else:
             render_portfolio_plan(
                 enriched_allocations,
@@ -398,7 +386,7 @@ def main() -> None:
         st.markdown("### Review")
         _render_video_link(st, label="▶ Watch: Understanding Review", url=_HELP_VIDEO_URLS["review"])
         if ranked_df.empty:
-            st.info("Review unavailable: ranked outputs were not generated.")
+            st.info("Review will populate once ranked outputs are generated for this run.")
         else:
             render_portfolio_plan(
                 enriched_allocations,
@@ -415,7 +403,7 @@ def main() -> None:
         _render_video_link(st, label="▶ Watch: Understanding Ticker Analysis", url=_HELP_VIDEO_URLS["ticker_analysis"])
         ticker_options = _cached_extract_ticker_options(canonical_df)
         if not ticker_options:
-            st.info("Ticker Analysis is unavailable because no ticker rows are loaded.")
+            st.info("Ticker Analysis will populate once ticker rows are loaded into the dataset.")
         else:
             selected_ticker = st.selectbox("Select ticker", ticker_options)
             ticker_payload, ticker_metrics = _cached_ticker_payloads(analyst_df, selected_ticker, mode_token)
@@ -423,109 +411,80 @@ def main() -> None:
             metrics_stats = ticker_metrics.get("stats", {})
             metrics_behavior = ticker_metrics.get("behavior", {})
 
-            st.markdown("#### A) Quick Take")
-            st.caption("A fast read of what this stock has looked like so far.")
-            for line in _build_quick_take(
-                stats=metrics_stats, holding_window_stats=ticker_payload["holding_window_stats"]
-            ):
+            st.markdown("#### Quick Take")
+            for line in _build_quick_take(stats=metrics_stats, holding_window_stats=ticker_payload["holding_window_stats"]):
                 st.markdown(f"- {line}")
 
-            st.markdown("#### B) Best Holding Strategy")
-            st.caption("This compares how the stock has behaved across holding periods and highlights the strongest window.")
-            holding_window_df = _build_holding_window_table(
-                ticker_payload["holding_window_stats"], analyst_mode=analyst_mode
-            )
+            st.markdown("#### Best Holding Strategy")
+            holding_window_df = _build_holding_window_table(ticker_payload["holding_window_stats"], analyst_mode=analyst_mode)
             if holding_window_df.empty:
                 st.info("No holding window data is ready for this ticker yet.")
             else:
-                best_window = str(metrics_stats.get("best_window") or "N/A")
-                st.markdown(f"**Best holding period:** {best_window}")
-                st.markdown(f"{metrics_behavior.get('holding_window', 'Holding-window comparison is limited right now.')}")
+                st.metric("Best holding period", str(metrics_stats.get("best_window") or "N/A"))
+                st.info(metrics_behavior.get("holding_window", "Holding-window comparison is limited right now."))
                 st.dataframe(clean_dataframe_labels(holding_window_df), use_container_width=True, hide_index=True)
 
-            st.markdown("#### C) Risk Profile")
-            st.caption("This explains how steady or uneven the returns have been.")
-            for key in ("reliability", "consistency"):
-                st.markdown(f"- {metrics_behavior.get(key, '')}")
-            distribution = ticker_payload["return_distribution"]
-            st.markdown(
-                f"- Losses: {distribution.get('negative', 0)} | Smaller wins: {distribution.get('small_positive', 0)} | Strong wins: {distribution.get('strong_positive', 0)}."
-            )
-            if distribution.get("strong_positive", 0) > 0 and distribution.get("strong_positive", 0) <= distribution.get(
-                "small_positive", 0
-            ):
-                st.markdown("- The average can be lifted by a smaller number of bigger wins.")
+            st.markdown("#### Risk Profile")
+            st.warning(metrics_behavior.get("reliability", ""))
+            st.info(metrics_behavior.get("consistency", ""))
 
-            execution_summary = ticker_metrics.get("execution", {})
-            st.markdown("#### D) Execution Behavior")
-            if analyst_mode:
-                st.caption("Expanded execution framing with median-first outcome context and practical caveats.")
-            else:
-                st.caption("Short execution framing for entry, exit, typical outcome, and practical caveats.")
+            st.markdown("#### What Usually Happens")
+            st.markdown(f"- {ticker_payload['pattern_summary']}")
+            st.markdown(f"- {metrics_behavior.get('tier_profile', '')}")
+
+            st.markdown("#### What to Watch")
+            st.markdown("- Results can look mixed when win rate and average return move in different directions.")
+            st.markdown("- Median return stays primary; average return adds context.")
+
+            st.markdown("#### Execution Behavior")
             for line in _build_execution_behavior_lines(
-                execution_summary=execution_summary,
+                execution_summary=ticker_metrics.get("execution", {}),
                 behavior=metrics_behavior,
                 stats=metrics_stats,
                 analyst_mode=analyst_mode,
             ):
                 st.markdown(f"- {line}")
 
-            st.markdown("#### E) What Usually Happens")
-            st.caption("This section translates recurring behavior seen in the historical sample.")
-            st.markdown(f"- {ticker_payload['pattern_summary']}")
-            st.markdown(f"- {metrics_behavior.get('holding_window', '')}")
-            st.markdown(f"- {metrics_behavior.get('tier_profile', '')}")
-
-            st.markdown("#### F) What to Watch")
-            st.caption("These points flag caution areas that can make results look better or worse than expected.")
-            if "20D looks stronger" in metrics_behavior.get("holding_window", ""):
-                st.markdown("- Short-term setups have looked weaker than longer holds in this sample.")
-            st.markdown("- Results can look mixed when win rate and average return move in different directions.")
-            st.markdown("- A smaller number of bigger moves can shape the average return.")
-
             if analyst_mode:
-                st.markdown("#### G) Analyst Deep Dive")
-                st.caption("These tables provide the full raw breakdown for deeper inspection.")
+                with st.expander("Advanced breakdown", expanded=False):
+                    st.markdown("##### Holding window details")
+                    raw_holding_df = pd.DataFrame.from_dict(ticker_payload["holding_window_stats"], orient="index")
+                    st.dataframe(
+                        clean_dataframe_labels(raw_holding_df.reset_index().rename(columns={"index": "holding_window"})),
+                        use_container_width=True,
+                    )
 
-                st.markdown("This table shows full holding-window stats including raw sample count.")
-                raw_holding_df = pd.DataFrame.from_dict(ticker_payload["holding_window_stats"], orient="index")
-                st.dataframe(clean_dataframe_labels(raw_holding_df.reset_index().rename(columns={"index": "holding_window"})), use_container_width=True)
+                    st.markdown("##### Tier breakdown")
+                    tier_df = pd.DataFrame.from_dict(ticker_payload["tier_performance"], orient="index")
+                    st.dataframe(
+                        clean_dataframe_labels(tier_df.reset_index().rename(columns={"index": "quality_tier"})),
+                        use_container_width=True,
+                    )
 
-                st.markdown("This table shows how each quality tier has performed for this ticker.")
-                tier_df = pd.DataFrame.from_dict(ticker_payload["tier_performance"], orient="index")
-                if tier_df.empty:
-                    st.info("No tier breakdown is ready for this ticker yet.")
-                else:
-                    st.dataframe(clean_dataframe_labels(tier_df.reset_index().rename(columns={"index": "quality_tier"})), use_container_width=True)
-
-                st.markdown("This table shows whether results changed across volatility buckets.")
-                volatility_df = pd.DataFrame.from_dict(ticker_payload["volatility_performance"], orient="index")
-                if volatility_df.empty:
-                    st.info("No volatility breakdown is ready for this ticker yet.")
-                else:
+                    st.markdown("##### Volatility breakdown")
+                    volatility_df = pd.DataFrame.from_dict(ticker_payload["volatility_performance"], orient="index")
                     st.dataframe(
                         clean_dataframe_labels(volatility_df.reset_index().rename(columns={"index": "volatility_bucket"})),
                         use_container_width=True,
                     )
 
-                st.markdown("This table shows the return distribution split between losses and stronger wins.")
-                distribution_df = pd.DataFrame([ticker_payload["return_distribution"]])
-                st.dataframe(clean_dataframe_labels(distribution_df), use_container_width=True)
+                    st.markdown("##### Return distribution")
+                    st.dataframe(clean_dataframe_labels(pd.DataFrame([ticker_payload["return_distribution"]])), use_container_width=True)
 
-                st.markdown("This table lists the raw signal history for analyst review.")
-                signal_df = pd.DataFrame(ticker_payload["signals"])
-                if signal_df.empty:
-                    st.info("No signal history is available for this ticker yet.")
-                else:
-                    st.dataframe(clean_dataframe_labels(signal_df), use_container_width=True)
+                    st.markdown("##### Signal history")
+                    signal_df = pd.DataFrame(ticker_payload["signals"])
+                    if signal_df.empty:
+                        st.info("No signal history is available for this ticker yet.")
+                    else:
+                        st.dataframe(clean_dataframe_labels(signal_df), use_container_width=True)
             else:
-                st.markdown("**Analyst Deep Dive** is available in Analyst mode for full raw tables.")
+                st.caption("Switch to Advanced View to open the full table breakdown.")
 
     if "Analyst Insights" in tab_map:
         with tab_map["Analyst Insights"]:
             st.markdown("### Analyst Insights")
             _render_video_link(st, label="▶ Watch: How to Use Analyst Mode", url=_HELP_VIDEO_URLS["analyst_mode"])
-            if _has_analyst_insight_content(analyst_df, analyst_mode=mode_token == "analyst"):
+            if _has_analyst_insight_content(analyst_df, analyst_mode=True):
                 render_analyst_insights(analyst_df, st_module=st, analyst_mode=True)
             else:
                 st.info("Analyst insights are not available for this dataset yet.")
@@ -541,48 +500,26 @@ def main() -> None:
                 dataset_id=meta.get("dataset_id"),
                 analyst_mode=mode_token == "analyst",
             )
-            st.caption("Dataset diagnostics (temporary)")
-            diagnostics_df = pd.DataFrame(
-                [
-                    {"stage": "canonical", "rows": int(len(canonical_df)), "unique_tickers": _extract_unique_ticker_count(canonical_df)},
-                    {"stage": "ranked", "rows": int(len(ranked_df)), "unique_tickers": _extract_unique_ticker_count(ranked_df)},
-                ]
-            )
-            st.dataframe(clean_dataframe_labels(diagnostics_df), use_container_width=True, hide_index=True)
-            st.code(
-                (
-                    f"canonical first 20 tickers: {_extract_ticker_preview(canonical_df)}\n"
-                    f"ranked first 20 tickers: {_extract_ticker_preview(ranked_df)}"
-                ),
-                language="text",
-            )
-            st.markdown("#### Main Dashboard")
-            st.dataframe(clean_dataframe_labels(canonical_df.head(50)), use_container_width=True)
-
-
-def _render_first_run_header(st_module, *, mode: str) -> None:
-    mode_label = "Analyst" if str(mode).lower() == "analyst" else "Beginner"
-    st_module.markdown(
-        (
-            '<div class="jse-card">'
-            '<div class="jse-eyebrow">First-Run Orientation</div>'
-            "<h3 style='margin:0 0 0.45rem 0;'>JSE Market Lab</h3>"
-            "<p style='margin:0 0 0.35rem 0;'>This dashboard helps you review stock opportunities on the Jamaican market using structured rules and risk checks.</p>"
-            "<p class='jse-muted' style='margin:0;'>It highlights stronger setups, explains key risks, and keeps your review flow focused for "
-            f"{mode_label} mode.</p>"
-            "</div>"
-        ),
-        unsafe_allow_html=True,
-    )
-    st_module.markdown("**How to read this**")
-    st_module.markdown("- The system scans the market and ranks possible trades.")
-    st_module.markdown("- Only the stronger setups are selected in the plan below.")
-    st_module.markdown("- Each trade explains why it was chosen and what risk is involved.")
-    st_module.caption("Based on historical data. Results can vary, so risk still matters.")
-    if mode == "beginner":
-        st_module.caption("Beginner mode keeps the view simple: explanation first, fewer metrics.")
-    else:
-        st_module.caption("Analyst mode adds more metrics while keeping explanations first.")
+            if mode_token == "analyst":
+                diagnostics_df = pd.DataFrame(
+                    [
+                        {"stage": "canonical", "rows": int(len(canonical_df)), "unique_tickers": _extract_unique_ticker_count(canonical_df)},
+                        {"stage": "ranked", "rows": int(len(ranked_df)), "unique_tickers": _extract_unique_ticker_count(ranked_df)},
+                    ]
+                )
+                st.dataframe(clean_dataframe_labels(diagnostics_df), use_container_width=True, hide_index=True)
+                st.code(
+                    (
+                        f"canonical first 20 tickers: {_extract_ticker_preview(canonical_df)}\n"
+                        f"ranked first 20 tickers: {_extract_ticker_preview(ranked_df)}"
+                    ),
+                    language="text",
+                )
+                with st.expander("Data preview"):
+                    st.dataframe(clean_dataframe_labels(canonical_df.head(100)), use_container_width=True)
+            else:
+                with st.expander("Preview loaded rows"):
+                    st.dataframe(clean_dataframe_labels(canonical_df.head(25)), use_container_width=True)
 
 
 if __name__ == "__main__":

--- a/app/analysis/ticker_intelligence.py
+++ b/app/analysis/ticker_intelligence.py
@@ -29,10 +29,10 @@ def _empty_payload() -> dict[str, Any]:
             "signal_count": 0,
         },
         "behavior": {
-            "holding_window": "There is not enough 5D or 20D data to compare holding windows right now.",
-            "consistency": "No consistency read is available because return data is missing.",
-            "reliability": "Reliability cannot be read because there are no completed signals.",
-            "tier_profile": "Tier profile cannot be read because tier data is missing.",
+            "holding_window": "Holding-window comparison will sharpen as more 5D and 20D rows are captured.",
+            "consistency": "Consistency read becomes available as return coverage grows.",
+            "reliability": "Reliability read strengthens as completed signals accumulate.",
+            "tier_profile": "Tier profile summary becomes available when tier-tagged rows are present.",
         },
         "execution": build_execution_summary({}, mode="beginner"),
     }
@@ -84,7 +84,7 @@ def build_ticker_behavior(metrics: dict[str, Any], *, mode: str = "beginner") ->
         else:
             holding_window = "The 5D and 20D windows came out nearly the same for this ticker."
     else:
-        holding_window = "There is not enough 5D or 20D data to compare holding windows right now."
+        holding_window = "Holding-window comparison will sharpen as more 5D and 20D rows are captured."
 
     avg_return = float(metrics["stats"]["avg_return"])
     median_return = float(metrics["stats"]["median_return"])
@@ -115,7 +115,7 @@ def build_ticker_behavior(metrics: dict[str, Any], *, mode: str = "beginner") ->
         top_share = (tier_counts[top_tier] / sum(tier_counts.values())) * 100
         tier_profile = f"Setup mix leans to {top_tier}, with about {top_share:.0f}% of rows in that tier."
     else:
-        tier_profile = "Tier profile cannot be read because tier data is missing."
+        tier_profile = "Tier profile summary becomes available when tier-tagged rows are present."
 
     if str(mode).lower() == "analyst":
         reliability = reliability + f" (Win rate: {win_rate:.0%})"

--- a/app/insights/analyst.py
+++ b/app/insights/analyst.py
@@ -155,8 +155,8 @@ def render_analyst_insights(
     return_column = resolve_return_column(trades_df)
     if return_column is None:
         st_module.info(
-            "Analyst Insights unavailable: no return column found. "
-            f"Expected one of {PREFERRED_RETURN_COLUMNS}."
+            "Analyst Insights is ready once a return column is present. "
+            f"Accepted columns: {PREFERRED_RETURN_COLUMNS}."
         )
         return
 
@@ -166,50 +166,45 @@ def render_analyst_insights(
 
     with insights_tab:
         st_module.subheader("Feature Insights")
-        st_module.caption(
-            "Question answered: Which setup tags are associated with stronger or weaker outcomes? "
-            "This view is only shown when feature-tag columns are present in the dataset."
-        )
+        st_module.caption("Feature Insights — setup tags connected to stronger or weaker outcomes.")
         insights = build_feature_insights(trades_df, return_column=return_column)
         if not insights:
             st_module.info(
-                "Feature Insights is not available yet for this dataset because feature-tag columns are missing."
+                "Feature Insights activates when feature-tag columns are included in this dataset."
             )
         for feature, summary in insights.items():
             st_module.markdown(f"#### {display_label(feature)}")
+            st_module.markdown("One-line read: review this tag's win rate and median return before ranking confidence.")
             st_module.dataframe(clean_dataframe_labels(summary, value_columns=[feature]))
 
     with matrix_tab:
         st_module.subheader("Performance Matrix")
-        st_module.caption(
-            "Question answered: Which setup tier and holding period combinations have historically behaved best? "
-            "Grouping by both matters because setup quality can perform differently at short vs. longer holds."
-        )
+        st_module.caption("Performance Matrix — grouped setup quality and holding periods.")
         try:
             matrix_payload = build_performance_matrix(
                 trades_df,
                 return_column=return_column,
             )
         except ValueError as error:
-            st_module.info(f"Performance Matrix unavailable: {error}")
+            st_module.info(f"Performance Matrix is ready once required columns are present: {error}")
         else:
+            st_module.markdown("Median-first interpretation: compare grouped cells by median return first, then win rate.")
             st_module.markdown("#### Grouped Summary")
             st_module.dataframe(clean_dataframe_labels(matrix_payload["summary"]))
-            st_module.markdown("#### Win-Rate Matrix")
-            st_module.dataframe(clean_dataframe_labels(matrix_payload["win_rate_matrix"].reset_index()))
-            st_module.markdown("#### Median-Return Matrix")
-            st_module.dataframe(clean_dataframe_labels(matrix_payload["median_return_matrix"].reset_index()))
-            st_module.markdown("#### Best Setups")
-            st_module.dataframe(clean_dataframe_labels(matrix_payload["best_setups"].head(10)))
+            with st_module.expander("Matrix views"):
+                st_module.markdown("#### Win-Rate Matrix")
+                st_module.dataframe(clean_dataframe_labels(matrix_payload["win_rate_matrix"].reset_index()))
+                st_module.markdown("#### Median-Return Matrix")
+                st_module.dataframe(clean_dataframe_labels(matrix_payload["median_return_matrix"].reset_index()))
+            with st_module.expander("Best Setups"):
+                st_module.dataframe(clean_dataframe_labels(matrix_payload["best_setups"].head(10)))
 
     with exit_tab:
         st_module.subheader("Exit Analysis")
-        st_module.caption(
-            "Question answered: How do trades usually end, and does that exit pattern reveal useful behavior? "
-            "If one exit reason dominates, that can indicate whether winners or risk controls are driving outcomes."
-        )
+        st_module.caption("Exit Analysis — how trades usually end and what that says about discipline.")
         required_cols = {"exit_reason", "quality_tier"}
         if required_cols.issubset(trades_df.columns):
+            st_module.markdown("Interpretation: frequent stop exits can signal risk controls or weak setup quality.")
             st_module.dataframe(
                 clean_dataframe_labels(
                     build_exit_analysis(trades_df, return_column=return_column),
@@ -219,6 +214,6 @@ def render_analyst_insights(
         else:
             missing = required_cols - set(trades_df.columns)
             st_module.info(
-                "Exit Analysis unavailable — missing required columns: "
+                "Exit Analysis is ready once these columns are available: "
                 + ", ".join(sorted(missing))
             )

--- a/app/insights/execution.py
+++ b/app/insights/execution.py
@@ -16,7 +16,7 @@ def build_execution_summary(row: Mapping[str, Any], mode: str = "beginner") -> d
 
     status_prefix = ""
     if float(row.get("allocation_amount", 0.0) or 0.0) <= 0:
-        status_prefix = "Execution plan is inactive unless this trade is funded. "
+        status_prefix = "Execution plan activates when this trade receives funding. "
 
     summary = (
         f"{status_prefix}Entry reference: {entry_reference} "
@@ -65,8 +65,8 @@ def _build_typical_outcome(row: Mapping[str, Any], *, analyst_mode: bool) -> str
 
     if median_return is None:
         if avg_return is None:
-            return "Median outcome data is limited for this setup."
-        return f"Median outcome is unavailable; supporting average return is about {avg_return:.2%}."
+            return "Median outcome read will strengthen as completed trade outcomes increase."
+        return f"Median read is building; supporting average return is currently about {avg_return:.2%}."
 
     typical = f"Typical result is centered on median return near {median_return:.2%}."
     if avg_return is None:

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -125,15 +125,13 @@ def render_portfolio_plan(
         normalized_section = "both"
 
     if show_header:
-        st_module.subheader("Portfolio Plan")
+        st_module.subheader("Portfolio")
     analyst_mode = str(mode or "beginner").lower() == "analyst"
     if show_header and normalized_section in {"plan", "both"}:
-        st_module.caption(
-            "The plan funds the strongest eligible setups first, while other trades stay out when rules or limits block them."
-        )
+        st_module.caption("The plan funds stronger eligible setups first and keeps reserve discipline in view.")
 
     if not allocations:
-        st_module.info("Portfolio Plan unavailable: no allocation outputs were provided.")
+        st_module.info("Portfolio Plan will populate once allocation outputs are available.")
         return
 
     summary = build_portfolio_summary(allocations, total_capital)
@@ -165,48 +163,39 @@ def render_portfolio_plan(
                     "Rule Note": explain_funded_trade_why(trade) if funded else "Not funded this cycle.",
                 }
             )
-        else:
-            row.update(
-                {
-                    "Allocation Amount": trade.get("allocation_amount", 0.0),
-                    "Decision Status": classify_decision_status(trade),
-                }
-            )
         return row
 
     def _render_snapshot_blocks() -> None:
         snapshot = build_portfolio_snapshot(allocations, total_capital, mode=mode)
         st_module.markdown("#### Portfolio Snapshot")
-        for line in snapshot["lines"]:
-            st_module.markdown(f"- {line}")
+        metric_cols = st_module.columns(4)
+        metric_cols[0].metric("Trades Found", len(allocations))
+        metric_cols[1].metric("Funded Trades", summary["funded_trade_count"])
+        metric_cols[2].metric("Cash Reserved %", f"{summary['cash_reserve_pct']:.0%}")
+        metric_cols[3].metric("Allocated %", f"{summary['total_allocated_pct']:.0%}")
+        if analyst_mode:
+            st_module.info(
+                "Funding stayed concentrated on stronger ranked setups while maintaining reserve coverage."
+            )
+        else:
+            st_module.info("This snapshot shows how much is funded now and how much stays reserved.")
+
+        with st_module.expander("How to read setup strength and confidence"):
+            for line in snapshot["lines"]:
+                st_module.markdown(f"- {line}")
 
         reserved_cash = build_reserved_cash_explanation(allocations, total_capital, mode=mode)
         if reserved_cash["reserve_ratio"] > 0:
             st_module.markdown("#### Why cash is reserved")
-            for line in reserved_cash["lines"]:
-                st_module.markdown(f"- {line}")
+            st_module.info(reserved_cash["lines"][0] if reserved_cash["lines"] else "Cash reserve supports discipline.")
+            if analyst_mode and len(reserved_cash["lines"]) > 1:
+                with st_module.expander("Reserve detail"):
+                    for line in reserved_cash["lines"][1:]:
+                        st_module.markdown(f"- {line}")
 
 
     def _render_plan_section() -> None:
         _render_snapshot_blocks()
-
-        st_module.markdown(
-            '<div class="jse-card"><div class="jse-eyebrow">Portfolio Summary</div><p style="margin:0;" class="jse-muted">Funding view of current eligible setups and reserve coverage.</p></div>',
-            unsafe_allow_html=True,
-        )
-        summary_df = pd.DataFrame(
-            [
-                {
-                    "Total Capital": float(total_capital or 0.0),
-                    "Allocated Amount": summary["total_allocated_amount"],
-                    **({"Allocated %": summary["total_allocated_pct"]} if analyst_mode else {}),
-                    "Cash Reserve Amount": summary["cash_reserve_amount"],
-                    **({"Cash Reserve %": summary["cash_reserve_pct"]} if analyst_mode else {}),
-                    "Funded Trades": summary["funded_trade_count"],
-                }
-            ]
-        )
-        st_module.dataframe(summary_df, use_container_width=True)
 
         st_module.markdown("#### Funded Trades")
         if funded_trades:
@@ -231,8 +220,12 @@ def render_portfolio_plan(
             if hidden_unfunded_count > 0:
                 st_module.caption(
                     f"Showing top {_BEGINNER_UNFUNDED_ROW_LIMIT} unfunded trades for speed. "
-                    f"Switch to Analyst mode to view all {len(unfunded_trades)} rows."
+                    f"Switch to Advanced View to view all {len(unfunded_trades)} rows."
                 )
+                with st_module.expander("See why more trades were not funded"):
+                    st_module.markdown(
+                        "Lower-ranked setups remain unfunded first when limits and reserve rules are active."
+                    )
         else:
             st_module.info("No unfunded trades for the selected inputs.")
 
@@ -250,12 +243,16 @@ def render_portfolio_plan(
             rules.append(
                 "- Caution: increasing this cap may include lower-ranked setups and reduce reserve discipline."
             )
-        st_module.markdown("\n".join(rules))
+        if analyst_mode:
+            st_module.markdown("\n".join(rules))
+        else:
+            with st_module.expander("Portfolio rules and funding approach"):
+                st_module.markdown("\n".join(rules))
 
     def _render_review_section() -> None:
-        st_module.markdown(
-            '<div class="jse-card"><div class="jse-eyebrow">Review Summary</div><p style="margin:0;">This section shows how closely selected trades followed system rules and where risk discipline changed.</p></div>',
-            unsafe_allow_html=True,
+        st_module.markdown("#### Review")
+        st_module.info(
+            "Review checks whether the plan followed its intended rules and where discipline mattered."
         )
         trades_df = pd.DataFrame(list(allocations))
         safe_signals_df = signals_df if signals_df is not None else pd.DataFrame()
@@ -267,31 +264,44 @@ def render_portfolio_plan(
         )
         discipline_score = compute_discipline_score(review_df)
 
-        st_module.write({"Discipline Score": discipline_score})
+        st_module.metric("Discipline Score", discipline_score)
 
         behavior_summary = build_behavior_summary(trades_df, review_df)
-        st_module.markdown("**Behavior Summary**")
-        for item in behavior_summary:
+        st_module.markdown("**Summary**")
+        for item in behavior_summary[: (3 if not analyst_mode else len(behavior_summary))]:
             st_module.markdown(f"- {item}")
+        if not analyst_mode and len(behavior_summary) > 3:
+            with st_module.expander("More summary detail"):
+                for item in behavior_summary[3:]:
+                    st_module.markdown(f"- {item}")
 
-        st_module.markdown("**What this means**")
+        st_module.markdown("**Interpretation**")
         for paragraph in _build_review_interpretation_paragraphs(review_df, mode=mode):
             st_module.markdown(paragraph)
 
         st_module.markdown("**What to improve**")
-        for bullet in _build_behavior_improvement_points(review_df, mode=mode):
+        improvements = _build_behavior_improvement_points(review_df, mode=mode)
+        for bullet in improvements[: (2 if not analyst_mode else len(improvements))]:
             st_module.markdown(f"- {bullet}")
+        if not analyst_mode and len(improvements) > 2:
+            with st_module.expander("More improvement points"):
+                for bullet in improvements[2:]:
+                    st_module.markdown(f"- {bullet}")
 
         st_module.markdown("**Mistakes Detected**")
         grouped_mistakes = _group_mistakes_for_display(mistake_list, mode=mode)
         if grouped_mistakes:
-            for line in grouped_mistakes:
+            for line in grouped_mistakes[: (2 if not analyst_mode else len(grouped_mistakes))]:
                 st_module.markdown(f"- {line}")
+            if not analyst_mode and len(grouped_mistakes) > 2:
+                with st_module.expander("More detected mistakes"):
+                    for line in grouped_mistakes[2:]:
+                        st_module.markdown(f"- {line}")
         else:
             st_module.markdown("- No clear decision mistakes were detected.")
 
         if show_review_table:
-            st_module.markdown("**Decision Audit Table**")
+            st_module.markdown("**Decision Audit**")
             if review_df.empty:
                 st_module.info("No review rows available for this run.")
             else:
@@ -316,7 +326,7 @@ def render_portfolio_plan(
 
 def _build_review_interpretation_paragraphs(review_df: pd.DataFrame, *, mode: str = "beginner") -> list[str]:
     if review_df is None or review_df.empty:
-        return ["There is not enough decision activity yet to read a clear behavior pattern."]
+        return ["Behavior read becomes sharper as more reviewed decisions accumulate."]
 
     total = max(int(len(review_df)), 1)
     followed = int(review_df["followed_rules"].fillna(False).astype(bool).sum())

--- a/tests/test_analyst_insights.py
+++ b/tests/test_analyst_insights.py
@@ -127,6 +127,9 @@ class DummyStreamlitInsights:
     def info(self, text):
         self.calls.append(("info", text))
 
+    def expander(self, _label, **_kwargs):
+        return _DummyTab()
+
 
 def test_render_analyst_insights_handles_missing_quality_tier_for_exit_analysis():
     from app.insights.analyst import render_analyst_insights
@@ -138,7 +141,7 @@ def test_render_analyst_insights_handles_missing_quality_tier_for_exit_analysis(
 
     assert (
         "info",
-        "Exit Analysis unavailable — missing required columns: quality_tier",
+        "Exit Analysis is ready once these columns are available: quality_tier",
     ) in st.calls
 
 
@@ -187,7 +190,7 @@ def test_render_analyst_insights_feature_insights_unavailable_message_is_explici
 
     assert (
         "info",
-        "Feature Insights is not available yet for this dataset because feature-tag columns are missing.",
+        "Feature Insights activates when feature-tag columns are included in this dataset.",
     ) in st.calls
 
 
@@ -198,8 +201,8 @@ def test_render_analyst_insights_includes_explanatory_captions_for_matrix_and_ex
     render_analyst_insights(_sample_trades(), st_module=st, analyst_mode=True)
 
     captions = [text for event, text in st.calls if event == "caption"]
-    assert any("Question answered: Which setup tier and holding period" in text for text in captions)
-    assert any("Question answered: How do trades usually end" in text for text in captions)
+    assert any("Performance Matrix — grouped setup quality and holding periods." in text for text in captions)
+    assert any("Exit Analysis — how trades usually end and what that says about discipline." in text for text in captions)
 
 
 def test_render_analyst_insights_cleans_snake_case_labels_for_display_tables():

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -11,8 +11,31 @@ from app.demo import run_demo as run_demo_module
 
 
 class DummyColumn:
+    def __init__(self, st_module):
+        self._st = st_module
+
     def __enter__(self):
         return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def metric(self, label, value, *_args, **_kwargs):
+        self._st.metrics.append((self._st.current_tab, label, value))
+
+    def markdown(self, *_args, **_kwargs):
+        return None
+
+    def info(self, *_args, **_kwargs):
+        return None
+
+
+class DummyExpander:
+    def __init__(self, st_module):
+        self._st = st_module
+
+    def __enter__(self):
+        return self._st
 
     def __exit__(self, exc_type, exc, tb):
         return False
@@ -46,7 +69,7 @@ class DummyComponents:
 
 
 class DummyStreamlit:
-    def __init__(self, *, mode_choice="Analyst"):
+    def __init__(self, *, mode_choice="Advanced View"):
         self.session_state = {}
         self.current_tab = None
         self.mode_choice = mode_choice
@@ -59,6 +82,7 @@ class DummyStreamlit:
         self.selectbox_calls = []
         self.html_blocks = []
         self.components = DummyComponents(self)
+        self.metrics = []
 
     def set_page_config(self, **_kwargs):
         return None
@@ -92,6 +116,9 @@ class DummyStreamlit:
     def write(self, _payload):
         return None
 
+    def metric(self, label, value, *_args, **_kwargs):
+        self.metrics.append((self.current_tab, label, value))
+
     def number_input(self, label, value=0.0, key=None, **_kwargs):
         self.number_inputs.append((self.current_tab, label, key))
         if key is not None:
@@ -110,13 +137,16 @@ class DummyStreamlit:
         return options[0]
 
     def columns(self, count):
-        return [DummyColumn() for _ in range(count)]
+        return [DummyColumn(self) for _ in range(count)]
 
     def subheader(self, _text):
         return None
 
     def code(self, _text, **_kwargs):
         return None
+
+    def expander(self, _label, **_kwargs):
+        return DummyExpander(self)
 
 
 def _load_app_module():
@@ -150,8 +180,6 @@ def test_sprint12_tab_layout_and_capital_location(monkeypatch):
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [{"instrument": "AAA"}])
     monkeypatch.setattr(app_main, "generate_portfolio_allocation", lambda _rows, _capital: {"allocations": [{"allocation_amount": 5000, "allocation_pct": 0.05}]})
-    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
-    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(app_main, "render_portfolio_plan", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(app_main, "render_analyst_insights", lambda *_args, **_kwargs: None)
 
@@ -161,9 +189,9 @@ def test_sprint12_tab_layout_and_capital_location(monkeypatch):
     assert dummy_st.number_inputs == [("Portfolio", "Total capital", "total_capital")]
 
 
-def test_beginner_mode_hides_analyst_and_data_tabs(monkeypatch):
+def test_guided_view_hides_analyst_insights_tab(monkeypatch):
     app_main = _load_app_module()
-    dummy_st = DummyStreamlit(mode_choice="Beginner")
+    dummy_st = DummyStreamlit(mode_choice="Guided View")
 
     canonical_df = pd.DataFrame({"instrument": ["AAA"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
 
@@ -176,19 +204,16 @@ def test_beginner_mode_hides_analyst_and_data_tabs(monkeypatch):
     monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
-    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
-    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
 
     app_main.main()
 
-    assert dummy_st.tabs_requested[0] == ["Portfolio", "Review", "Ticker Analysis"]
-    assert not any(tab == "Data" for tab, _ in dummy_st.dataframes)
+    assert dummy_st.tabs_requested[0] == ["Portfolio", "Review", "Ticker Analysis", "Data"]
     assert not any(tab == "Analyst Insights" for tab, _ in dummy_st.info_messages)
 
 
 def test_analyst_mode_keeps_all_tabs_visible(monkeypatch):
     app_main = _load_app_module()
-    dummy_st = DummyStreamlit(mode_choice="Analyst")
+    dummy_st = DummyStreamlit(mode_choice="Advanced View")
 
     canonical_df = pd.DataFrame({"instrument": ["AAA"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
 
@@ -201,8 +226,6 @@ def test_analyst_mode_keeps_all_tabs_visible(monkeypatch):
     monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
-    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
-    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
 
     app_main.main()
 
@@ -213,7 +236,7 @@ def test_analyst_mode_keeps_all_tabs_visible(monkeypatch):
 
 def test_help_video_labels_and_links_render_in_expected_sections(monkeypatch):
     app_main = _load_app_module()
-    dummy_st = DummyStreamlit(mode_choice="Analyst")
+    dummy_st = DummyStreamlit(mode_choice="Advanced View")
 
     canonical_df = pd.DataFrame({"instrument": ["AAA"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
 
@@ -226,8 +249,6 @@ def test_help_video_labels_and_links_render_in_expected_sections(monkeypatch):
     monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
-    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
-    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
 
     app_main.main()
 
@@ -243,7 +264,7 @@ def test_help_video_labels_and_links_render_in_expected_sections(monkeypatch):
 
 def test_analyst_help_video_hidden_from_beginner_mode(monkeypatch):
     app_main = _load_app_module()
-    dummy_st = DummyStreamlit(mode_choice="Beginner")
+    dummy_st = DummyStreamlit(mode_choice="Guided View")
 
     canonical_df = pd.DataFrame({"instrument": ["AAA"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
 
@@ -256,8 +277,6 @@ def test_analyst_help_video_hidden_from_beginner_mode(monkeypatch):
     monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
-    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
-    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
 
     app_main.main()
 
@@ -288,8 +307,6 @@ def test_review_excludes_data_status_and_data_tab_contains_raw_preview(monkeypat
     monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
-    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
-    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
 
     app_main.main()
 
@@ -299,7 +316,6 @@ def test_review_excludes_data_status_and_data_tab_contains_raw_preview(monkeypat
 
     data_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Data"]
     assert "#### Data Status" in data_markdowns
-    assert "#### Main Dashboard" in data_markdowns
     assert any(tab == "Data" and len(df) == 2 for tab, df in dummy_st.dataframes)
 
 
@@ -324,8 +340,6 @@ def test_analyst_insights_empty_state_when_no_content(monkeypatch):
     monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
-    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
-    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
 
     app_main.main()
 
@@ -335,7 +349,7 @@ def test_analyst_insights_empty_state_when_no_content(monkeypatch):
 
 def test_ticker_analysis_options_come_from_canonical_dataset_not_ranked_subset(monkeypatch):
     app_main = _load_app_module()
-    dummy_st = DummyStreamlit(mode_choice="Analyst")
+    dummy_st = DummyStreamlit(mode_choice="Advanced View")
 
     large_ticker_universe = [f"T{i:03d}" for i in range(1, 21)]
     canonical_df = pd.DataFrame(
@@ -364,8 +378,6 @@ def test_ticker_analysis_options_come_from_canonical_dataset_not_ranked_subset(m
     )
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
-    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
-    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
 
     app_main.main()
 
@@ -390,12 +402,11 @@ def test_data_status_uses_warning_bucket_for_counts_and_details():
     markdowns = [text for _, text in dummy_st.markdowns]
     captions = [text for _, text in dummy_st.captions]
 
-    assert "**Errors:** 0" in markdowns
-    assert "**Warnings:** 1" in markdowns
-    assert "**Warning details**" in markdowns
+    assert ("Rows loaded", 12) in [(label, value) for _, label, value in dummy_st.metrics]
+    assert ("Warnings", 1) in [(label, value) for _, label, value in dummy_st.metrics]
+    assert ("Errors", 0) in [(label, value) for _, label, value in dummy_st.metrics]
     assert "- Missing volume for BBB" in markdowns
-    assert "**Error details**" not in markdowns
-    assert "No ingestion errors were reported for this dataset." in captions
+    assert "Source: demo" in captions
 
 
 def test_data_status_uses_error_bucket_for_counts_and_details():
@@ -414,12 +425,10 @@ def test_data_status_uses_error_bucket_for_counts_and_details():
     markdowns = [text for _, text in dummy_st.markdowns]
     captions = [text for _, text in dummy_st.captions]
 
-    assert "**Errors:** 1" in markdowns
-    assert "**Warnings:** 0" in markdowns
-    assert "**Error details**" in markdowns
+    assert ("Warnings", 0) in [(label, value) for _, label, value in dummy_st.metrics]
+    assert ("Errors", 1) in [(label, value) for _, label, value in dummy_st.metrics]
     assert "- Missing required column: close" in markdowns
-    assert "**Warning details**" not in markdowns
-    assert "No ingestion warnings were reported for this dataset." in captions
+    assert "Source: upload" in captions
 
 
 def test_data_status_uses_both_buckets_without_top_level_keys():
@@ -440,11 +449,9 @@ def test_data_status_uses_both_buckets_without_top_level_keys():
 
     markdowns = [text for _, text in dummy_st.markdowns]
 
-    assert "**Errors:** 1" in markdowns
-    assert "**Warnings:** 1" in markdowns
-    assert "**Warning details**" in markdowns
+    assert ("Warnings", 1) in [(label, value) for _, label, value in dummy_st.metrics]
+    assert ("Errors", 1) in [(label, value) for _, label, value in dummy_st.metrics]
     assert "- Ticker normalized: BRG -> BRG.JM" in markdowns
-    assert "**Error details**" in markdowns
     assert "- Price parse failed on row 3" in markdowns
     assert "- errors" not in markdowns
     assert "- warnings" not in markdowns
@@ -544,8 +551,6 @@ def test_ticker_analysis_selector_uses_canonical_dataset_universe(monkeypatch):
     monkeypatch.setattr(app_main, "run_demo", lambda *_args, **_kwargs: {"ranked": pd.DataFrame()})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: analyst_subset)
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
-    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
-    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(app_main, "compute_ticker_metrics", lambda *_args, **_kwargs: {"summary": "", "behavior": {}})
     monkeypatch.setattr(
         app_main,
@@ -568,7 +573,7 @@ def test_ticker_analysis_selector_uses_canonical_dataset_universe(monkeypatch):
 
 def test_main_startup_path_is_not_blocked_by_missing_legacy_events_file(monkeypatch):
     app_main = _load_app_module()
-    dummy_st = DummyStreamlit(mode_choice="Beginner")
+    dummy_st = DummyStreamlit(mode_choice="Guided View")
     events_path = (ROOT / "data" / "demo" / "earnings_events.csv").resolve()
     original_exists = Path.exists
     original_read_csv = pd.read_csv
@@ -595,7 +600,7 @@ def test_main_startup_path_is_not_blocked_by_missing_legacy_events_file(monkeypa
 
 def test_ticker_analysis_beginner_mode_hides_raw_deep_dive_tables(monkeypatch):
     app_main = _load_app_module()
-    dummy_st = DummyStreamlit(mode_choice="Beginner")
+    dummy_st = DummyStreamlit(mode_choice="Guided View")
 
     canonical_df = pd.DataFrame({"instrument": ["CAR"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
     analyst_df = pd.DataFrame({"instrument": ["CAR"], "holding_window": [5], "net_return_pct": [0.01]})
@@ -613,8 +618,6 @@ def test_ticker_analysis_beginner_mode_hides_raw_deep_dive_tables(monkeypatch):
     monkeypatch.setattr(app_main, "run_demo", lambda *_args, **_kwargs: {"ranked": pd.DataFrame()})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: analyst_df)
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
-    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
-    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         app_main,
         "compute_ticker_metrics",
@@ -652,17 +655,15 @@ def test_ticker_analysis_beginner_mode_hides_raw_deep_dive_tables(monkeypatch):
     app_main.main()
 
     ticker_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Ticker Analysis"]
-    ticker_captions = [text for tab, text in dummy_st.captions if tab == "Ticker Analysis"]
-    assert "#### D) Execution Behavior" in ticker_markdowns
+    assert "#### Execution Behavior" in ticker_markdowns
     assert "#### G) Analyst Deep Dive" not in ticker_markdowns
-    assert any("Short execution framing" in text for text in ticker_captions)
+    assert any("Switch to Advanced View to open the full table breakdown." in text for _, text in dummy_st.captions)
     assert not any("Outcome context:" in text for text in ticker_markdowns)
-    assert any("Analyst Deep Dive" in text for text in ticker_markdowns)
 
 
 def test_ticker_analysis_analyst_mode_shows_deep_dive_tables(monkeypatch):
     app_main = _load_app_module()
-    dummy_st = DummyStreamlit(mode_choice="Analyst")
+    dummy_st = DummyStreamlit(mode_choice="Advanced View")
 
     canonical_df = pd.DataFrame({"instrument": ["CAR"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
     analyst_df = pd.DataFrame({"instrument": ["CAR"], "holding_window": [5], "net_return_pct": [0.01]})
@@ -680,8 +681,6 @@ def test_ticker_analysis_analyst_mode_shows_deep_dive_tables(monkeypatch):
     monkeypatch.setattr(app_main, "run_demo", lambda *_args, **_kwargs: {"ranked": pd.DataFrame()})
     monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: analyst_df)
     monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
-    monkeypatch.setattr(app_main, "generate_embedded_insights", lambda *_args, **_kwargs: {"headline": "ok"})
-    monkeypatch.setattr(app_main, "render_embedded_insights", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         app_main,
         "compute_ticker_metrics",
@@ -719,10 +718,8 @@ def test_ticker_analysis_analyst_mode_shows_deep_dive_tables(monkeypatch):
     app_main.main()
 
     ticker_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Ticker Analysis"]
-    ticker_captions = [text for tab, text in dummy_st.captions if tab == "Ticker Analysis"]
     ticker_dataframes = [df for tab, df in dummy_st.dataframes if tab == "Ticker Analysis"]
-    assert "#### D) Execution Behavior" in ticker_markdowns
-    assert "#### G) Analyst Deep Dive" in ticker_markdowns
-    assert any("Expanded execution framing" in text for text in ticker_captions)
+    assert "#### Execution Behavior" in ticker_markdowns
+    assert "#### G) Analyst Deep Dive" not in ticker_markdowns
     assert any("Outcome context:" in text for text in ticker_markdowns)
-    assert len(ticker_dataframes) >= 5
+    assert len(ticker_dataframes) >= 4

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -31,6 +31,20 @@ class DummyStreamlit:
         def __exit__(self, exc_type, exc, tb):
             return False
 
+    class _DummyColumn:
+        def metric(self, *_args, **_kwargs):
+            return None
+
+    class _DummyExpander:
+        def __init__(self, st_module):
+            self._st = st_module
+
+        def __enter__(self):
+            return self._st
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
     def subheader(self, _text):
         return None
 
@@ -49,6 +63,15 @@ class DummyStreamlit:
 
     def write(self, payload):
         self.writes.append(payload)
+
+    def metric(self, *_args, **_kwargs):
+        return None
+
+    def columns(self, count):
+        return [self._DummyColumn() for _ in range(count)]
+
+    def expander(self, _label, **_kwargs):
+        return self._DummyExpander(self)
 
     def tabs(self, names):
         self.tabs_requested.append(list(names))
@@ -79,8 +102,8 @@ def test_render_portfolio_plan_uses_cleaned_plan_labels_in_beginner_mode():
         st_module=st,
     )
 
-    funded_df = st.dataframes[1][0]
-    unfunded_df = st.dataframes[2][0]
+    funded_df = st.dataframes[0][0]
+    unfunded_df = st.dataframes[1][0]
 
     assert "Ticker" in funded_df.columns
     assert "Setup Strength" in funded_df.columns
@@ -102,11 +125,11 @@ def test_render_portfolio_plan_uses_cleaned_plan_labels_in_beginner_mode():
     assert "Selected because" in funded_df.iloc[0]["Why this trade"]
     assert "planned exit" in funded_df.iloc[0]["Execution Summary"]
     assert "trading days" not in funded_df.iloc[0]["Execution Summary"]
-    assert funded_df.iloc[0]["Decision Status"] == "Selected"
-    assert unfunded_df.iloc[0]["Decision Status"] == "Not funded (limit reached)"
-    assert "funds the strongest eligible setups first" in st.captions[0]
+    assert "Decision Status" not in funded_df.columns
+    assert "Decision Status" not in unfunded_df.columns
+    assert "funds stronger eligible setups first" in st.captions[0]
     assert st.tabs_requested == [["Plan", "Review"]]
-    assert any("followed system rules" in line for line in st.markdowns)
+    assert any("Decision Audit" in line for line in st.markdowns)
 
 
 def test_render_portfolio_plan_beginner_vs_analyst_columns():
@@ -139,8 +162,8 @@ def test_render_portfolio_plan_beginner_vs_analyst_columns():
         mode="analyst",
     )
 
-    beginner_df = beginner_st.dataframes[1][0]
-    analyst_df = analyst_st.dataframes[1][0]
+    beginner_df = beginner_st.dataframes[0][0]
+    analyst_df = analyst_st.dataframes[0][0]
 
     assert "Selection Rank" not in beginner_df.columns
     assert "Allocation %" not in beginner_df.columns
@@ -172,7 +195,7 @@ def test_render_portfolio_plan_keeps_explanations_before_supporting_fields():
         mode="analyst",
     )
 
-    funded_df = st.dataframes[1][0]
+    funded_df = st.dataframes[0][0]
     ordered_columns = list(funded_df.columns)
 
     assert ordered_columns.index("Why this trade") < ordered_columns.index("Allocation %")
@@ -223,12 +246,8 @@ def test_render_portfolio_plan_places_snapshot_and_reserved_cash_before_tables()
     assert "#### Portfolio Snapshot" in st.markdowns
     assert "#### Why cash is reserved" in st.markdowns
     snapshot_idx = st.markdowns.index("#### Portfolio Snapshot")
-    summary_idx = next(
-        idx
-        for idx, text in enumerate(st.markdowns)
-        if "Portfolio Summary" in text
-    )
-    assert snapshot_idx < summary_idx
+    funded_idx = st.markdowns.index("#### Funded Trades")
+    assert snapshot_idx < funded_idx
 
 
 def test_render_portfolio_plan_reframes_rules_and_analyst_override_copy():
@@ -290,7 +309,7 @@ def test_render_portfolio_plan_limits_unfunded_rows_in_beginner_mode():
         mode="beginner",
     )
 
-    unfunded_df = st.dataframes[2][0]
+    unfunded_df = st.dataframes[1][0]
     assert len(unfunded_df) == 12
     assert any("Showing top 12 unfunded trades for speed." in caption for caption in st.captions)
 
@@ -435,7 +454,7 @@ def test_render_portfolio_plan_funded_rank_deviation_row_does_not_crash():
         section="plan",
     )
 
-    funded_df = st.dataframes[1][0]
+    funded_df = st.dataframes[0][0]
     summary = funded_df.iloc[0]["Execution Summary"]
     assert "planned exit after 7 trading days" in summary
     assert "NameError" not in summary
@@ -557,8 +576,8 @@ def test_render_portfolio_plan_shows_explicit_holding_window_for_funded_and_unfu
         mode="beginner",
     )
 
-    funded_df = st.dataframes[1][0]
-    unfunded_df = st.dataframes[2][0]
+    funded_df = st.dataframes[0][0]
+    unfunded_df = st.dataframes[1][0]
 
     assert funded_df.iloc[0]["Holding Window"] == "10 trading days"
     assert unfunded_df.iloc[0]["Holding Window"] == "20 trading days"


### PR DESCRIPTION
### Motivation
- Unify and clarify the app's user-facing modes and onboarding to present a simpler "Guided" view and a fuller "Advanced" (analyst) view. 
- Improve readability and interpretability of the dashboard by using metric cards, clearer phrasing, and progressive disclosure for advanced tables. 
- Make data-status, portfolio and ticker explanations more informative and less brittle when datasets are sparse. 

### Description
- Replace legacy mode names and tab sets with `_MODE_OPTIONS` mapping and `_GUIDED_TABS` / `_ADVANCED_TABS`, and switch the radio to show "Guided View" / "Advanced View" labels. 
- Add onboarding UI and start-here video via `_render_onboarding` and consolidate video/link rendering helpers. 
- Rework data status display to use `st.metric` cards and expanders for warnings/errors, and show richer diagnostics only in Advanced mode. 
- Polish ticker and portfolio sections with updated headings, phrasing, metric cards, progressive disclosure of advanced tables (expanders), and adjusted sample/summary wording across `ticker_intelligence`, `execution`, and `portfolio_ui`. 
- Simplify and tidy several helper functions (string updates, small refactors, compacted conditional logic) and remove use of the now-absent embedded insights rendering in the main flow. 
- Update unit tests and test stubs to reflect the new view labels, new Streamlit interactions (`metric`, `expander`, components), and changed text expectations. 

### Testing
- Ran the unit test suite with `pytest` focusing on updated modules and UI architecture tests including `tests/test_app_information_architecture.py`, `tests/test_analyst_insights.py`, and `tests/test_portfolio_ui.py`. 
- All modified and related tests passed after updating expectations for new view labels, metrics usage, and expanded/hidden content behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df064c84488322bcf3536a8c2457dc)