### PR TITLE
Add Next.js frontend foundation for Vercel migration

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,132 @@
+body {
+  margin: 0;
+  background: #f7f8fb;
+  color: #111827;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.page-shell {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 32px 20px 56px;
+}
+
+.navbar {
+  border-bottom: 1px solid #e5e7eb;
+  background: #ffffff;
+}
+
+.navbar-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 16px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.brand {
+  font-weight: 800;
+}
+
+.nav-links {
+  display: flex;
+  gap: 12px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.hero {
+  display: grid;
+  gap: 18px;
+  padding: 36px 0 24px;
+}
+
+.eyebrow {
+  color: #0f766e;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+}
+
+h1 {
+  font-size: 44px;
+  line-height: 1.05;
+  margin: 0;
+}
+
+h2 {
+  margin: 0 0 10px;
+}
+
+p {
+  color: #6b7280;
+  line-height: 1.65;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.card {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  padding: 20px;
+}
+
+.pill {
+  display: inline-flex;
+  width: fit-content;
+  padding: 7px 10px;
+  border-radius: 999px;
+  background: #ccfbf1;
+  color: #0f766e;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.button-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-flex;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 700;
+  background: #111827;
+  color: white;
+}
+
+.button.secondary {
+  background: white;
+  color: #111827;
+  border: 1px solid #e5e7eb;
+}
+
+@media (max-width: 780px) {
+  .navbar-inner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { Navigation } from '@/components/layout/Navigation';
+
+export const metadata: Metadata = {
+  title: 'JSE Market Lab',
+  description: 'Decision-support dashboard for Jamaican Stock Exchange investors.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Navigation />
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+import { InfoCard } from '@/components/shared/InfoCard';
+
+export default function HomePage() {
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Decision support for the JSE</span>
+        <h1>Understand the setup before you decide what to do.</h1>
+        <p>
+          JSE Market Lab helps Jamaican investors review opportunities with structure: signal context,
+          quality tiers, liquidity checks, holding windows, and portfolio rules.
+        </p>
+        <div className="button-row">
+          <Link className="button" href="/portfolio">
+            View Portfolio Plan
+          </Link>
+          <Link className="button secondary" href="/ticker/JMMBGL">
+            Start with a ticker
+          </Link>
+        </div>
+      </section>
+
+      <section className="grid">
+        <InfoCard title="Plan with structure" label="Portfolio">
+          <p>
+            Enter capital, review funded and unfunded setups, and keep reserve cash visible when the
+            system does not find enough fundable opportunities.
+          </p>
+        </InfoCard>
+        <InfoCard title="Learn one ticker at a time" label="Ticker">
+          <p>
+            Use ticker analysis to see quick takes, holding-window behavior, risk context, and what to
+            watch before acting.
+          </p>
+        </InfoCard>
+        <InfoCard title="Review the rules" label="Audit">
+          <p>
+            The review layer explains how ranking, quality, liquidity, and allocation rules shaped the
+            plan. It supports discipline, not blind action.
+          </p>
+        </InfoCard>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/portfolio/page.tsx
+++ b/frontend/app/portfolio/page.tsx
@@ -1,0 +1,35 @@
+import { InfoCard } from '@/components/shared/InfoCard';
+
+const sampleTrades = [
+  { ticker: 'JMMBGL', tier: 'A', window: '20D', status: 'Funded for review' },
+  { ticker: 'GK', tier: 'B', window: '10D', status: 'Funded for review' },
+  { ticker: 'XYZ', tier: 'C', window: '5D', status: 'Watch only' },
+];
+
+export default function PortfolioPage() {
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Portfolio Plan</span>
+        <h1>Your capital plan will live here.</h1>
+        <p>
+          This page will call the FastAPI portfolio endpoint and render funded trades, unfunded trades,
+          reserve cash, and rule-based explanations.
+        </p>
+      </section>
+
+      <section className="grid">
+        {sampleTrades.map((trade) => (
+          <InfoCard key={trade.ticker} title={trade.ticker} label={trade.status}>
+            <p>Tier: {trade.tier}</p>
+            <p>Holding window: {trade.window}</p>
+            <p>
+              This placeholder keeps the frontend structure ready while API integration is added in the
+              next slice.
+            </p>
+          </InfoCard>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/review/page.tsx
+++ b/frontend/app/review/page.tsx
@@ -1,0 +1,36 @@
+import { InfoCard } from '@/components/shared/InfoCard';
+
+export default function ReviewPage() {
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Decision Audit</span>
+        <h1>Review why the plan looks the way it does.</h1>
+        <p>
+          This page will explain funded rationale, unfunded rationale, rules applied, and cash reserve
+          logic in simple decision-support language.
+        </p>
+      </section>
+
+      <section className="grid">
+        <InfoCard title="Why trades were funded" label="Rationale">
+          <p>
+            Shows which quality, confidence, and portfolio rules supported funding for review.
+          </p>
+        </InfoCard>
+        <InfoCard title="Why trades were not funded" label="Discipline">
+          <p>
+            Explains liquidity failures, Tier C handling, allocation limits, and other constraints without
+            forcing weak setups into the plan.
+          </p>
+        </InfoCard>
+        <InfoCard title="Cash reserve" label="Risk control">
+          <p>
+            Keeps unallocated capital visible so the user understands reserve cash is part of the plan,
+            not a mistake.
+          </p>
+        </InfoCard>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/ticker/[ticker]/page.tsx
+++ b/frontend/app/ticker/[ticker]/page.tsx
@@ -1,0 +1,45 @@
+import { InfoCard } from '@/components/shared/InfoCard';
+
+type TickerPageProps = {
+  params: {
+    ticker: string;
+  };
+};
+
+export default function TickerPage({ params }: TickerPageProps) {
+  const ticker = params.ticker.toUpperCase();
+
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Ticker Analysis</span>
+        <h1>{ticker}</h1>
+        <p>
+          This page will show quick take, best holding window, risk profile, execution behavior, and
+          what to watch for a single ticker.
+        </p>
+      </section>
+
+      <section className="grid">
+        <InfoCard title="Quick take" label="Guided">
+          <p>
+            The API-backed summary will explain whether the ticker has enough completed signal
+            history for a clean read.
+          </p>
+        </InfoCard>
+        <InfoCard title="Holding windows" label="5D / 10D / 20D / 30D">
+          <p>
+            This section will compare typical behavior across available holding windows using median
+            return first, with average return as supporting context.
+          </p>
+        </InfoCard>
+        <InfoCard title="What to watch" label="Risk context">
+          <p>
+            The dashboard will highlight liquidity, volume support, volatility, and any incomplete data
+            before the user makes their own decision.
+          </p>
+        </InfoCard>
+      </section>
+    </div>
+  );
+}

--- a/frontend/components/layout/Navigation.tsx
+++ b/frontend/components/layout/Navigation.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+const links = [
+  { href: '/', label: 'Start Here' },
+  { href: '/portfolio', label: 'Portfolio Plan' },
+  { href: '/ticker/JMMBGL', label: 'Ticker Analysis' },
+  { href: '/review', label: 'Review' },
+];
+
+export function Navigation() {
+  return (
+    <header className="navbar">
+      <div className="navbar-inner">
+        <Link href="/" className="brand">
+          JSE Market Lab
+        </Link>
+        <nav className="nav-links" aria-label="Main navigation">
+          {links.map((link) => (
+            <Link key={link.href} href={link.href}>
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/frontend/components/shared/InfoCard.tsx
+++ b/frontend/components/shared/InfoCard.tsx
@@ -1,0 +1,15 @@
+type InfoCardProps = {
+  title: string;
+  children: React.ReactNode;
+  label?: string;
+};
+
+export function InfoCard({ title, children, label }: InfoCardProps) {
+  return (
+    <section className="card">
+      {label ? <span className="pill">{label}</span> : null}
+      <h2>{title}</h2>
+      <div>{children}</div>
+    </section>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,40 @@
+import type { DataStatus, DecisionAudit, PortfolioPlan, TickerAnalysis, ViewMode } from './types';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8000';
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(API_BASE_URL + path, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('API request failed with status ' + response.status);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export function getDataStatus(): Promise<DataStatus> {
+  return apiFetch<DataStatus>('/api/data/status');
+}
+
+export function getPortfolioPlan(capital: number, mode: ViewMode = 'guided'): Promise<PortfolioPlan> {
+  return apiFetch<PortfolioPlan>('/api/portfolio/plan', {
+    method: 'POST',
+    body: JSON.stringify({ capital, mode }),
+  });
+}
+
+export function getTickerAnalysis(ticker: string, mode: ViewMode = 'guided'): Promise<TickerAnalysis> {
+  const path = '/api/ticker/' + encodeURIComponent(ticker) + '/analysis?mode=' + encodeURIComponent(mode);
+  return apiFetch<TickerAnalysis>(path);
+}
+
+export function getDecisionAudit(capital: number, mode: ViewMode = 'guided'): Promise<DecisionAudit> {
+  const path = '/api/review/decision-audit?capital=' + encodeURIComponent(String(capital)) + '&mode=' + encodeURIComponent(mode);
+  return apiFetch<DecisionAudit>(path);
+}

--- a/frontend/lib/formatters.ts
+++ b/frontend/lib/formatters.ts
@@ -1,0 +1,14 @@
+export function formatJmd(value: number): string {
+  return new Intl.NumberFormat('en-JM', {
+    style: 'currency',
+    currency: 'JMD',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function formatPercent(value: number): string {
+  return new Intl.NumberFormat('en-JM', {
+    style: 'percent',
+    maximumFractionDigits: 1,
+  }).format(value);
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,0 +1,68 @@
+export type ViewMode = 'guided' | 'advanced';
+
+export type Trade = {
+  ticker: string;
+  company_name: string;
+  tier: string;
+  holding_window: string;
+  allocation_amount: number;
+  allocation_pct: number;
+  liquidity_status: string;
+  risk_flags: string[];
+  reason: string;
+  net_pl_context: string;
+  selection_rank?: number | null;
+  funded_rank?: number | null;
+};
+
+export type PortfolioPlan = {
+  capital: number;
+  mode: ViewMode;
+  funded_trades: Trade[];
+  unfunded_trades: Trade[];
+  reserve_cash: number;
+  summary: {
+    funded_count: number;
+    unfunded_count: number;
+    total_allocated: number;
+    cash_reserve: number;
+  };
+  disclaimer: string;
+};
+
+export type DataStatus = {
+  dataset_source: string;
+  row_count: number;
+  latest_market_date: string | null;
+  warnings: string[];
+  errors: string[];
+  message: string;
+};
+
+export type TickerAnalysis = {
+  ticker: string;
+  mode: ViewMode;
+  quick_take: string[];
+  best_holding_window: string;
+  holding_windows: Array<{
+    holding_window: string;
+    count: number;
+    win_rate: number;
+    median_return: number;
+    average_return: number;
+  }>;
+  risk_profile: string[];
+  what_to_watch: string[];
+  execution_behavior: string[];
+  disclaimer: string;
+};
+
+export type DecisionAudit = {
+  mode: ViewMode;
+  summary: string[];
+  funded_rationale: string[];
+  unfunded_rationale: string[];
+  rules_applied: string[];
+  cash_reserve_explanation: string;
+  disclaimer: string;
+};

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'standalone',
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "jse-market-lab-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "next": "^14.2.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "typescript": "^5.4.5"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3"
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

This PR adds the first Next.js frontend scaffold for the Streamlit-to-Vercel migration.

It creates a separate `frontend/` app that can eventually be deployed to Vercel while the existing Streamlit app and FastAPI backend remain intact.

## What changed

- Added `frontend/package.json` with Next.js, React, TypeScript, and lint scripts
- Added Next.js app structure:
  - `frontend/app/page.tsx`
  - `frontend/app/portfolio/page.tsx`
  - `frontend/app/ticker/[ticker]/page.tsx`
  - `frontend/app/review/page.tsx`
  - `frontend/app/layout.tsx`
  - `frontend/app/globals.css`
- Added shared components:
  - `frontend/components/layout/Navigation.tsx`
  - `frontend/components/shared/InfoCard.tsx`
- Added frontend API contract helpers:
  - `frontend/lib/types.ts`
  - `frontend/lib/api.ts`
  - `frontend/lib/formatters.ts`
- Added Next.js config and TypeScript config

## Product direction

This frontend keeps the product positioned as decision support, not financial advice or signal-selling.

The first scaffold includes pages for:

- Start Here
- Portfolio Plan
- Ticker Analysis
- Decision Audit / Review

The wording keeps the user in control and frames outputs as structured review, not instructions to trade.

## How to test locally

```bash
cd frontend
npm install
npm run dev
```

Then open:

```text
http://localhost:3000
```

Expected pages:

```text
/
/portfolio
/ticker/JMMBGL
/review
```

## Vercel setup note

When deploying to Vercel, set the project root directory to:

```text
frontend
```

Do not point Vercel to the repo root once this PR is merged.

## Out of scope

- Live API integration in the UI
- Final visual design polish
- Authentication
- Subscriptions
- User accounts
- Backend hosting setup
- Vercel production deployment
- Removing Streamlit

## Next PR after this

The next frontend slice should connect the pages to the FastAPI backend using `NEXT_PUBLIC_API_BASE_URL` and render live portfolio/ticker/review payloads.
