### PR TITLE
Harden first-run onboarding compatibility checks

### DIFF
--- a/app.py
+++ b/app.py
@@ -264,12 +264,29 @@ def _render_first_run_header(st_module, mode: str = "beginner", **_kwargs) -> No
     """
     del mode  # preserved for compatibility with older call sites
 
+    components = getattr(st_module, "components", None)
+    components_v1 = getattr(components, "v1", None) if components is not None else None
     supports_full_onboarding = all(
-        hasattr(st_module, attr) for attr in ("columns", "expander", "components")
+        (
+            hasattr(st_module, "markdown"),
+            hasattr(st_module, "caption"),
+            hasattr(st_module, "columns"),
+            hasattr(st_module, "info"),
+            hasattr(st_module, "expander"),
+            hasattr(st_module, "components"),
+            components is not None,
+            hasattr(components, "v1"),
+            components_v1 is not None,
+            hasattr(components_v1, "html"),
+        )
     )
     if supports_full_onboarding:
-        _render_onboarding(st_module)
-        return
+        try:
+            _render_onboarding(st_module)
+            return
+        except AttributeError:
+            # Compatibility fallback for partial streamlit-like stubs.
+            pass
 
     # Minimal fallback for lightweight streamlit stubs used in tests/callers.
     st_module.markdown("### How to read this dashboard")

--- a/tests/test_language_outputs.py
+++ b/tests/test_language_outputs.py
@@ -74,6 +74,98 @@ def test_first_run_helper_renders_without_breaking():
     assert any("risk still matters" in line.lower() for line in st.lines)
 
 
+def test_first_run_helper_falls_back_when_info_missing():
+    module_path = ROOT / "app.py"
+    spec = importlib.util.spec_from_file_location("app_main", module_path)
+    assert spec and spec.loader
+    app_main = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(app_main)
+
+    class DummyComponentsV1:
+        def html(self, *_args, **_kwargs):
+            return None
+
+    class DummyComponents:
+        v1 = DummyComponentsV1()
+
+    class DummyExpander:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyStreamlitMissingInfo:
+        components = DummyComponents()
+
+        def __init__(self):
+            self.lines = []
+
+        def markdown(self, text, **_kwargs):
+            self.lines.append(text)
+
+        def caption(self, text):
+            self.lines.append(text)
+
+        def columns(self, n):
+            return [object() for _ in range(n)]
+
+        def expander(self, *_args, **_kwargs):
+            return DummyExpander()
+
+    st = DummyStreamlitMissingInfo()
+    app_main._render_first_run_header(st, mode="beginner")
+    assert any("How to read this" in line for line in st.lines)
+    assert any("Based on historical data." in line for line in st.lines)
+
+
+def test_first_run_helper_falls_back_when_components_html_missing():
+    module_path = ROOT / "app.py"
+    spec = importlib.util.spec_from_file_location("app_main", module_path)
+    assert spec and spec.loader
+    app_main = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(app_main)
+
+    class DummyComponentsV1:
+        pass
+
+    class DummyComponents:
+        v1 = DummyComponentsV1()
+
+    class DummyExpander:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyStreamlitMissingHtml:
+        components = DummyComponents()
+
+        def __init__(self):
+            self.lines = []
+
+        def markdown(self, text, **_kwargs):
+            self.lines.append(text)
+
+        def caption(self, text):
+            self.lines.append(text)
+
+        def columns(self, n):
+            return [object() for _ in range(n)]
+
+        def info(self, text):
+            self.lines.append(text)
+
+        def expander(self, *_args, **_kwargs):
+            return DummyExpander()
+
+    st = DummyStreamlitMissingHtml()
+    app_main._render_first_run_header(st, mode="beginner")
+    assert any("How to read this" in line for line in st.lines)
+    assert any("Based on historical data." in line for line in st.lines)
+
+
 def test_embedded_why_this_matters_includes_trust_layer_without_advisory_terms():
     payload = generate_embedded_insights(
         [{"quality_tier": "A", "volatility_bucket": "medium", "win_rate": 0.52, "avg_return": 0.01, "median_return": 0.01}],


### PR DESCRIPTION
### Motivation
- The compatibility wrapper `_render_first_run_header` previously performed only partial feature detection and could delegate into `_render_onboarding` on partial Streamlit-like stubs, causing `AttributeError` at startup or in tests. 
- The goal is to make delegation truly defensive so partial/older stubs or lightweight test doubles do not crash while preserving the new onboarding experience for full Streamlit environments.

### Description
- Updated `app.py` to perform full-chain feature detection before delegating, checking `st_module.markdown`, `st_module.caption`, `st_module.columns`, `st_module.info`, `st_module.expander`, `st_module.components`, `st_module.components.v1`, and `st_module.components.v1.html` via nested `getattr`/`hasattr` checks. 
- Wrapped the delegation call to `_render_onboarding(st_module)` in a narrow `try/except AttributeError` to fall back cleanly if a missing attribute is discovered at runtime. 
- Added regression tests to `tests/test_language_outputs.py` that validate fallback behavior for partial stubs missing `info` and missing `components.v1.html`. 
- Did not remove or alter `_render_onboarding`, and the onboarding redesign is preserved and still used when the full API surface is present.

### Testing
- Files updated: `app.py` and `tests/test_language_outputs.py`.
- Ran the test suite for the changed tests with `pytest -q tests/test_language_outputs.py` and observed: `7 passed` (all tests succeeded). 
- The new tests assert that `_render_first_run_header` falls back cleanly for stubs missing `info` and for stubs where `components.v1.html` is absent, and they passed. 
- Confirmed that the onboarding path remains intact and continues to be used when the full Streamlit API chain is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df10b81e9c8322ba77828fa2ac1017)