### PR TITLE
Follow-up: fix Sprint 18A readiness context/date accuracy gaps

### DIFF
--- a/app/analysis/readiness_gates.py
+++ b/app/analysis/readiness_gates.py
@@ -80,11 +80,21 @@ def compute_readiness_metrics(data: pd.DataFrame, thresholds: ReadinessThreshold
         if high_col and low_col:
             high = pd.to_numeric(grp[high_col], errors="coerce")
             low = pd.to_numeric(grp[low_col], errors="coerce")
+            high_low_usable = bool((high.notna() & low.notna()).any())
             daily_range_pct = (high - low) / close.replace(0, np.nan)
             avg_range_pct_20d = float(daily_range_pct.tail(20).mean())
             high_low_volatility = bool(avg_range_pct_20d > 0.05) if not np.isnan(avg_range_pct_20d) else False
-            volatility_context_available = True
-            spread_context_available = True
+            volatility_context_available = high_low_usable
+
+            spread_context_available = False
+            if traded_value_col:
+                traded_value_num = pd.to_numeric(grp[traded_value_col], errors="coerce")
+                spread_context_available = bool(traded_value_num.notna().any())
+            elif trades_count_col:
+                trades_count_num = pd.to_numeric(grp[trades_count_col], errors="coerce")
+                spread_context_available = bool(trades_count_num.notna().any())
+            elif high_col and low_col:
+                spread_context_available = high_low_usable
         else:
             avg_range_pct_20d = np.nan
             high_low_volatility = False
@@ -106,7 +116,8 @@ def compute_readiness_metrics(data: pd.DataFrame, thresholds: ReadinessThreshold
             and (np.isnan(avg_volume_20d) or avg_volume_20d >= thresholds.min_avg_volume_20d)
         )
 
-        timing_assessable = bool(signal_date_col is not None and grp[signal_date_col].notna().any())
+        parsed_signal_dates = pd.to_datetime(grp[signal_date_col], errors="coerce") if signal_date_col is not None else pd.Series(dtype="datetime64[ns]")
+        timing_assessable = bool(signal_date_col is not None and parsed_signal_dates.notna().any())
 
         rows.append(
             {

--- a/tests/test_readiness_gates.py
+++ b/tests/test_readiness_gates.py
@@ -77,6 +77,76 @@ def test_model_c_reports_spread_limitation_when_high_low_unavailable():
     assert strict_row["reason"] == "strict_spread_unavailable"
 
 
+def test_high_low_columns_with_all_nan_do_not_enable_context_flags():
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2025-01-01", periods=30),
+            "ticker": ["AAA"] * 30,
+            "close": [10 + i * 0.1 for i in range(30)],
+            "volume": [1000] * 30,
+            "high": [None] * 30,
+            "low": [None] * 30,
+            "signal_date": ["2025-01-05"] * 30,
+        }
+    )
+
+    metrics = compute_readiness_metrics(df)
+    row = metrics.iloc[0]
+    assert not bool(row["volatility_context_available"])
+    assert not bool(row["spread_context_available"])
+
+    _summary, detail = evaluate_models(metrics)
+    strict_row = detail[detail["model"] == "C_strict"].iloc[0]
+    assert strict_row["reason"] == "strict_spread_unavailable"
+
+
+def test_high_low_with_numeric_values_enables_volatility_context():
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2025-01-01", periods=30),
+            "ticker": ["AAA"] * 30,
+            "close": [10 + i * 0.1 for i in range(30)],
+            "volume": [1000] * 30,
+            "high": [11 + i * 0.1 for i in range(30)],
+            "low": [9 + i * 0.1 for i in range(30)],
+            "signal_date": ["2025-01-05"] * 30,
+        }
+    )
+
+    metrics = compute_readiness_metrics(df)
+    row = metrics.iloc[0]
+    assert bool(row["volatility_context_available"])
+
+
+def test_invalid_signal_date_strings_are_not_timing_assessable():
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2025-01-01", periods=30),
+            "ticker": ["AAA"] * 30,
+            "close": [10.0] * 30,
+            "volume": [1000] * 30,
+            "signal_date": ["not-a-date"] * 30,
+        }
+    )
+    metrics = compute_readiness_metrics(df)
+    assert not bool(metrics.iloc[0]["timing_assessable"])
+
+
+def test_at_least_one_valid_signal_date_is_timing_assessable():
+    signal_dates = ["not-a-date"] * 29 + ["2025-01-31"]
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2025-01-01", periods=30),
+            "ticker": ["AAA"] * 30,
+            "close": [10.0] * 30,
+            "volume": [1000] * 30,
+            "signal_date": signal_dates,
+        }
+    )
+    metrics = compute_readiness_metrics(df)
+    assert bool(metrics.iloc[0]["timing_assessable"])
+
+
 def test_output_files_created_in_expected_artifact_location(tmp_path):
     metrics = pd.DataFrame([{"ticker": "AAA"}])
     summary = pd.DataFrame([{"model": "A_current", "total_candidate_trades": 1}])


### PR DESCRIPTION
### Motivation
- Prevent false-positive readiness signals caused by empty `high`/`low` columns being treated as usable context for the strict model. 
- Ensure timing assessability only counts parseable dates so invalid strings cannot satisfy timing gates. 

### Description
- In `app/analysis/readiness_gates.py` updated `compute_readiness_metrics` to require at least one parseable numeric `high` and `low` (`high_low_usable`) before setting `volatility_context_available` to `True`. 
- `spread_context_available` now requires usable numeric data from `value_traded` (preferred) or `trades_count` (fallback), and only falls back to usable `high`/`low` if present; empty `high`/`low` columns no longer fake spread availability. 
- `timing_assessable` now uses `pd.to_datetime(..., errors="coerce")` and requires at least one valid parsed date. 
- Added/updated unit tests in `tests/test_readiness_gates.py` to cover: all-NaN `high`/`low` (no volatility/spread), numeric `high`/`low` (volatility available), all-invalid date strings (timing not assessable), and at-least-one valid date (timing assessable). 

### Testing
- Ran `pytest -q tests/test_readiness_gates.py` which passed with `9 passed` and reported `2 warnings` related to date parsing format fallback. 
- All added tests exercise the new logic for context availability and timing parsing and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18ea452b483228b256a13b52ea538)