### PR TITLE
Polish Guided View layout for lighter onboarding and mobile-first trade cards

### DIFF
--- a/app.py
+++ b/app.py
@@ -223,9 +223,9 @@ def _resolve_dataset_period_description(df: pd.DataFrame) -> str:
     if date_values.empty:
         return "Using historical JSE data available in the current dataset."
 
-    min_year = int(date_values.min().year)
-    max_year = int(date_values.max().year)
-    return f"Using historical JSE data from {min_year} to {max_year} in the current dataset."
+    min_date = date_values.min().date().isoformat()
+    max_date = date_values.max().date().isoformat()
+    return f"Using historical JSE data from {min_date} to {max_date} in the current dataset."
 
 
 def _render_start_here_video(st_module) -> None:
@@ -247,6 +247,11 @@ def _render_onboarding(st_module, *, dataset_period_description: str) -> None:
         st_module.info("**Review**\n\nCheck whether the plan followed its rules.")
 
     with st_module.expander("Learn how this works", expanded=False):
+        st_module.markdown("#### Methodology")
+        st_module.markdown(
+            "This is a decision-support dashboard for selecting, sizing, and reviewing JSE trade setups."
+        )
+
         st_module.markdown("#### What this dashboard does")
         st_module.markdown("- Highlights stronger and weaker setups.")
         st_module.markdown("- Helps compare trades more clearly.")
@@ -350,7 +355,6 @@ def main() -> None:
     _render_visual_polish(st)
 
     st.title("JSE Market Lab")
-    st.caption("Decision support for selecting, sizing, and reviewing JSE trade setups.")
     mode_label = st.radio("View", options=list(_MODE_OPTIONS.keys()), horizontal=True, index=0)
     mode_token = _MODE_OPTIONS[mode_label]
     st.caption("Guided View: simpler explanations and lighter detail")

--- a/app/insights/analyst.py
+++ b/app/insights/analyst.py
@@ -166,9 +166,7 @@ def render_analyst_insights(
 
     with insights_tab:
         st_module.subheader("Feature Insights")
-        st_module.caption(
-            "This section shows whether detailed setup tags are linked to stronger or weaker outcomes."
-        )
+        st_module.caption("Purpose: understand which setup tags are historically linked to stronger or weaker outcomes.")
         insights = build_feature_insights(trades_df, return_column=return_column)
         if not insights:
             st_module.info(
@@ -181,9 +179,7 @@ def render_analyst_insights(
 
     with matrix_tab:
         st_module.subheader("Performance Matrix")
-        st_module.caption(
-            "Use this section to compare grouped setup quality, holding period behavior, and historical consistency."
-        )
+        st_module.caption("Purpose: compare grouped setup quality, holding-window behavior, and consistency side by side.")
         try:
             matrix_payload = build_performance_matrix(
                 trades_df,
@@ -205,9 +201,7 @@ def render_analyst_insights(
 
     with exit_tab:
         st_module.subheader("Exit Analysis")
-        st_module.caption(
-            "Use this section to compare how trades behaved across exit windows, and where outcomes strengthened, weakened, or leveled off."
-        )
+        st_module.caption("Purpose: see where exit timing helped, hurt, or flattened outcomes across setups.")
         required_cols = {"exit_reason", "quality_tier"}
         if required_cols.issubset(trades_df.columns):
             st_module.markdown("Interpretation: frequent stop exits can signal risk controls or weak setup quality.")

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -173,14 +173,12 @@ def render_portfolio_plan(
         metric_cols[1].metric("Funded Trades", summary["funded_trade_count"])
         metric_cols[2].metric("Allocated %", f"{summary['total_allocated_pct']:.0%}")
         metric_cols[3].metric("Cash Reserved %", f"{summary['cash_reserve_pct']:.0%}")
-        if analyst_mode:
-            st_module.info(
-                "Funding stayed concentrated on stronger ranked setups while maintaining reserve coverage."
-            )
-        else:
-            st_module.info(
-                "The current set is concentrated in a few stronger setups, with some capital held back for selectivity."
-            )
+        interpretation = (
+            "Funding remained concentrated in stronger ranked setups while preserving cash for selectivity."
+            if analyst_mode
+            else "This plan funds the stronger setups first while preserving a cash buffer for discipline."
+        )
+        st_module.caption(interpretation)
 
         with st_module.expander("How to read setup strength and confidence"):
             for line in snapshot["lines"]:
@@ -189,7 +187,7 @@ def render_portfolio_plan(
         reserved_cash = build_reserved_cash_explanation(allocations, total_capital, mode=mode)
         if reserved_cash["reserve_ratio"] > 0:
             with st_module.expander("Why cash is reserved", expanded=False):
-                st_module.info(
+                st_module.caption(
                     reserved_cash["lines"][0] if reserved_cash["lines"] else "Cash reserve supports discipline."
                 )
                 if analyst_mode and len(reserved_cash["lines"]) > 1:
@@ -199,13 +197,14 @@ def render_portfolio_plan(
     def _render_trade_cards(trades: Sequence[Mapping[str, Any]], *, funded: bool) -> None:
         for trade in trades:
             plan_row = _portfolio_plan_row(trade, funded=funded)
-            st_module.markdown(
-                f"**{plan_row['Ticker']}** · {plan_row['Setup Strength']} · {plan_row['Confidence / Reliability']}"
-            )
-            st_module.caption(f"Holding window: {plan_row['Holding Window']}")
+            st_module.markdown(f"#### {plan_row['Ticker']}")
+            st_module.markdown(f"**Setup Strength:** {plan_row['Setup Strength']}")
+            st_module.markdown(f"**Confidence / Reliability:** {plan_row['Confidence / Reliability']}")
+            st_module.markdown(f"**Holding Window:** {plan_row['Holding Window']}")
             st_module.markdown(f"**Why this trade:** {plan_row['Why this trade']}")
-            if funded:
-                st_module.markdown(f"**Execution Summary:** {plan_row['Execution Summary']}")
+            st_module.markdown(
+                f"**Execution Summary:** {plan_row['Execution Summary'] if funded else 'Not funded in this cycle.'}"
+            )
             st_module.markdown("---")
 
 

--- a/tests/test_analyst_insights.py
+++ b/tests/test_analyst_insights.py
@@ -202,7 +202,7 @@ def test_render_analyst_insights_includes_explanatory_captions_for_matrix_and_ex
 
     captions = [text for event, text in st.calls if event == "caption"]
     assert any("compare grouped setup quality" in text for text in captions)
-    assert any("behaved across exit windows" in text for text in captions)
+    assert any("exit timing helped, hurt, or flattened outcomes" in text for text in captions)
 
 
 def test_render_analyst_insights_cleans_snake_case_labels_for_display_tables():

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -205,7 +205,7 @@ def test_dataset_period_description_uses_date_range_when_available():
 
     df = pd.DataFrame({"date": pd.to_datetime(["2020-01-01", "2024-12-31", None])})
     assert app_main._resolve_dataset_period_description(df) == (
-        "Using historical JSE data from 2020 to 2024 in the current dataset."
+        "Using historical JSE data from 2020-01-01 to 2024-12-31 in the current dataset."
     )
 
 

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -314,7 +314,9 @@ def test_render_portfolio_plan_limits_unfunded_rows_in_beginner_mode():
         mode="beginner",
     )
 
-    unfunded_headers = [line for line in st.markdowns if line.startswith("**U")]
+    unfunded_headers = [
+        line for line in st.markdowns if line.startswith("#### U") and len(line) > 6 and line[6].isdigit()
+    ]
     assert len(unfunded_headers) == 12
     assert any("Showing top 12 unfunded trades for speed." in caption for caption in st.captions)
 
@@ -582,9 +584,9 @@ def test_render_portfolio_plan_shows_explicit_holding_window_for_funded_and_unfu
         mode="beginner",
     )
 
-    holding_captions = [line for line in st.captions if line.startswith("Holding window:")]
-    assert "Holding window: 10 trading days" in holding_captions
-    assert "Holding window: 20 trading days" in holding_captions
+    holding_lines = [line for line in st.markdowns if line.startswith("**Holding Window:**")]
+    assert "**Holding Window:** 10 trading days" in holding_lines
+    assert "**Holding Window:** 20 trading days" in holding_lines
 
 
 def test_compact_execution_summary_uses_holding_window_when_planned_exit_missing():


### PR DESCRIPTION
### Motivation
- Reduce vertical overload and improve mobile readability in the Sprint 14 Guided View while preserving the new layout and all core calculations. 
- Make the onboarding and Portfolio area feel lighter and more action-oriented without changing ranking, allocation, execution, or signal logic.

### Description
- Shortened the always-visible top area by removing the long methodology copy and moved it into the collapsed `Learn how this works` expander under a new `Methodology` heading in `_render_onboarding` (`app.py`).
- Replaced the hard-coded data-period sentence with a dynamic dataset range produced by `_resolve_dataset_period_description`, returning ISO dates (`YYYY-MM-DD` to `YYYY-MM-DD`) when `date` values exist and keeping the existing fallback otherwise (`app.py`).
- Simplified the Portfolio Snapshot in `render_portfolio_plan` (`app/planner/portfolio_ui.py`) to show four metric cards (`Trades Found`, `Funded Trades`, `Allocated %`, `Cash Reserved %`) plus one short interpretation line, and moved detailed explanations into expanders (`How to read setup strength and confidence`, `Why cash is reserved`).
- Improved Guided View trade rendering to stacked per-trade cards (compact, mobile-friendly) that show the prioritized fields in order: `Ticker`, `Setup Strength`, `Confidence / Reliability`, `Holding Window`, `Why this trade`, and `Execution Summary`; Advanced mode still uses fuller tables (`app/planner/portfolio_ui.py`).
- Kept Portfolio Rules collapsed under the expander `Portfolio rules and funding approach` for Guided View while preserving full rules display in Analyst mode (`app/planner/portfolio_ui.py`).
- Added one-line purpose captions to the Advanced tabs (`Feature Insights`, `Performance Matrix`, `Exit Analysis`) to clarify intent (`app/insights/analyst.py`).
- Adjusted test expectations where wording/format changed to match the new copy/structure (`tests/*`).

### Testing
- Ran the full automated test suite with `pytest -q`, which passed: `216 passed`.
- Updated unit test expectations that depended on the previous top-copy, date-format, and card formatting to reflect the new wording and card layout; all tests now pass.

No ranking, allocation, execution, or signal calculation logic was modified; this change is a UI/copy/layout polish only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df268a13d48322b7a3710f55013197)