### PR TITLE
Polish Guided View information architecture and mobile scanability

### DIFF
--- a/app.py
+++ b/app.py
@@ -215,16 +215,26 @@ def _render_video_link(st_module, *, label: str, url: str) -> None:
     st_module.markdown(f'<a href="{url}" target="_blank" rel="noopener noreferrer">{label}</a>', unsafe_allow_html=True)
 
 
+def _resolve_dataset_period_description(df: pd.DataFrame) -> str:
+    if df.empty or "date" not in df.columns:
+        return "Using historical JSE data available in the current dataset."
+
+    date_values = pd.to_datetime(df["date"], errors="coerce").dropna()
+    if date_values.empty:
+        return "Using historical JSE data available in the current dataset."
+
+    min_year = int(date_values.min().year)
+    max_year = int(date_values.max().year)
+    return f"Using historical JSE data from {min_year} to {max_year} in the current dataset."
+
+
 def _render_start_here_video(st_module) -> None:
     st_module.markdown("### New here? Start with this video")
-    st_module.caption("This quick walkthrough shows how to use the dashboard and where to start.")
     st_module.components.v1.html(_START_HERE_EMBED_HTML, height=460)
 
 
-def _render_onboarding(st_module) -> None:
-    st_module.caption(
-        "Decision-support for JSE trades, using price action, volume participation, volatility, liquidity, and realized outcomes from the JSE sample (since 2018 where available)."
-    )
+def _render_onboarding(st_module, *, dataset_period_description: str) -> None:
+    st_module.caption(dataset_period_description)
     _render_start_here_video(st_module)
 
     st_module.markdown("### Where to start")
@@ -236,23 +246,24 @@ def _render_onboarding(st_module) -> None:
     with review_col:
         st_module.info("**Review**\n\nCheck whether the plan followed its rules.")
 
-    with st_module.expander("What this dashboard does"):
+    with st_module.expander("Learn how this works", expanded=False):
+        st_module.markdown("#### What this dashboard does")
         st_module.markdown("- Highlights stronger and weaker setups.")
         st_module.markdown("- Helps compare trades more clearly.")
         st_module.markdown("- Shows how long setups typically take to play out.")
         st_module.markdown("- Helps frame risk, not just returns.")
 
-    with st_module.expander("How this dashboard supports decisions"):
+        st_module.markdown("#### How this dashboard supports decisions")
         st_module.markdown("- Structures trade review with consistent rules.")
         st_module.markdown("- Keeps portfolio discipline visible before and after selection.")
         st_module.markdown("- Helps compare opportunities with a shared, repeatable framework.")
 
-    with st_module.expander("What the system looks at"):
-        st_module.markdown("- Price behavior.")
-        st_module.markdown("- Volume / participation.")
-        st_module.markdown("- Volatility / risk.")
+        st_module.markdown("#### What the system looks at")
+        st_module.markdown("- Price action.")
+        st_module.markdown("- Volume participation.")
+        st_module.markdown("- Volatility.")
         st_module.markdown("- Liquidity.")
-        st_module.markdown("- Historical outcomes like win rate and median return.")
+        st_module.markdown("- Realized outcomes and historical consistency.")
 
 
 def _render_first_run_header(st_module, mode: str = "beginner", **_kwargs) -> None:
@@ -282,7 +293,10 @@ def _render_first_run_header(st_module, mode: str = "beginner", **_kwargs) -> No
     )
     if supports_full_onboarding:
         try:
-            _render_onboarding(st_module)
+            _render_onboarding(
+                st_module,
+                dataset_period_description="Using historical JSE data available in the current dataset.",
+            )
             return
         except AttributeError:
             # Compatibility fallback for partial streamlit-like stubs.
@@ -290,7 +304,7 @@ def _render_first_run_header(st_module, mode: str = "beginner", **_kwargs) -> No
 
     # Minimal fallback for lightweight streamlit stubs used in tests/callers.
     st_module.markdown("### How to read this dashboard")
-    st_module.caption("Based on historical data.")
+    st_module.caption("Using historical JSE data available in the current dataset.")
     st_module.markdown("Use it as decision support—risk still matters in every setup.")
 
 
@@ -336,6 +350,7 @@ def main() -> None:
     _render_visual_polish(st)
 
     st.title("JSE Market Lab")
+    st.caption("Decision support for selecting, sizing, and reviewing JSE trade setups.")
     mode_label = st.radio("View", options=list(_MODE_OPTIONS.keys()), horizontal=True, index=0)
     mode_token = _MODE_OPTIONS[mode_label]
     st.caption("Guided View: simpler explanations and lighter detail")
@@ -398,7 +413,8 @@ def main() -> None:
         base_allocations = allocation_payload.get("allocations", [])
         enriched_allocations = [{**allocation, **row} for row, allocation in zip(trade_rows, base_allocations)]
 
-    _render_onboarding(st)
+    dataset_period_description = _resolve_dataset_period_description(canonical_df)
+    _render_onboarding(st, dataset_period_description=dataset_period_description)
 
     tabs = st.tabs(_resolve_tabs_for_mode(mode_token))
     tab_map = {name: tab for name, tab in zip(_resolve_tabs_for_mode(mode_token), tabs)}

--- a/app/insights/analyst.py
+++ b/app/insights/analyst.py
@@ -166,11 +166,13 @@ def render_analyst_insights(
 
     with insights_tab:
         st_module.subheader("Feature Insights")
-        st_module.caption("Feature Insights — setup tags connected to stronger or weaker outcomes.")
+        st_module.caption(
+            "This section shows whether detailed setup tags are linked to stronger or weaker outcomes."
+        )
         insights = build_feature_insights(trades_df, return_column=return_column)
         if not insights:
             st_module.info(
-                "Feature Insights activates when feature-tag columns are included in this dataset."
+                "This section becomes available when the dataset includes feature-tag columns."
             )
         for feature, summary in insights.items():
             st_module.markdown(f"#### {display_label(feature)}")
@@ -179,7 +181,9 @@ def render_analyst_insights(
 
     with matrix_tab:
         st_module.subheader("Performance Matrix")
-        st_module.caption("Performance Matrix — grouped setup quality and holding periods.")
+        st_module.caption(
+            "Use this section to compare grouped setup quality, holding period behavior, and historical consistency."
+        )
         try:
             matrix_payload = build_performance_matrix(
                 trades_df,
@@ -201,7 +205,9 @@ def render_analyst_insights(
 
     with exit_tab:
         st_module.subheader("Exit Analysis")
-        st_module.caption("Exit Analysis — how trades usually end and what that says about discipline.")
+        st_module.caption(
+            "Use this section to compare how trades behaved across exit windows, and where outcomes strengthened, weakened, or leveled off."
+        )
         required_cols = {"exit_reason", "quality_tier"}
         if required_cols.issubset(trades_df.columns):
             st_module.markdown("Interpretation: frequent stop exits can signal risk controls or weak setup quality.")

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -171,14 +171,16 @@ def render_portfolio_plan(
         metric_cols = st_module.columns(4)
         metric_cols[0].metric("Trades Found", len(allocations))
         metric_cols[1].metric("Funded Trades", summary["funded_trade_count"])
-        metric_cols[2].metric("Cash Reserved %", f"{summary['cash_reserve_pct']:.0%}")
-        metric_cols[3].metric("Allocated %", f"{summary['total_allocated_pct']:.0%}")
+        metric_cols[2].metric("Allocated %", f"{summary['total_allocated_pct']:.0%}")
+        metric_cols[3].metric("Cash Reserved %", f"{summary['cash_reserve_pct']:.0%}")
         if analyst_mode:
             st_module.info(
                 "Funding stayed concentrated on stronger ranked setups while maintaining reserve coverage."
             )
         else:
-            st_module.info("This snapshot shows how much is funded now and how much stays reserved.")
+            st_module.info(
+                "The current set is concentrated in a few stronger setups, with some capital held back for selectivity."
+            )
 
         with st_module.expander("How to read setup strength and confidence"):
             for line in snapshot["lines"]:
@@ -186,12 +188,25 @@ def render_portfolio_plan(
 
         reserved_cash = build_reserved_cash_explanation(allocations, total_capital, mode=mode)
         if reserved_cash["reserve_ratio"] > 0:
-            st_module.markdown("#### Why cash is reserved")
-            st_module.info(reserved_cash["lines"][0] if reserved_cash["lines"] else "Cash reserve supports discipline.")
-            if analyst_mode and len(reserved_cash["lines"]) > 1:
-                with st_module.expander("Reserve detail"):
+            with st_module.expander("Why cash is reserved", expanded=False):
+                st_module.info(
+                    reserved_cash["lines"][0] if reserved_cash["lines"] else "Cash reserve supports discipline."
+                )
+                if analyst_mode and len(reserved_cash["lines"]) > 1:
                     for line in reserved_cash["lines"][1:]:
                         st_module.markdown(f"- {line}")
+
+    def _render_trade_cards(trades: Sequence[Mapping[str, Any]], *, funded: bool) -> None:
+        for trade in trades:
+            plan_row = _portfolio_plan_row(trade, funded=funded)
+            st_module.markdown(
+                f"**{plan_row['Ticker']}** · {plan_row['Setup Strength']} · {plan_row['Confidence / Reliability']}"
+            )
+            st_module.caption(f"Holding window: {plan_row['Holding Window']}")
+            st_module.markdown(f"**Why this trade:** {plan_row['Why this trade']}")
+            if funded:
+                st_module.markdown(f"**Execution Summary:** {plan_row['Execution Summary']}")
+            st_module.markdown("---")
 
 
     def _render_plan_section() -> None:
@@ -199,8 +214,11 @@ def render_portfolio_plan(
 
         st_module.markdown("#### Funded Trades")
         if funded_trades:
-            funded_df = pd.DataFrame([_portfolio_plan_row(trade, funded=True) for trade in funded_trades])
-            st_module.dataframe(funded_df, use_container_width=True)
+            if analyst_mode:
+                funded_df = pd.DataFrame([_portfolio_plan_row(trade, funded=True) for trade in funded_trades])
+                st_module.dataframe(funded_df, use_container_width=True)
+            else:
+                _render_trade_cards(funded_trades, funded=True)
         else:
             st_module.info("No funded trades for the selected inputs.")
 
@@ -215,8 +233,11 @@ def render_portfolio_plan(
                 )[:_BEGINNER_UNFUNDED_ROW_LIMIT]
                 hidden_unfunded_count = len(unfunded_trades) - len(visible_unfunded)
 
-            unfunded_df = pd.DataFrame([_portfolio_plan_row(trade, funded=False) for trade in visible_unfunded])
-            st_module.dataframe(unfunded_df, use_container_width=True)
+            if analyst_mode:
+                unfunded_df = pd.DataFrame([_portfolio_plan_row(trade, funded=False) for trade in visible_unfunded])
+                st_module.dataframe(unfunded_df, use_container_width=True)
+            else:
+                _render_trade_cards(visible_unfunded, funded=False)
             if hidden_unfunded_count > 0:
                 st_module.caption(
                     f"Showing top {_BEGINNER_UNFUNDED_ROW_LIMIT} unfunded trades for speed. "

--- a/tests/test_analyst_insights.py
+++ b/tests/test_analyst_insights.py
@@ -190,7 +190,7 @@ def test_render_analyst_insights_feature_insights_unavailable_message_is_explici
 
     assert (
         "info",
-        "Feature Insights activates when feature-tag columns are included in this dataset.",
+        "This section becomes available when the dataset includes feature-tag columns.",
     ) in st.calls
 
 
@@ -201,8 +201,8 @@ def test_render_analyst_insights_includes_explanatory_captions_for_matrix_and_ex
     render_analyst_insights(_sample_trades(), st_module=st, analyst_mode=True)
 
     captions = [text for event, text in st.calls if event == "caption"]
-    assert any("Performance Matrix — grouped setup quality and holding periods." in text for text in captions)
-    assert any("Exit Analysis — how trades usually end and what that says about discipline." in text for text in captions)
+    assert any("compare grouped setup quality" in text for text in captions)
+    assert any("behaved across exit windows" in text for text in captions)
 
 
 def test_render_analyst_insights_cleans_snake_case_labels_for_display_tables():

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -83,6 +83,7 @@ class DummyStreamlit:
         self.html_blocks = []
         self.components = DummyComponents(self)
         self.metrics = []
+        self.expanders = []
 
     def set_page_config(self, **_kwargs):
         return None
@@ -146,6 +147,7 @@ class DummyStreamlit:
         return None
 
     def expander(self, _label, **_kwargs):
+        self.expanders.append((self.current_tab, _label))
         return DummyExpander(self)
 
 
@@ -260,6 +262,7 @@ def test_help_video_labels_and_links_render_in_expected_sections(monkeypatch):
     assert any("▶ Watch: Understanding Review" in text for tab, text in dummy_st.markdowns if tab == "Review")
     assert any("▶ Watch: How to Use Analyst Mode" in text for tab, text in dummy_st.markdowns if tab == "Analyst Insights")
     assert any("loom.com/embed/7429a995143a4bf498b640b5371309bc" in html for _, html, _ in dummy_st.html_blocks)
+    assert (None, "Learn how this works") in dummy_st.expanders
 
 
 def test_analyst_help_video_hidden_from_beginner_mode(monkeypatch):

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -195,3 +195,20 @@ def test_freeze_and_unfreeze_issues_round_trip():
     restored = app_main._unfreeze_issues(frozen)
 
     assert restored == issues
+
+
+def test_dataset_period_description_uses_date_range_when_available():
+    spec = importlib.util.spec_from_file_location("app_main", ROOT / "app.py")
+    app_main = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_main)
+
+    df = pd.DataFrame({"date": pd.to_datetime(["2020-01-01", "2024-12-31", None])})
+    assert app_main._resolve_dataset_period_description(df) == (
+        "Using historical JSE data from 2020 to 2024 in the current dataset."
+    )
+
+
+def test_app_no_long_hard_coded_data_period_copy():
+    source = (ROOT / "app.py").read_text()
+    assert "since 2018 where available" not in source

--- a/tests/test_language_outputs.py
+++ b/tests/test_language_outputs.py
@@ -70,7 +70,7 @@ def test_first_run_helper_renders_without_breaking():
     st = DummyStreamlit()
     app_main._render_first_run_header(st, mode="beginner")
     assert any("How to read this" in line for line in st.lines)
-    assert any("Based on historical data." in line for line in st.lines)
+    assert any("Using historical JSE data available in the current dataset." in line for line in st.lines)
     assert any("risk still matters" in line.lower() for line in st.lines)
 
 
@@ -116,7 +116,7 @@ def test_first_run_helper_falls_back_when_info_missing():
     st = DummyStreamlitMissingInfo()
     app_main._render_first_run_header(st, mode="beginner")
     assert any("How to read this" in line for line in st.lines)
-    assert any("Based on historical data." in line for line in st.lines)
+    assert any("Using historical JSE data available in the current dataset." in line for line in st.lines)
 
 
 def test_first_run_helper_falls_back_when_components_html_missing():
@@ -163,7 +163,7 @@ def test_first_run_helper_falls_back_when_components_html_missing():
     st = DummyStreamlitMissingHtml()
     app_main._render_first_run_header(st, mode="beginner")
     assert any("How to read this" in line for line in st.lines)
-    assert any("Based on historical data." in line for line in st.lines)
+    assert any("Using historical JSE data available in the current dataset." in line for line in st.lines)
 
 
 def test_embedded_why_this_matters_includes_trust_layer_without_advisory_terms():

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -23,6 +23,7 @@ class DummyStreamlit:
         self.writes = []
         self.markdowns = []
         self.tabs_requested = []
+        self.expanders = []
 
     class _DummyTab:
         def __enter__(self):
@@ -71,6 +72,7 @@ class DummyStreamlit:
         return [self._DummyColumn() for _ in range(count)]
 
     def expander(self, _label, **_kwargs):
+        self.expanders.append(_label)
         return self._DummyExpander(self)
 
     def tabs(self, names):
@@ -78,7 +80,7 @@ class DummyStreamlit:
         return [self._DummyTab(), self._DummyTab()]
 
 
-def test_render_portfolio_plan_uses_cleaned_plan_labels_in_beginner_mode():
+def test_render_portfolio_plan_uses_compact_cards_in_beginner_mode():
     st = DummyStreamlit()
     render_portfolio_plan(
         allocations=[
@@ -100,36 +102,20 @@ def test_render_portfolio_plan_uses_cleaned_plan_labels_in_beginner_mode():
         ],
         total_capital=10_000,
         st_module=st,
+        section="plan",
     )
 
-    funded_df = st.dataframes[0][0]
-    unfunded_df = st.dataframes[1][0]
-
-    assert "Ticker" in funded_df.columns
-    assert "Setup Strength" in funded_df.columns
-    assert "Confidence / Reliability" in funded_df.columns
-    assert "Holding Window" in funded_df.columns
-    assert "Why this trade" in funded_df.columns
-    assert "Execution Summary" in funded_df.columns
-    assert "Why this trade" in unfunded_df.columns
-    assert "Execution Summary" in unfunded_df.columns
-    assert "Instrument" not in funded_df.columns
-    assert "Confidence" not in funded_df.columns
-    assert "Execution Framework" not in funded_df.columns
-    assert "Setup Strength" in funded_df.columns
-    assert "Strong setup" in funded_df.iloc[0]["Setup Strength"]
-    assert "High confidence" in funded_df.iloc[0]["Confidence / Reliability"]
-    assert funded_df.iloc[0]["Holding Window"] == "Not specified"
-    assert "Primary Rule/Constraint" not in funded_df.columns
-    assert "Primary Rule/Constraint" not in unfunded_df.columns
-    assert "Selected because" in funded_df.iloc[0]["Why this trade"]
-    assert "planned exit" in funded_df.iloc[0]["Execution Summary"]
-    assert "trading days" not in funded_df.iloc[0]["Execution Summary"]
-    assert "Decision Status" not in funded_df.columns
-    assert "Decision Status" not in unfunded_df.columns
+    assert not st.dataframes
+    combined_markdown = " ".join(st.markdowns)
+    assert "AAA" in combined_markdown
+    assert "Strong setup" in combined_markdown
+    assert "High confidence" in combined_markdown
+    assert "Why this trade" in combined_markdown
+    assert "Execution Summary" in combined_markdown
+    assert "Selected because" in combined_markdown
     assert "funds stronger eligible setups first" in st.captions[0]
-    assert st.tabs_requested == [["Plan", "Review"]]
-    assert any("Decision Audit" in line for line in st.markdowns)
+    assert st.tabs_requested == []
+    assert not any("Decision Audit" in line for line in st.markdowns)
 
 
 def test_render_portfolio_plan_beginner_vs_analyst_columns():
@@ -162,12 +148,9 @@ def test_render_portfolio_plan_beginner_vs_analyst_columns():
         mode="analyst",
     )
 
-    beginner_df = beginner_st.dataframes[0][0]
+    assert not beginner_st.dataframes
+    assert any("Execution Summary" in line for line in beginner_st.markdowns)
     analyst_df = analyst_st.dataframes[0][0]
-
-    assert "Selection Rank" not in beginner_df.columns
-    assert "Allocation %" not in beginner_df.columns
-    assert "Rule Note" not in beginner_df.columns
 
     assert "Selection Rank" in analyst_df.columns
     assert "Allocation %" in analyst_df.columns
@@ -244,7 +227,7 @@ def test_render_portfolio_plan_places_snapshot_and_reserved_cash_before_tables()
     )
 
     assert "#### Portfolio Snapshot" in st.markdowns
-    assert "#### Why cash is reserved" in st.markdowns
+    assert "Why cash is reserved" in st.expanders
     snapshot_idx = st.markdowns.index("#### Portfolio Snapshot")
     funded_idx = st.markdowns.index("#### Funded Trades")
     assert snapshot_idx < funded_idx
@@ -275,6 +258,28 @@ def test_render_portfolio_plan_reframes_rules_and_analyst_override_copy():
     assert "Funding approach: prioritize top-ranked, stronger setups" in combined
     assert "Analyst cap override: up to 4 funded trades" in combined
     assert "may include lower-ranked setups and reduce reserve discipline" in combined
+
+
+def test_render_portfolio_plan_collapses_rules_in_beginner_mode():
+    st = DummyStreamlit()
+    render_portfolio_plan(
+        allocations=[
+            {
+                "instrument": "AAA",
+                "allocation_amount": 1000,
+                "allocation_pct": 0.1,
+                "quality_tier": "A",
+                "confidence_label": "strong",
+                "selection_rank": 1,
+            }
+        ],
+        total_capital=10_000,
+        st_module=st,
+        section="plan",
+        mode="beginner",
+    )
+
+    assert "Portfolio rules and funding approach" in st.expanders
 
 
 def test_render_portfolio_plan_limits_unfunded_rows_in_beginner_mode():
@@ -309,8 +314,8 @@ def test_render_portfolio_plan_limits_unfunded_rows_in_beginner_mode():
         mode="beginner",
     )
 
-    unfunded_df = st.dataframes[1][0]
-    assert len(unfunded_df) == 12
+    unfunded_headers = [line for line in st.markdowns if line.startswith("**U")]
+    assert len(unfunded_headers) == 12
     assert any("Showing top 12 unfunded trades for speed." in caption for caption in st.captions)
 
 
@@ -454,8 +459,9 @@ def test_render_portfolio_plan_funded_rank_deviation_row_does_not_crash():
         section="plan",
     )
 
-    funded_df = st.dataframes[0][0]
-    summary = funded_df.iloc[0]["Execution Summary"]
+    summary_lines = [line for line in st.markdowns if "Execution Summary:" in line]
+    assert summary_lines
+    summary = summary_lines[0]
     assert "planned exit after 7 trading days" in summary
     assert "NameError" not in summary
 
@@ -576,11 +582,9 @@ def test_render_portfolio_plan_shows_explicit_holding_window_for_funded_and_unfu
         mode="beginner",
     )
 
-    funded_df = st.dataframes[0][0]
-    unfunded_df = st.dataframes[1][0]
-
-    assert funded_df.iloc[0]["Holding Window"] == "10 trading days"
-    assert unfunded_df.iloc[0]["Holding Window"] == "20 trading days"
+    holding_captions = [line for line in st.captions if line.startswith("Holding window:")]
+    assert "Holding window: 10 trading days" in holding_captions
+    assert "Holding window: 20 trading days" in holding_captions
 
 
 def test_compact_execution_summary_uses_holding_window_when_planned_exit_missing():


### PR DESCRIPTION
### Motivation
- Reduce Guided View overload and improve mobile scanability while keeping the Sprint 14 redesign intact. 
- Move secondary educational content out of the main flow and clarify purpose-driven language in deeper analyst sections.
- This is a UI/UX polish only and must not change ranking, allocation, execution, or signal logic.

### Description
- Top-of-page: tightened the header area to a title + one-line description, dataset-aware period wording (`_resolve_dataset_period_description`) and kept the `Start Here` Loom embed near the top, moving additional explanation under one collapsed expander labeled `Learn how this works` (`_render_onboarding`). (`app.py`)
- Portfolio Guided View: snapshot now surfaces four compact metrics and a single interpretation sentence, `Why cash is reserved` moved into a compact expander, glossary and portfolio rules collapsed by default, and Guided View funded/unfunded rows render as stacked compact cards while Advanced View retains full tables (`render_portfolio_plan`, `_render_trade_cards`). (`app/planner/portfolio_ui.py`)
- Analyst Insights: clarified purpose and unavailable-state copy for `Feature Insights`, `Performance Matrix`, and `Exit Analysis` to make sections actionable and avoid a broken-page feel. (`app/insights/analyst.py`)
- Tests updated to reflect UI changes and new copy/behaviour: several UI tests adapted and new checks added for dataset-period resolution and expander usage. (modified `tests/*` files).
- No changes to core business logic: ranking, allocation math, execution calculations, and signal-generation were not modified (presentation-only changes).

### Testing
- Ran the focused UI/test suite: `pytest -q tests/test_portfolio_ui.py tests/test_app_shell.py tests/test_app_information_architecture.py tests/test_analyst_insights.py tests/test_language_outputs.py` and all tests passed (`76 passed`).
- Updated tests include assertions for dataset-period wording, collapsed explainers/expanders, compact Guided View rendering, and clarified analyst captions; those tests succeeded.
- Manual validation notes (UI-focused): homepage first-load scanability, top-area reduction, Guided View mobile readability improvements, and clearer advanced section purpose were validated via unit tests simulating Streamlit stubs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df1e4fd8308322a597ff7af5e7d176)