### PR TITLE
Clarify Portfolio capital input and loaded-data plan copy (Sprint 14 closeout)

### DIFF
--- a/app.py
+++ b/app.py
@@ -427,7 +427,16 @@ def main() -> None:
         st.markdown("### Portfolio")
         _render_video_link(st, label="▶ Watch: Understanding the Portfolio", url=_HELP_VIDEO_URLS["portfolio"])
         _render_video_link(st, label="▶ Watch: How to Read a Trade", url=_HELP_VIDEO_URLS["read_trade"])
-        selected_capital = st.number_input("Total capital", min_value=0.0, value=selected_capital, step=5_000.0, key="total_capital")
+        st.info("Start here: enter your investment amount above to build your plan.")
+        selected_capital = st.number_input(
+            "Enter your investment amount (JMD)",
+            min_value=0.0,
+            value=selected_capital,
+            step=5_000.0,
+            key="total_capital",
+        )
+        st.caption("This is the amount you want to allocate across trades.")
+        st.caption("This plan is built from the market data currently loaded in the dashboard.")
         if ranked_df.empty:
             st.info("Portfolio Plan will appear after ranked outputs are generated for the current run.")
         else:

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -188,7 +188,13 @@ def test_sprint12_tab_layout_and_capital_location(monkeypatch):
     app_main.main()
 
     assert dummy_st.tabs_requested[0] == ["Portfolio", "Review", "Ticker Analysis", "Analyst Insights", "Data"]
-    assert dummy_st.number_inputs == [("Portfolio", "Total capital", "total_capital")]
+    assert dummy_st.number_inputs == [("Portfolio", "Enter your investment amount (JMD)", "total_capital")]
+    assert ("Portfolio", "Start here: enter your investment amount above to build your plan.") in dummy_st.info_messages
+    assert ("Portfolio", "This is the amount you want to allocate across trades.") in dummy_st.captions
+    assert (
+        "Portfolio",
+        "This plan is built from the market data currently loaded in the dashboard.",
+    ) in dummy_st.captions
 
 
 def test_guided_view_hides_analyst_insights_tab(monkeypatch):


### PR DESCRIPTION
### Motivation
- Make first-run UX clearer so users understand the portfolio uses their own capital and the plan reflects the data currently loaded in the dashboard.
- Keep changes presentation-only and avoid implying live updates, refresh controls, or any algorithmic/logic changes.

### Description
- Replace the Portfolio capital input label with `Enter your investment amount (JMD)` and add a visible directional cue `Start here: enter your investment amount above to build your plan.` above the input in `app.py`.
- Add helper caption `This is the amount you want to allocate across trades.` under the input and a system-state caption `This plan is built from the market data currently loaded in the dashboard.` to set expectations.
- Update `tests/test_app_information_architecture.py` assertions to match the new labels and copy.

### Testing
- Updated architecture test expectations in `tests/test_app_information_architecture.py` and ran `pytest -q tests/test_app_information_architecture.py` which returned 18 passed.
- Ran `pytest -q tests/test_portfolio_ui.py::test_render_portfolio_plan_uses_compact_cards_in_beginner_mode` which returned 1 passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e684b7a92883228b3c40fbd365bec5)