### PR TITLE
Show viewed timestamp and latest market data; add review-window guidance in UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import inspect
 import json
 
@@ -459,6 +460,14 @@ def main() -> None:
 
     dataset_period_description = _resolve_dataset_period_description(canonical_df)
     _render_onboarding(st, dataset_period_description=dataset_period_description)
+    viewed_ts = datetime.now().strftime("%Y-%m-%d %I:%M %p")
+    latest_date = canonical_df["date"].max() if "date" in canonical_df.columns else pd.NaT
+    if pd.isna(latest_date):
+        latest_market_data_label = "Unavailable"
+    elif hasattr(latest_date, "strftime"):
+        latest_market_data_label = latest_date.strftime("%Y-%m-%d")
+    else:
+        latest_market_data_label = str(latest_date)
 
     available_tabs = _resolve_tabs_for_mode(mode_token)
     active_tab_name = st.session_state.get(_STATE_ACTIVE_TAB)
@@ -483,7 +492,13 @@ def main() -> None:
         )
         st.caption("This is the amount you want to allocate across trades.")
         st.caption("This plan is built from the market data currently loaded in the dashboard.")
-        st.caption("Click a stock to review its behavior in Ticker Analysis.")
+        st.caption(f"Viewed as at: {viewed_ts}")
+        st.caption(f"Latest market data in dashboard: {latest_market_data_label}")
+        st.info(
+            "5D, 10D, 20D, and 30D are review windows.\n"
+            "Check the trade around that time — not a fixed hold until month-end."
+        )
+        st.caption("Click a stock to see how it typically behaves and when it’s usually reviewed.")
         if ranked_df.empty:
             st.info("Portfolio Plan will appear after ranked outputs are generated for the current run.")
         else:
@@ -540,6 +555,12 @@ def main() -> None:
             metrics_stats = ticker_metrics.get("stats", {})
             metrics_behavior = ticker_metrics.get("behavior", {})
 
+            st.caption(f"Viewed as at: {viewed_ts}")
+            st.caption(f"Latest market data in dashboard: {latest_market_data_label}")
+            st.info(
+                "5D, 10D, 20D, and 30D are review windows.\n"
+                "Check the trade around that time — not a fixed hold until month-end."
+            )
             st.markdown("#### Quick Take")
             for line in _build_quick_take(stats=metrics_stats, holding_window_stats=ticker_payload["holding_window_stats"]):
                 st.markdown(f"- {line}")

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -205,6 +205,20 @@ def test_sprint12_tab_layout_and_capital_location(monkeypatch):
         "Portfolio",
         "This plan is built from the market data currently loaded in the dashboard.",
     ) in dummy_st.captions
+    assert (
+        "Portfolio",
+        "Click a stock to see how it typically behaves and when it’s usually reviewed.",
+    ) in dummy_st.captions
+    assert any(tab == "Portfolio" and "Viewed as at" in text for tab, text in dummy_st.captions)
+    assert any(tab == "Portfolio" and "Latest market data in dashboard" in text for tab, text in dummy_st.captions)
+    assert any(
+        tab == "Portfolio" and "5D, 10D, 20D, and 30D are review windows." in text
+        for tab, text in dummy_st.info_messages
+    )
+    assert any(
+        tab == "Portfolio" and "not a fixed hold until month-end." in text
+        for tab, text in dummy_st.info_messages
+    )
 
 
 def test_guided_view_hides_analyst_insights_tab(monkeypatch):
@@ -823,6 +837,16 @@ def test_ticker_analysis_beginner_mode_hides_raw_deep_dive_tables(monkeypatch):
     ticker_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Ticker Analysis"]
     assert "#### Execution Behavior" in ticker_markdowns
     assert "#### G) Analyst Deep Dive" not in ticker_markdowns
+    assert any(tab == "Ticker Analysis" and "Viewed as at" in text for tab, text in dummy_st.captions)
+    assert any(tab == "Ticker Analysis" and "Latest market data in dashboard" in text for tab, text in dummy_st.captions)
+    assert any(
+        tab == "Ticker Analysis" and "5D, 10D, 20D, and 30D are review windows." in text
+        for tab, text in dummy_st.info_messages
+    )
+    assert any(
+        tab == "Ticker Analysis" and "not a fixed hold until month-end." in text
+        for tab, text in dummy_st.info_messages
+    )
     assert any("Switch to Advanced View to open the full table breakdown." in text for _, text in dummy_st.captions)
     assert not any("Outcome context:" in text for text in ticker_markdowns)
 


### PR DESCRIPTION
### Motivation
- Improve user awareness of when the dashboard view was generated and which market date is loaded, and provide clearer guidance on review/holding windows.

### Description
- Import `datetime` and compute `viewed_ts` and `latest_market_data_label` from `canonical_df` for display in the UI.
- Surface the viewed timestamp and latest market data label as captions in the `Portfolio` and `Ticker Analysis` tabs.
- Add an informational note explaining that `5D, 10D, 20D, and 30D` are review windows and update caption text to clarify how to inspect ticker behavior.
- Update unit tests in `tests/test_app_information_architecture.py` to assert the presence of the new captions and info messages.

### Testing
- Ran `pytest tests/test_app_information_architecture.py::test_sprint12_tab_layout_and_capital_location` and it passed.
- Ran `pytest tests/test_app_information_architecture.py::test_ticker_analysis_beginner_mode_hides_raw_deep_dive_tables` and it passed.
- Ran `pytest tests/test_app_information_architecture.py` to validate the file-level changes and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee96d44bf483229f9e84cdeacc220d)