### PR TITLE
Ignore frontend local build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ ipython_config.py
 
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
+#   intended to run in multiple environments; otherwise, check these files in:
 # .python-version
 
 # pipenv
@@ -171,7 +171,7 @@ cython_debug/
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  and can be added to the global gitignore or merged into this file. For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
@@ -182,10 +182,10 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#  you could uncomment the following to ignore the entire vscode folder
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
+#  you could uncomment the following to ignore the entire vscode folder.
 # .vscode/
 
 # Ruff stuff:
@@ -205,6 +205,15 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# macOS
+.DS_Store
+
+# Node / Next.js frontend
+frontend/node_modules/
+frontend/.next/
+frontend/out/
+frontend/.vercel/
 
 # Demo artifacts
 artifacts/


### PR DESCRIPTION
## Summary

Adds frontend and macOS local artifacts to `.gitignore` now that the repo includes a Next.js app.

## What changed

Ignored:

```text
.DS_Store
frontend/node_modules/
frontend/.next/
frontend/out/
frontend/.vercel/
```

## Why

Running the frontend locally creates generated folders and local files that should not be committed. This keeps the working tree cleaner after `npm install` and `npm run dev`.

## Testing

No app behavior changed. `.gitignore` only.
