### PR TITLE
Add 'View analysis' action to portfolio plan and preload Ticker Analysis from portfolio context

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,10 @@ _HELP_VIDEO_URLS = {
     "review": "https://www.loom.com/share/6e2058d50c5d447b98d9031b4e1050cf",
     "analyst_mode": "https://www.loom.com/share/399c4760e90744c49fd4aadcf172f4a3",
 }
+_STATE_SELECTED_TICKER = "selected_ticker"
+_STATE_ACTIVE_TAB = "active_tab_name"
+_STATE_TICKER_SOURCE = "ticker_analysis_source"
+_STATE_TICKER_SOURCE_TICKER = "ticker_analysis_source_ticker"
 
 
 def _has_analyst_insight_content(trades_df: pd.DataFrame, *, analyst_mode: bool) -> bool:
@@ -360,6 +364,16 @@ def main() -> None:
     st.caption("Guided View: simpler explanations and lighter detail")
     st.caption("Advanced View: deeper breakdowns and fuller analysis")
 
+    def _open_ticker_analysis_from_portfolio(ticker: str) -> None:
+        normalized_ticker = canonicalize_symbol(str(ticker or "").strip())
+        if not normalized_ticker:
+            return
+        st.session_state[_STATE_SELECTED_TICKER] = normalized_ticker
+        st.session_state[_STATE_TICKER_SOURCE] = "portfolio"
+        st.session_state[_STATE_TICKER_SOURCE_TICKER] = normalized_ticker
+        st.session_state[_STATE_ACTIVE_TAB] = "Ticker Analysis"
+        st.rerun()
+
     @st.cache_data(show_spinner=False)
     def _cached_ingest_dataset() -> tuple[pd.DataFrame, dict, tuple[tuple[str, tuple[str, ...]], ...]]:
         canonical_df_value, meta_value, issues_value = ingest_dataset("demo")
@@ -420,8 +434,13 @@ def main() -> None:
     dataset_period_description = _resolve_dataset_period_description(canonical_df)
     _render_onboarding(st, dataset_period_description=dataset_period_description)
 
-    tabs = st.tabs(_resolve_tabs_for_mode(mode_token))
-    tab_map = {name: tab for name, tab in zip(_resolve_tabs_for_mode(mode_token), tabs)}
+    available_tabs = _resolve_tabs_for_mode(mode_token)
+    active_tab_name = st.session_state.get(_STATE_ACTIVE_TAB)
+    resolved_default_tab = active_tab_name if active_tab_name in available_tabs else None
+    tabs = st.tabs(available_tabs, default=resolved_default_tab)
+    if resolved_default_tab is not None:
+        st.session_state[_STATE_ACTIVE_TAB] = None
+    tab_map = {name: tab for name, tab in zip(available_tabs, tabs)}
 
     with tab_map["Portfolio"]:
         st.markdown("### Portfolio")
@@ -437,6 +456,7 @@ def main() -> None:
         )
         st.caption("This is the amount you want to allocate across trades.")
         st.caption("This plan is built from the market data currently loaded in the dashboard.")
+        st.caption("Click a stock to review its behavior in Ticker Analysis.")
         if ranked_df.empty:
             st.info("Portfolio Plan will appear after ranked outputs are generated for the current run.")
         else:
@@ -448,6 +468,7 @@ def main() -> None:
                 mode=mode_token,
                 section="plan",
                 show_header=False,
+                on_view_analysis=_open_ticker_analysis_from_portfolio,
             )
 
     with tab_map["Review"]:
@@ -473,7 +494,20 @@ def main() -> None:
         if not ticker_options:
             st.info("Ticker Analysis will populate once ticker rows are loaded into the dataset.")
         else:
-            selected_ticker = st.selectbox("Select ticker", ticker_options)
+            stored_selected_ticker = canonicalize_symbol(str(st.session_state.get(_STATE_SELECTED_TICKER) or "").strip())
+            default_ticker_index = 0
+            if stored_selected_ticker and stored_selected_ticker in ticker_options:
+                default_ticker_index = ticker_options.index(stored_selected_ticker)
+            selected_ticker = st.selectbox("Select ticker", ticker_options, index=default_ticker_index)
+            st.session_state[_STATE_SELECTED_TICKER] = selected_ticker
+
+            source = str(st.session_state.get(_STATE_TICKER_SOURCE) or "").strip().lower()
+            source_ticker = canonicalize_symbol(str(st.session_state.get(_STATE_TICKER_SOURCE_TICKER) or "").strip())
+            if source == "portfolio" and source_ticker and selected_ticker == source_ticker:
+                st.caption(f"Viewing analysis for {selected_ticker} from your portfolio plan.")
+            elif source == "portfolio" and selected_ticker != source_ticker:
+                st.session_state[_STATE_TICKER_SOURCE] = None
+                st.session_state[_STATE_TICKER_SOURCE_TICKER] = None
             ticker_payload, ticker_metrics = _cached_ticker_payloads(analyst_df, selected_ticker, mode_token)
             analyst_mode = mode_token == "analyst"
             metrics_stats = ticker_metrics.get("stats", {})

--- a/app/planner/portfolio_ui.py
+++ b/app/planner/portfolio_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 import pandas as pd
 
@@ -115,6 +115,7 @@ def render_portfolio_plan(
     section: str = "both",
     show_header: bool = True,
     analyst_max_funded_trades_override: int | None = None,
+    on_view_analysis: Callable[[str], None] | None = None,
 ) -> None:
     """Render portfolio summary/review details in one section or both."""
     if st_module is None:
@@ -208,6 +209,14 @@ def render_portfolio_plan(
                 )
                 st_module.markdown(f"**Rule Note:** {plan_row['Rule Note']}")
                 st_module.markdown(f"**Decision Status:** {plan_row['Decision Status']}")
+            if on_view_analysis is not None:
+                ticker = str(plan_row["Ticker"]).strip()
+                if ticker:
+                    if st_module.button(
+                        f"View analysis · {ticker}",
+                        key=f"view-analysis-card-{funded}-{ticker}-{plan_row['Selection Rank']}",
+                    ):
+                        on_view_analysis(ticker)
             st_module.markdown("---")
 
     def _render_advanced_decision_table(rows: Sequence[Mapping[str, Any]]) -> None:
@@ -242,6 +251,13 @@ def render_portfolio_plan(
                 st_module.markdown(f"**Allocation %:** {plan_row['Allocation %']:.0%}")
                 st_module.markdown(f"**Selection Rank:** #{plan_row['Selection Rank']}")
                 st_module.markdown(f"**Decision Status:** {plan_row['Decision Status']}")
+                if on_view_analysis is not None:
+                    ticker = str(plan_row["Ticker"]).strip()
+                    if ticker and st_module.button(
+                        f"View analysis · {ticker}",
+                        key=f"view-analysis-advanced-{funded}-{ticker}-{plan_row['Selection Rank']}",
+                    ):
+                        on_view_analysis(ticker)
 
     def _render_full_analyst_table(rows: Sequence[Mapping[str, Any]], *, funded: bool) -> None:
         with st_module.expander("Show full analyst table", expanded=False):

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -84,6 +84,8 @@ class DummyStreamlit:
         self.components = DummyComponents(self)
         self.metrics = []
         self.expanders = []
+        self.rerun_called = False
+        self.selectbox_choice = None
 
     def set_page_config(self, **_kwargs):
         return None
@@ -126,16 +128,18 @@ class DummyStreamlit:
             self.session_state[key] = value
         return value
 
-    def tabs(self, names):
+    def tabs(self, names, **_kwargs):
         self.tabs_requested.append(list(names))
         return [DummyTab(self, name) for name in names]
 
     def dataframe(self, df, **_kwargs):
         self.dataframes.append((self.current_tab, df.copy()))
 
-    def selectbox(self, _label, options):
+    def selectbox(self, _label, options, index=0):
         self.selectbox_calls.append(list(options))
-        return options[0]
+        if self.selectbox_choice in options:
+            return self.selectbox_choice
+        return options[index]
 
     def columns(self, count):
         return [DummyColumn(self) for _ in range(count)]
@@ -149,6 +153,12 @@ class DummyStreamlit:
     def expander(self, _label, **_kwargs):
         self.expanders.append((self.current_tab, _label))
         return DummyExpander(self)
+
+    def button(self, *_args, **_kwargs):
+        return False
+
+    def rerun(self):
+        self.rerun_called = True
 
 
 def _load_app_module():
@@ -238,6 +248,131 @@ def test_analyst_mode_keeps_all_tabs_visible(monkeypatch):
     app_main.main()
 
     assert dummy_st.tabs_requested[0] == ["Portfolio", "Review", "Ticker Analysis", "Analyst Insights", "Data"]
+
+
+def test_ticker_analysis_preloads_selected_ticker_from_portfolio_context(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit(mode_choice="Guided View")
+    dummy_st.session_state["selected_ticker"] = "BBB"
+    dummy_st.session_state["ticker_analysis_source"] = "portfolio"
+    dummy_st.session_state["ticker_analysis_source_ticker"] = "BBB"
+    dummy_st.session_state["active_tab_name"] = "Ticker Analysis"
+
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["AAA", "BBB"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "close": [10.0, 12.0],
+        }
+    )
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo-v1"}, {"errors": [], "warnings": []}),
+    )
+    monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: canonical_df)
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(
+        app_main,
+        "build_ticker_drilldown",
+        lambda _analyst_df, _ticker: {
+            "holding_window_stats": {"10D": {"win_rate": 0.6, "median_return": 0.03, "avg_return": 0.02, "count": 5}},
+            "pattern_summary": "Pattern summary",
+            "tier_performance": {},
+            "volatility_performance": {},
+            "return_distribution": {},
+            "signals": [],
+        },
+    )
+    monkeypatch.setattr(
+        app_main,
+        "compute_ticker_metrics",
+        lambda _analyst_df, _ticker, mode="beginner": {
+            "stats": {"win_rate": 0.6, "avg_return": 0.02, "median_return": 0.03, "best_window": "10D"},
+            "behavior": {
+                "holding_window": "Holding window context",
+                "reliability": "Reliability",
+                "consistency": "Consistency",
+                "tier_profile": "Tier profile",
+            },
+            "execution": {
+                "entry_reference": "Entry reference",
+                "planned_exit": "Planned exit",
+                "typical_outcome": "Typical outcome",
+                "execution_risk": "Execution risk",
+            },
+        },
+    )
+
+    app_main.main()
+
+    assert ("Ticker Analysis", "Viewing analysis for BBB from your portfolio plan.") in dummy_st.captions
+
+
+def test_ticker_analysis_clears_portfolio_context_after_manual_ticker_change(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit(mode_choice="Guided View")
+    dummy_st.session_state["selected_ticker"] = "BBB"
+    dummy_st.session_state["ticker_analysis_source"] = "portfolio"
+    dummy_st.session_state["ticker_analysis_source_ticker"] = "BBB"
+    dummy_st.selectbox_choice = "AAA"
+
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["AAA", "BBB"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "close": [10.0, 12.0],
+        }
+    )
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo-v1"}, {"errors": [], "warnings": []}),
+    )
+    monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: canonical_df)
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+    monkeypatch.setattr(
+        app_main,
+        "build_ticker_drilldown",
+        lambda _analyst_df, _ticker: {
+            "holding_window_stats": {"10D": {"win_rate": 0.6, "median_return": 0.03, "avg_return": 0.02, "count": 5}},
+            "pattern_summary": "Pattern summary",
+            "tier_performance": {},
+            "volatility_performance": {},
+            "return_distribution": {},
+            "signals": [],
+        },
+    )
+    monkeypatch.setattr(
+        app_main,
+        "compute_ticker_metrics",
+        lambda _analyst_df, _ticker, mode="beginner": {
+            "stats": {"win_rate": 0.6, "avg_return": 0.02, "median_return": 0.03, "best_window": "10D"},
+            "behavior": {
+                "holding_window": "Holding window context",
+                "reliability": "Reliability",
+                "consistency": "Consistency",
+                "tier_profile": "Tier profile",
+            },
+            "execution": {
+                "entry_reference": "Entry reference",
+                "planned_exit": "Planned exit",
+                "typical_outcome": "Typical outcome",
+                "execution_risk": "Execution risk",
+            },
+        },
+    )
+
+    app_main.main()
+
+    assert ("Ticker Analysis", "Viewing analysis for AAA from your portfolio plan.") not in dummy_st.captions
+    assert dummy_st.session_state.get("ticker_analysis_source") is None
 
 
 

--- a/tests/test_portfolio_ui.py
+++ b/tests/test_portfolio_ui.py
@@ -24,6 +24,8 @@ class DummyStreamlit:
         self.markdowns = []
         self.tabs_requested = []
         self.expanders = []
+        self.buttons = []
+        self.button_presses = set()
 
     class _DummyTab:
         def __enter__(self):
@@ -78,6 +80,10 @@ class DummyStreamlit:
     def tabs(self, names):
         self.tabs_requested.append(list(names))
         return [self._DummyTab(), self._DummyTab()]
+
+    def button(self, label, **_kwargs):
+        self.buttons.append(label)
+        return label in self.button_presses
 
 
 def test_render_portfolio_plan_uses_compact_cards_in_beginner_mode():
@@ -184,6 +190,67 @@ def test_render_portfolio_plan_advanced_details_keep_explanations_in_expander():
     assert "**Execution Summary:**" in combined_markdown
     assert "**Allocation %:**" in combined_markdown
     assert "**Selection Rank:**" in combined_markdown
+
+
+def test_render_portfolio_plan_shows_view_analysis_actions_in_both_modes():
+    beginner_st = DummyStreamlit()
+    analyst_st = DummyStreamlit()
+    allocations = [
+        {
+            "instrument": "AAA",
+            "allocation_amount": 1000,
+            "allocation_pct": 0.1,
+            "quality_tier": "A",
+            "confidence_label": "strong",
+            "selection_rank": 1,
+        }
+    ]
+
+    render_portfolio_plan(
+        allocations=allocations,
+        total_capital=10_000,
+        st_module=beginner_st,
+        section="plan",
+        mode="beginner",
+        on_view_analysis=lambda _ticker: None,
+    )
+    render_portfolio_plan(
+        allocations=allocations,
+        total_capital=10_000,
+        st_module=analyst_st,
+        section="plan",
+        mode="analyst",
+        on_view_analysis=lambda _ticker: None,
+    )
+
+    assert any("View analysis · AAA" in label for label in beginner_st.buttons)
+    assert any("View analysis · AAA" in label for label in analyst_st.buttons)
+
+
+def test_render_portfolio_plan_triggers_view_analysis_callback_when_clicked():
+    st = DummyStreamlit()
+    st.button_presses.add("View analysis · AAA")
+    selected = []
+
+    render_portfolio_plan(
+        allocations=[
+            {
+                "instrument": "AAA",
+                "allocation_amount": 1000,
+                "allocation_pct": 0.1,
+                "quality_tier": "A",
+                "confidence_label": "strong",
+                "selection_rank": 1,
+            }
+        ],
+        total_capital=10_000,
+        st_module=st,
+        section="plan",
+        mode="beginner",
+        on_view_analysis=lambda ticker: selected.append(ticker),
+    )
+
+    assert selected == ["AAA"]
 
 
 def test_group_mistakes_for_display_combines_repeated_types():


### PR DESCRIPTION
### Motivation
- Enable users to jump from a portfolio trade card or advanced row into the Ticker Analysis tab and see the selected ticker preloaded. 
- Preserve UX context across reruns by storing the selected ticker and source in `st.session_state` so the Ticker Analysis tab can reflect navigation originating from the portfolio. 
- Support testing and headless flows by making the portfolio UI callback-invokable and ensuring the tabs can open with a default active tab from state.

### Description
- Added session state keys `selected_ticker`, `active_tab_name`, `ticker_analysis_source`, and `ticker_analysis_source_ticker` and logic to preload the Ticker Analysis selectbox from these keys. 
- Implemented `_open_ticker_analysis_from_portfolio` in `app.py` to normalize a ticker, set session state values and call `st.rerun()` to navigate to the `Ticker Analysis` tab. 
- Updated tab rendering to support a `default` tab via `st.tabs(..., default=...)` and to clear the `active_tab_name` after use. 
- Extended `render_portfolio_plan` in `app/planner/portfolio_ui.py` with an optional `on_view_analysis: Callable[[str], None] | None` parameter and added `View analysis · {ticker}` buttons in both compact cards and advanced views that invoke the callback when clicked. 
- Updated test doubles and unit tests to exercise the new interactions, including preloading behavior, clearing portfolio context after manual change, button rendering in both modes, and callback invocation when a button is pressed.

### Testing
- Ran the test suite with the modified tests in `tests/test_app_information_architecture.py` and `tests/test_portfolio_ui.py`, including `test_ticker_analysis_preloads_selected_ticker_from_portfolio_context`, `test_ticker_analysis_clears_portfolio_context_after_manual_ticker_change`, `test_render_portfolio_plan_shows_view_analysis_actions_in_both_modes`, and `test_render_portfolio_plan_triggers_view_analysis_callback_when_clicked`, and all tests passed. 
- Existing tab/layout and help-video related tests were also executed and continued to pass. 
- No new failing automated tests were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6f9f55ccc83228c0366a07b02ce04)