### PR TITLE
Sprint 16 follow-up: clarify holding windows and timezone-label viewed timestamp

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 import inspect
 import json
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
@@ -259,6 +260,17 @@ def _resolve_dataset_period_description(df: pd.DataFrame) -> str:
     return f"Using historical JSE data from {min_date} to {max_date} in the current dataset."
 
 
+def _format_viewed_timestamp() -> str:
+    """Return a timezone-labeled 'Viewed as at' timestamp."""
+    try:
+        jamaica_now = datetime.now(ZoneInfo("America/Jamaica"))
+        hour = jamaica_now.strftime("%I").lstrip("0") or "0"
+        return f"{jamaica_now:%b} {jamaica_now.day}, {jamaica_now:%Y} {hour}:{jamaica_now:%M} {jamaica_now:%p} Jamaica time"
+    except Exception:
+        utc_now = datetime.utcnow()
+        return f"{utc_now:%Y-%m-%d %H:%M} UTC"
+
+
 def _render_start_here_video(st_module) -> None:
     st_module.markdown("### New here? Start with this video")
     st_module.components.v1.html(_START_HERE_EMBED_HTML, height=460)
@@ -460,7 +472,7 @@ def main() -> None:
 
     dataset_period_description = _resolve_dataset_period_description(canonical_df)
     _render_onboarding(st, dataset_period_description=dataset_period_description)
-    viewed_ts = datetime.now().strftime("%Y-%m-%d %I:%M %p")
+    viewed_ts = _format_viewed_timestamp()
     latest_date = canonical_df["date"].max() if "date" in canonical_df.columns else pd.NaT
     if pd.isna(latest_date):
         latest_market_data_label = "Unavailable"
@@ -495,8 +507,9 @@ def main() -> None:
         st.caption(f"Viewed as at: {viewed_ts}")
         st.caption(f"Latest market data in dashboard: {latest_market_data_label}")
         st.info(
-            "5D, 10D, 20D, and 30D are review windows.\n"
-            "Check the trade around that time — not a fixed hold until month-end."
+            "5D, 10D, 20D, and 30D are review windows. "
+            "If you enter today, start counting from your entry date and review after that many trading days. "
+            "These are not month-end hold rules."
         )
         st.caption("Click a stock to see how it typically behaves and when it’s usually reviewed.")
         if ranked_df.empty:
@@ -558,8 +571,9 @@ def main() -> None:
             st.caption(f"Viewed as at: {viewed_ts}")
             st.caption(f"Latest market data in dashboard: {latest_market_data_label}")
             st.info(
-                "5D, 10D, 20D, and 30D are review windows.\n"
-                "Check the trade around that time — not a fixed hold until month-end."
+                "5D, 10D, 20D, and 30D are review windows. "
+                "If you enter today, start counting from your entry date and review after that many trading days. "
+                "These are not month-end hold rules."
             )
             st.markdown("#### Quick Take")
             for line in _build_quick_take(stats=metrics_stats, holding_window_stats=ticker_payload["holding_window_stats"]):

--- a/tests/test_app_information_architecture.py
+++ b/tests/test_app_information_architecture.py
@@ -209,14 +209,29 @@ def test_sprint12_tab_layout_and_capital_location(monkeypatch):
         "Portfolio",
         "Click a stock to see how it typically behaves and when it’s usually reviewed.",
     ) in dummy_st.captions
-    assert any(tab == "Portfolio" and "Viewed as at" in text for tab, text in dummy_st.captions)
+    assert any(
+        tab == "Portfolio" and "Viewed as at" in text and ("Jamaica time" in text or "UTC" in text)
+        for tab, text in dummy_st.captions
+    )
     assert any(tab == "Portfolio" and "Latest market data in dashboard" in text for tab, text in dummy_st.captions)
     assert any(
         tab == "Portfolio" and "5D, 10D, 20D, and 30D are review windows." in text
         for tab, text in dummy_st.info_messages
     )
     assert any(
-        tab == "Portfolio" and "not a fixed hold until month-end." in text
+        tab == "Portfolio" and "If you enter today" in text
+        for tab, text in dummy_st.info_messages
+    )
+    assert any(
+        tab == "Portfolio" and "start counting from your entry date" in text
+        for tab, text in dummy_st.info_messages
+    )
+    assert any(
+        tab == "Portfolio" and "review after that many trading days" in text
+        for tab, text in dummy_st.info_messages
+    )
+    assert any(
+        tab == "Portfolio" and "not month-end hold rules" in text
         for tab, text in dummy_st.info_messages
     )
 
@@ -837,14 +852,29 @@ def test_ticker_analysis_beginner_mode_hides_raw_deep_dive_tables(monkeypatch):
     ticker_markdowns = [text for tab, text in dummy_st.markdowns if tab == "Ticker Analysis"]
     assert "#### Execution Behavior" in ticker_markdowns
     assert "#### G) Analyst Deep Dive" not in ticker_markdowns
-    assert any(tab == "Ticker Analysis" and "Viewed as at" in text for tab, text in dummy_st.captions)
+    assert any(
+        tab == "Ticker Analysis" and "Viewed as at" in text and ("Jamaica time" in text or "UTC" in text)
+        for tab, text in dummy_st.captions
+    )
     assert any(tab == "Ticker Analysis" and "Latest market data in dashboard" in text for tab, text in dummy_st.captions)
     assert any(
         tab == "Ticker Analysis" and "5D, 10D, 20D, and 30D are review windows." in text
         for tab, text in dummy_st.info_messages
     )
     assert any(
-        tab == "Ticker Analysis" and "not a fixed hold until month-end." in text
+        tab == "Ticker Analysis" and "If you enter today" in text
+        for tab, text in dummy_st.info_messages
+    )
+    assert any(
+        tab == "Ticker Analysis" and "start counting from your entry date" in text
+        for tab, text in dummy_st.info_messages
+    )
+    assert any(
+        tab == "Ticker Analysis" and "review after that many trading days" in text
+        for tab, text in dummy_st.info_messages
+    )
+    assert any(
+        tab == "Ticker Analysis" and "not month-end hold rules" in text
         for tab, text in dummy_st.info_messages
     )
     assert any("Switch to Advanced View to open the full table breakdown." in text for _, text in dummy_st.captions)


### PR DESCRIPTION
### Motivation
- Make holding-window guidance explicit about when counting starts so new users can act on review windows.
- Ensure the displayed "Viewed as at" timestamp is labeled with a timezone and reflects Jamaica local time when possible.
- Preserve the existing Portfolio instruction line about clicking a stock so discoverability is unchanged.

### Description
- Replaced the holding-window guidance in both Portfolio and Ticker Analysis with the exact required sentence: "5D, 10D, 20D, and 30D are review windows. If you enter today, start counting from your entry date and review after that many trading days. These are not month-end hold rules.".
- Added `_format_viewed_timestamp()` which attempts to render the timestamp in `America/Jamaica` and appends `Jamaica time`, and falls back to a clearly labeled `YYYY-MM-DD HH:MM UTC` string if timezone conversion fails.
- Hooked the formatted timestamp into both Portfolio and Ticker Analysis captions and left the Portfolio instruction line unchanged: “Click a stock to see how it typically behaves and when it’s usually reviewed.”
- Updated UI tests in `tests/test_app_information_architecture.py` to assert the new holding-window fragments and require the viewed caption to include either `Jamaica time` or `UTC` while removing assertions tied to the old wording.

### Testing
- Ran the targeted UI test file with `pytest -q tests/test_app_information_architecture.py` and all tests passed (`21 passed`).
- Updated unit assertions to check for presence of the new holding-window wording fragments and the timezone label, and those assertions succeeded under the test run.
- No other logic (ranking, allocation, signals, analysis, or backtesting) was changed and no tests for those areas were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed2173a7483228f65065179e5dc96)