### PR TITLE
Surface dashboard view timestamp and latest market data label; add holding-window note and update tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import inspect
 import json
 
@@ -459,6 +460,14 @@ def main() -> None:
 
     dataset_period_description = _resolve_dataset_period_description(canonical_df)
     _render_onboarding(st, dataset_period_description=dataset_period_description)
+    viewed_ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+    latest_date = canonical_df["date"].max() if "date" in canonical_df.columns else pd.NaT
+    if pd.isna(latest_date):
+        latest_market_data_label = "Unavailable"
+    elif hasattr(latest_date, "strftime"):
+        latest_market_data_label = latest_date.strftime("%Y-%m-%d")
+    else:
+        latest_market_data_label = str(latest_date)
 
     available_tabs = _resolve_tabs_for_mode(mode_token)
     active_tab_name = st.session_state.get(_STATE_ACTIVE_TAB)
@@ -483,6 +492,11 @@ def main() -> None:
         )
         st.caption("This is the amount you want to allocate across trades.")
         st.caption("This plan is built from the market data currently loaded in the dashboard.")
+        st.caption(f"Viewed as at: {viewed_ts}")
+        st.caption(f"Latest market data in dashboard: {latest_market_data_label}")
+        st.info(
+            "Holding windows are measured in trading days from the signal or entry reference, not from the calendar month."
+        )
         st.caption("Click a stock to review its behavior in Ticker Analysis.")
         if ranked_df.empty:
             st.info("Portfolio Plan will appear after ranked outputs are generated for the current run.")
@@ -540,6 +554,11 @@ def main() -> None:
             metrics_stats = ticker_metrics.get("stats", {})
             metrics_behavior = ticker_metrics.get("behavior", {})
 
+            st.caption(f"Viewed as at: {viewed_ts}")
+            st.caption(f"Latest market data in dashboard: {latest_market_data_label}")
+            st.info(
+                "Holding windows are measured in trading days from the signal or entry reference, not from the calendar month."
+            )
             st.markdown("#### Quick Take")
             for line in _build_quick_take(stats=metrics_stats, holding_window_stats=ticker_payload["holding_window_stats"]):
                 st.markdown(f"- {line}")

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -205,6 +205,9 @@ def test_sprint12_tab_layout_and_capital_location(monkeypatch):
         "Portfolio",
         "This plan is built from the market data currently loaded in the dashboard.",
     ) in dummy_st.captions
+    assert any(tab == "Portfolio" and "Viewed as at" in text for tab, text in dummy_st.captions)
+    assert any(tab == "Portfolio" and "Latest market data in dashboard" in text for tab, text in dummy_st.captions)
+    assert any(tab == "Portfolio" and "trading days" in text for tab, text in dummy_st.info_messages)
 
 
 def test_guided_view_hides_analyst_insights_tab(monkeypatch):
@@ -823,6 +826,9 @@ def test_ticker_analysis_beginner_mode_hides_raw_deep_dive_tables(monkeypatch):
     ticker_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Ticker Analysis"]
     assert "#### Execution Behavior" in ticker_markdowns
     assert "#### G) Analyst Deep Dive" not in ticker_markdowns
+    assert any(tab == "Ticker Analysis" and "Viewed as at" in text for tab, text in dummy_st.captions)
+    assert any(tab == "Ticker Analysis" and "Latest market data in dashboard" in text for tab, text in dummy_st.captions)
+    assert any(tab == "Ticker Analysis" and "trading days" in text for tab, text in dummy_st.info_messages)
     assert any("Switch to Advanced View to open the full table breakdown." in text for _, text in dummy_st.captions)
     assert not any("Outcome context:" in text for text in ticker_markdowns)
 


### PR DESCRIPTION
### Motivation

- Provide users context about when the dashboard was viewed and what the latest market data date in the loaded dataset is.  
- Reinforce that holding windows are measured in trading days to reduce user confusion about time framing.  

### Description

- Added `datetime` import and compute a `viewed_ts` timestamp and `latest_market_data_label` derived from the dataset in `app.py`.  
- Display the viewed timestamp and latest market data label as captions in the `Portfolio` and `Ticker Analysis` tabs.  
- Added an informational caption noting that holding windows are measured in trading days in both `Portfolio` and `Ticker Analysis`.  
- Updated `tests/test_app_information_architecture.py` to assert the new captions and info message presence.  

### Testing

- Ran the modified unit tests in `tests/test_app_information_architecture.py`, including `test_sprint12_tab_layout_and_capital_location`, `test_ticker_analysis_beginner_mode_hides_raw_deep_dive_tables`, and `test_ticker_analysis_analyst_mode_shows_deep_dive_tables`, using `pytest`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee96d44bf483229f9e84cdeacc220d)