### PR TITLE
Fix Sprint 17 signal timing readiness fallback to canonical market dates

### DIFF
--- a/app.py
+++ b/app.py
@@ -211,16 +211,18 @@ def _build_trade_readiness_lines(
     else:
         evidence_label = "Broader sample"
 
-    signal_date_candidates = ("signal_date", "entry_date", "date")
-    signal_date_field = next((field for field in signal_date_candidates if field in ticker_scope_analysis.columns), None)
-    if signal_date_field is None:
-        signal_timing_label = "Signal date unavailable"
-    else:
-        parsed_dates = pd.to_datetime(ticker_scope_analysis[signal_date_field], errors="coerce")
-        if parsed_dates.notna().any():
-            signal_timing_label = "Not yet assessed"
-        else:
-            signal_timing_label = "Signal date unavailable"
+    def _has_parseable_date(df: pd.DataFrame, candidates: tuple[str, ...]) -> bool:
+        for field in candidates:
+            if field not in df.columns:
+                continue
+            parsed_dates = pd.to_datetime(df[field], errors="coerce")
+            if parsed_dates.notna().any():
+                return True
+        return False
+
+    has_analysis_signal_date = _has_parseable_date(ticker_scope_analysis, ("signal_date", "entry_date", "date"))
+    has_market_date = _has_parseable_date(ticker_scope_market, ("date",))
+    signal_timing_label = "Not yet assessed" if (has_analysis_signal_date or has_market_date) else "Signal date unavailable"
 
     return [
         f"Liquidity data: {liquidity_label}",

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -212,3 +212,65 @@ def test_dataset_period_description_uses_date_range_when_available():
 def test_app_no_long_hard_coded_data_period_copy():
     source = (ROOT / "app.py").read_text()
     assert "since 2018 where available" not in source
+
+
+def test_trade_readiness_signal_timing_falls_back_to_canonical_market_date():
+    spec = importlib.util.spec_from_file_location("app_main", ROOT / "app.py")
+    app_main = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_main)
+
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["AAA", "AAA"],
+            "date": ["2024-01-10", "2024-01-11"],
+            "volume": [1000, 1200],
+        }
+    )
+    analyst_df = pd.DataFrame(
+        {
+            "instrument": ["AAA"],
+            "liquidity_pass": [True],
+        }
+    )
+
+    lines = app_main._build_trade_readiness_lines(
+        canonical_df=canonical_df,
+        analyst_df=analyst_df,
+        selected_ticker="AAA",
+        ticker_payload={},
+        metrics_stats={},
+    )
+
+    assert "Signal timing: Not yet assessed" in lines
+
+
+def test_trade_readiness_signal_timing_unavailable_when_no_parseable_dates():
+    spec = importlib.util.spec_from_file_location("app_main", ROOT / "app.py")
+    app_main = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_main)
+
+    canonical_df = pd.DataFrame(
+        {
+            "instrument": ["AAA"],
+            "date": ["not-a-date"],
+            "volume": [1000],
+        }
+    )
+    analyst_df = pd.DataFrame(
+        {
+            "instrument": ["AAA"],
+            "signal_date": ["still-not-a-date"],
+        }
+    )
+
+    lines = app_main._build_trade_readiness_lines(
+        canonical_df=canonical_df,
+        analyst_df=analyst_df,
+        selected_ticker="AAA",
+        ticker_payload={},
+        metrics_stats={},
+    )
+
+    assert "Signal timing: Signal date unavailable" in lines


### PR DESCRIPTION
### Motivation
- The readiness logic only checked for `signal_date`/`entry_date`/`date` in the analyst dataset, so when `analyst_df` lacked parseable dates but `canonical_df` had market dates the UI incorrectly showed "Signal date unavailable". 
- The intent is to fall back to canonical market `date` for presentation/readiness without implementing full freshness semantics yet. 

### Description
- Add a small helper `_has_parseable_date` in `app.py` to test candidate fields for parseable dates using `pd.to_datetime` and `errors='coerce'`. 
- Change `_build_trade_readiness_lines` to mark signal timing as `Not yet assessed` if any parseable date exists in either the analyst scope (`signal_date`, `entry_date`, `date`) or the canonical market scope (`date`); otherwise show `Signal date unavailable`. 
- Preserve the requested deferment of Fresh/Active/Late/Stale logic and make no other changes to ranking, allocation, signal generation, liquidity thresholds, or backtesting. 
- Add two regression tests in `tests/test_app_shell.py` that cover (a) analyst missing date but canonical has parseable `date` → `Not yet assessed`, and (b) neither dataset has parseable dates → `Signal date unavailable`.

### Testing
- Ran the targeted tests with `pytest -q tests/test_app_shell.py -k trade_readiness_signal_timing` and the two new signal-timing tests passed (`2 passed, 10 deselected`).
- Ran the full shell test module with `pytest -q tests/test_app_shell.py` and all tests in that file passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeedd1995c8322861c8ae3c8fc0454)