### PR TITLE
Add Sprint 18A readiness-gate research layer

### DIFF
--- a/app/analysis/readiness_gates.py
+++ b/app/analysis/readiness_gates.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class ReadinessThresholds:
+    min_positive_volume_ratio: float = 0.6
+    min_trading_days: int = 20
+    min_avg_volume_20d: float = 1.0
+    min_latest_volume_vs_avg20: float = 0.5
+    small_sample_days: int = 60
+
+
+def _first_existing(df: pd.DataFrame, candidates: list[str]) -> str | None:
+    for col in candidates:
+        if col in df.columns:
+            return col
+    return None
+
+
+def _to_datetime(df: pd.DataFrame, column: str = "date") -> pd.DataFrame:
+    out = df.copy()
+    if column in out.columns:
+        out[column] = pd.to_datetime(out[column], errors="coerce")
+    return out
+
+
+def compute_readiness_metrics(data: pd.DataFrame, thresholds: ReadinessThresholds | None = None) -> pd.DataFrame:
+    thresholds = thresholds or ReadinessThresholds()
+    df = _to_datetime(data)
+    ticker_col = _first_existing(df, ["ticker", "instrument", "symbol"])
+    if ticker_col is None or "date" not in df.columns:
+        raise ValueError("Input data must contain date and ticker/instrument/symbol fields.")
+
+    close_col = _first_existing(df, ["close", "close_price", "adjusted_close", "adj_close"])
+    high_col = _first_existing(df, ["high"])
+    low_col = _first_existing(df, ["low"])
+    volume_col = _first_existing(df, ["volume"])
+    traded_value_col = _first_existing(df, ["value_traded"])
+    trades_count_col = _first_existing(df, ["trades_count"])
+    signal_date_col = _first_existing(df, ["signal_date", "candidate_date", "entry_date"])
+
+    base_cols = [ticker_col, "date"] + [c for c in [close_col, high_col, low_col, volume_col, traded_value_col, trades_count_col, signal_date_col] if c]
+    work = df[base_cols].copy().sort_values([ticker_col, "date"])
+
+    rows: list[dict[str, Any]] = []
+    for ticker, grp in work.groupby(ticker_col):
+        grp = grp.dropna(subset=["date"]).sort_values("date")
+        trading_days_count = int(len(grp))
+        vol = grp[volume_col] if volume_col else pd.Series(dtype=float)
+        vol_num = pd.to_numeric(vol, errors="coerce") if volume_col else pd.Series([np.nan] * len(grp))
+        positive_volume_days = int((vol_num > 0).sum())
+        zero_volume_days = int((vol_num.fillna(0) <= 0).sum()) if len(grp) else 0
+        positive_volume_ratio = float(positive_volume_days / trading_days_count) if trading_days_count else np.nan
+
+        avg_volume_20d = float(vol_num.tail(20).mean()) if trading_days_count else np.nan
+        median_volume_20d = float(vol_num.tail(20).median()) if trading_days_count else np.nan
+        avg_volume_60d = float(vol_num.tail(60).mean()) if trading_days_count >= 60 else np.nan
+        median_volume_60d = float(vol_num.tail(60).median()) if trading_days_count >= 60 else np.nan
+
+        close = pd.to_numeric(grp[close_col], errors="coerce") if close_col else pd.Series([np.nan] * len(grp))
+        estimated_turnover = close * vol_num
+        turnover = pd.to_numeric(grp[traded_value_col], errors="coerce") if traded_value_col else estimated_turnover
+        turnover = turnover.fillna(estimated_turnover)
+
+        daily_return = close.pct_change()
+        vol20 = float(daily_return.tail(20).std()) if trading_days_count >= 2 else np.nan
+        vol60 = float(daily_return.tail(60).std()) if trading_days_count >= 60 else np.nan
+
+        rolling_peak = close.cummax()
+        drawdown = (close / rolling_peak) - 1.0
+        max_drawdown = float(drawdown.min()) if len(drawdown) else np.nan
+
+        if high_col and low_col:
+            high = pd.to_numeric(grp[high_col], errors="coerce")
+            low = pd.to_numeric(grp[low_col], errors="coerce")
+            daily_range_pct = (high - low) / close.replace(0, np.nan)
+            avg_range_pct_20d = float(daily_range_pct.tail(20).mean())
+            high_low_volatility = bool(avg_range_pct_20d > 0.05) if not np.isnan(avg_range_pct_20d) else False
+            volatility_context_available = True
+            spread_context_available = True
+        else:
+            avg_range_pct_20d = np.nan
+            high_low_volatility = False
+            volatility_context_available = False
+            spread_context_available = False
+
+        latest_volume = float(vol_num.iloc[-1]) if len(vol_num) else np.nan
+        volume_deterioration = bool(
+            not np.isnan(latest_volume)
+            and not np.isnan(avg_volume_20d)
+            and avg_volume_20d > 0
+            and latest_volume < (avg_volume_20d * thresholds.min_latest_volume_vs_avg20)
+        )
+
+        liquidity_data_available = bool(volume_col is not None and close_col is not None)
+        volume_support_present = bool(
+            trading_days_count >= thresholds.min_trading_days
+            and positive_volume_ratio >= thresholds.min_positive_volume_ratio
+            and (np.isnan(avg_volume_20d) or avg_volume_20d >= thresholds.min_avg_volume_20d)
+        )
+
+        timing_assessable = bool(signal_date_col is not None and grp[signal_date_col].notna().any())
+
+        rows.append(
+            {
+                "ticker": ticker,
+                "latest_market_date": grp["date"].max(),
+                "candidate_date_field": signal_date_col,
+                "trading_days_count": trading_days_count,
+                "positive_volume_days": positive_volume_days,
+                "zero_volume_days": zero_volume_days,
+                "positive_volume_ratio": positive_volume_ratio,
+                "avg_volume_20d": avg_volume_20d,
+                "median_volume_20d": median_volume_20d,
+                "avg_volume_60d": avg_volume_60d,
+                "median_volume_60d": median_volume_60d,
+                "avg_turnover_20d": float(turnover.tail(20).mean()) if trading_days_count else np.nan,
+                "median_turnover_20d": float(turnover.tail(20).median()) if trading_days_count else np.nan,
+                "volume_deterioration": volume_deterioration,
+                "avg_trades_count_20d": float(pd.to_numeric(grp[trades_count_col], errors="coerce").tail(20).mean()) if trades_count_col else np.nan,
+                "close_to_close_volatility_20d": vol20,
+                "close_to_close_volatility_60d": vol60,
+                "max_close_to_close_drawdown": max_drawdown,
+                "avg_range_pct_20d": avg_range_pct_20d,
+                "high_low_volatility": high_low_volatility,
+                "signal_date_available": timing_assessable,
+                "timing_assessable": timing_assessable,
+                "liquidity_data_available": liquidity_data_available,
+                "volume_support_present": volume_support_present,
+                "volatility_context_available": volatility_context_available,
+                "spread_context_available": spread_context_available,
+                "small_sample": trading_days_count < thresholds.small_sample_days,
+                "risk_hook_downside_threshold_candidate": np.nan,
+                "risk_hook_price_decline_from_entry": np.nan,
+                "risk_hook_volume_deterioration_after_entry": np.nan,
+                "risk_hook_signal_invalidation": np.nan,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def evaluate_models(metrics: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+    model_rows = []
+    ticker_rows = []
+    for _, row in metrics.iterrows():
+        base = {
+            "A_current": (True, "none"),
+            "B_minimum": (
+                bool(row["liquidity_data_available"] and row["volume_support_present"] and row["timing_assessable"]),
+                "failed_minimum_gate",
+            ),
+            "C_strict": (
+                bool(
+                    row["liquidity_data_available"]
+                    and row["volume_support_present"]
+                    and row["timing_assessable"]
+                    and row["volatility_context_available"]
+                    and row["spread_context_available"]
+                ),
+                "failed_strict_gate",
+            ),
+        }
+        for model, (funded, fail_reason) in base.items():
+            if funded:
+                label = "Watch" if row["small_sample"] else "Ready"
+                reason = "small_sample_watch" if row["small_sample"] else "pass"
+            else:
+                label = "Not fundable"
+                reason = fail_reason
+            if model == "C_strict" and not row["spread_context_available"]:
+                reason = "strict_spread_unavailable"
+                label = "Incomplete"
+
+            ticker_rows.append({"model": model, "ticker": row["ticker"], "funded": funded, "label": label, "reason": reason})
+
+    detail = pd.DataFrame(ticker_rows)
+    for model, grp in detail.groupby("model"):
+        model_rows.append(
+            {
+                "model": model,
+                "total_candidate_trades": int(len(grp)),
+                "funded_trades_under_model": int(grp["funded"].sum()),
+                "excluded_trades": int((~grp["funded"]).sum()),
+                "top_exclusion_reason": grp.loc[~grp["funded"], "reason"].mode().iloc[0] if (~grp["funded"]).any() else "none",
+                "return_impact_note": "Return/outcome fields unavailable in current readiness input.",
+            }
+        )
+    return pd.DataFrame(model_rows), detail
+
+
+def write_research_artifacts(metrics: pd.DataFrame, model_summary: pd.DataFrame, model_ticker: pd.DataFrame, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    metrics.to_csv(output_dir / "readiness_gate_by_ticker.csv", index=False)
+    model_ticker.to_csv(output_dir / "readiness_gate_by_model.csv", index=False)
+    model_summary.to_csv(output_dir / "readiness_gate_summary.csv", index=False)
+
+    report = [
+        "# Readiness Gate Research Report",
+        "",
+        "## Data support and limitations",
+        "- This research uses available close/volume fields and optional rich fields when present.",
+        "- If return/outcome columns are absent, return impact cannot be evaluated.",
+        "- Strict spread gating is marked incomplete when spread/high-low context is unavailable.",
+        "",
+        "## Model comparison",
+        model_summary.to_csv(index=False),
+    ]
+    (output_dir / "readiness_gate_report.md").write_text("\n".join(report), encoding="utf-8")

--- a/scripts/analyze_readiness_gates.py
+++ b/scripts/analyze_readiness_gates.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.analysis.readiness_gates import compute_readiness_metrics, evaluate_models, write_research_artifacts
+from app.data.loaders import load_internal_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze readiness-gate research models.")
+    parser.add_argument("--output-dir", default="artifacts/research", help="Output directory for research artifacts")
+    args = parser.parse_args()
+
+    data = load_internal_dataset()
+    metrics = compute_readiness_metrics(data)
+    model_summary, model_ticker = evaluate_models(metrics)
+    write_research_artifacts(metrics, model_summary, model_ticker, Path(args.output_dir))
+
+    print(f"Wrote readiness research artifacts to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_readiness_gates.py
+++ b/tests/test_readiness_gates.py
@@ -1,0 +1,90 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.analysis.readiness_gates import compute_readiness_metrics, evaluate_models, write_research_artifacts
+
+
+def test_basic_readiness_metric_calculation_from_close_volume_data():
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2025-01-01", periods=30),
+            "ticker": ["AAA"] * 30,
+            "close": [10 + i * 0.1 for i in range(30)],
+            "volume": [1000] * 28 + [700, 650],
+            "signal_date": ["2025-01-05"] * 30,
+        }
+    )
+    metrics = compute_readiness_metrics(df)
+    row = metrics.iloc[0]
+    assert row["trading_days_count"] == 30
+    assert row["positive_volume_days"] == 30
+    assert row["avg_volume_20d"] > 0
+    assert pd.notna(row["close_to_close_volatility_20d"])
+
+
+def test_missing_optional_rich_fields_do_not_crash():
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2025-01-01", periods=25),
+            "ticker": ["BBB"] * 25,
+            "close": [20.0] * 25,
+            "volume": [0, 100] * 12 + [100],
+            "signal_date": [None] * 25,
+        }
+    )
+    metrics = compute_readiness_metrics(df)
+    assert len(metrics) == 1
+    assert not bool(metrics.iloc[0]["volatility_context_available"])
+
+
+def test_model_b_classifies_trades_using_minimum_gate():
+    df = pd.DataFrame(
+        {
+            "ticker": ["OK", "BAD"],
+            "date": [pd.Timestamp("2025-02-01"), pd.Timestamp("2025-02-01")],
+            "close": [10, 10],
+            "volume": [1000, 0],
+            "signal_date": ["2025-01-01", None],
+        }
+    )
+    expanded = pd.concat([df[df["ticker"] == "OK"]] * 25 + [df[df["ticker"] == "BAD"]] * 25, ignore_index=True)
+    metrics = compute_readiness_metrics(expanded)
+    model_summary, detail = evaluate_models(metrics)
+    b = detail[detail["model"] == "B_minimum"]
+    assert b[b["ticker"] == "OK"]["funded"].iloc[0]
+    assert not b[b["ticker"] == "BAD"]["funded"].iloc[0]
+    assert "B_minimum" in set(model_summary["model"])
+
+
+def test_model_c_reports_spread_limitation_when_high_low_unavailable():
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2025-01-01", periods=30),
+            "ticker": ["AAA"] * 30,
+            "close": [10 + i * 0.1 for i in range(30)],
+            "volume": [1000] * 30,
+            "signal_date": ["2025-01-05"] * 30,
+        }
+    )
+    metrics = compute_readiness_metrics(df)
+    _summary, detail = evaluate_models(metrics)
+    strict_row = detail[detail["model"] == "C_strict"].iloc[0]
+    assert strict_row["reason"] == "strict_spread_unavailable"
+
+
+def test_output_files_created_in_expected_artifact_location(tmp_path):
+    metrics = pd.DataFrame([{"ticker": "AAA"}])
+    summary = pd.DataFrame([{"model": "A_current", "total_candidate_trades": 1}])
+    by_model = pd.DataFrame([{"model": "A_current", "ticker": "AAA", "funded": True, "label": "Ready", "reason": "pass"}])
+
+    write_research_artifacts(metrics, summary, by_model, tmp_path)
+
+    assert (tmp_path / "readiness_gate_summary.csv").exists()
+    assert (tmp_path / "readiness_gate_by_model.csv").exists()
+    assert (tmp_path / "readiness_gate_by_ticker.csv").exists()
+    assert (tmp_path / "readiness_gate_report.md").exists()


### PR DESCRIPTION
### Motivation
- Provide a standalone research layer to evaluate whether Trade Readiness should affect funding decisions without changing any production funding, allocation, signal, or exit behavior.
- Produce reproducible artifacts that compare current behavior (Model A) against configurable readiness gates (Model B minimum, Model C strict) and surface limitations where richer market fields are missing.

### Description
- Add `app/analysis/readiness_gates.py` implementing `compute_readiness_metrics`, `evaluate_models`, and `write_research_artifacts` to compute per-ticker liquidity, volatility, timing, and readiness labels and to emit research outputs.
- Implement three candidate models (A_current, B_minimum, C_strict) and conservative handling/reporting when optional fields like `high`/`low`/`value_traded` are absent (strict spread gating marked incomplete rather than faked).
- Add CLI script `scripts/analyze_readiness_gates.py` that loads the bundled dataset and writes CSV/MD artifacts to `artifacts/research` by default, with `sys.path` append to run from repo root.
- Add unit tests `tests/test_readiness_gates.py` using small synthetic DataFrames to validate metric calculations, resilience to missing optional fields, Model B/C behavior, and artifact output creation.

### Testing
- Ran unit tests with `pytest -q tests/test_readiness_gates.py` which passed (`5 passed`).
- Executed the research CLI with `python scripts/analyze_readiness_gates.py --output-dir artifacts/research` and confirmed artifacts were written (`readiness_gate_summary.csv`, `readiness_gate_by_model.csv`, `readiness_gate_by_ticker.csv`, `readiness_gate_report.md`).
- No production ranking/allocation/signal/exit code was modified during this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18590d5a48322b2a98d2ee78aaeca)