### PR TITLE
Fix issue #115: reliably switch to Ticker Analysis on View analysis

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 
 import pandas as pd
 
@@ -217,6 +218,31 @@ def _render_visual_polish(st_module) -> None:
 
 def _render_video_link(st_module, *, label: str, url: str) -> None:
     st_module.markdown(f'<a href="{url}" target="_blank" rel="noopener noreferrer">{label}</a>', unsafe_allow_html=True)
+
+
+def _render_tab_focus_script(st_module, *, tab_name: str) -> None:
+    safe_tab_name = json.dumps(str(tab_name))
+    st_module.components.v1.html(
+        f"""
+        <script>
+        (() => {{
+            const targetLabel = {safe_tab_name};
+            const tryFocus = () => {{
+                const tabButtons = window.parent.document.querySelectorAll('.stTabs [data-baseweb="tab"]');
+                tabButtons.forEach((button) => {{
+                    const label = (button.textContent || '').trim();
+                    if (label === targetLabel) {{
+                        button.click();
+                    }}
+                }});
+            }};
+            requestAnimationFrame(tryFocus);
+            setTimeout(tryFocus, 120);
+        }})();
+        </script>
+        """,
+        height=0,
+    )
 
 
 def _resolve_dataset_period_description(df: pd.DataFrame) -> str:
@@ -439,6 +465,7 @@ def main() -> None:
     resolved_default_tab = active_tab_name if active_tab_name in available_tabs else None
     tabs = st.tabs(available_tabs, default=resolved_default_tab)
     if resolved_default_tab is not None:
+        _render_tab_focus_script(st, tab_name=resolved_default_tab)
         st.session_state[_STATE_ACTIVE_TAB] = None
     tab_map = {name: tab for name, tab in zip(available_tabs, tabs)}
 

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -375,6 +375,28 @@ def test_ticker_analysis_clears_portfolio_context_after_manual_ticker_change(mon
     assert dummy_st.session_state.get("ticker_analysis_source") is None
 
 
+def test_ticker_analysis_navigation_injects_tab_focus_script_when_tab_preselected(monkeypatch):
+    app_main = _load_app_module()
+    dummy_st = DummyStreamlit(mode_choice="Guided View")
+    dummy_st.session_state["active_tab_name"] = "Ticker Analysis"
+
+    canonical_df = pd.DataFrame({"instrument": ["AAA"], "date": pd.to_datetime(["2024-01-01"]), "close": [10.0]})
+
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setattr(
+        app_main,
+        "ingest_dataset",
+        lambda _dataset: (canonical_df, {"source": "demo", "dataset_id": "demo-v1"}, {"errors": [], "warnings": []}),
+    )
+    monkeypatch.setattr(app_main, "run_demo", lambda: {"ranked": pd.DataFrame()})
+    monkeypatch.setattr(app_main, "build_analyst_dataset", lambda _canonical, _ranked: pd.DataFrame())
+    monkeypatch.setattr(app_main, "coerce_trade_rows_from_ranked", lambda _ranked: [])
+
+    app_main.main()
+
+    focus_scripts = [html for _, html, _ in dummy_st.html_blocks if 'targetLabel = "Ticker Analysis"' in html]
+    assert len(focus_scripts) == 1
+    assert dummy_st.session_state.get("active_tab_name") is None
 
 
 def test_help_video_labels_and_links_render_in_expected_sections(monkeypatch):


### PR DESCRIPTION
### Motivation
- Users who click “View analysis” saw the ticker preloaded but the UI did not always visibly switch to the `Ticker Analysis` tab in some deployed Streamlit environments. 
- The goal is to ensure navigation reliably lands the user on the `Ticker Analysis` tab while preserving existing preload/session behavior and not touching business logic.

### Description
- Added a small client-side fallback function ` _render_tab_focus_script` in `app.py` that injects a zero-height HTML/JS snippet to programmatically click the requested tab label when a one-time `active_tab_name` is set. 
- Integrated the fallback immediately after the existing `st.tabs(..., default=...)` call so the script runs when `resolved_default_tab` is present (no change to tab set logic for Guided/Advanced modes). 
- Preserved the existing session-state keys and ticker preload flow (`selected_ticker`, `ticker_analysis_source`, `ticker_analysis_source_ticker`) without changing business rules. 
- Added a regression test in `tests/test_app_information_architecture.py` verifying that the focus script is emitted when `active_tab_name` is preselected and that the `active_tab_name` key is cleared afterward.

### Testing
- Ran `pytest -q tests/test_app_information_architecture.py tests/test_app_shell.py` and the targeted tests passed: `31 passed`.
- Existing ticker preload behavior and tab-set logic were validated by the regression tests included in the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a0a1a20483229d016d71bcf789f8)