### PR TITLE
Prepare frontend for Vercel API configuration

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,6 @@
+# FastAPI backend base URL.
+# Local example:
+# NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000
+# Production example:
+# NEXT_PUBLIC_API_BASE_URL=https://your-backend-host.example.com
+NEXT_PUBLIC_API_BASE_URL=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,62 @@
+# JSE Market Lab Frontend
+
+This folder contains the Next.js frontend for the Vercel migration.
+
+## Local development
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Open:
+
+```text
+http://localhost:3000
+```
+
+## Vercel setup
+
+When importing the GitHub repo into Vercel, use:
+
+```text
+Root Directory: frontend
+Framework Preset: Next.js
+Install Command: npm install
+Build Command: npm run build
+Output Directory: .next
+```
+
+## Backend API URL
+
+The frontend can connect to the FastAPI backend through:
+
+```text
+NEXT_PUBLIC_API_BASE_URL
+```
+
+Local example:
+
+```text
+NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000
+```
+
+Production example:
+
+```text
+NEXT_PUBLIC_API_BASE_URL=https://your-backend-host.example.com
+```
+
+If this variable is not set, the frontend still deploys and shows a frontend-ready status. API-backed product screens can be connected after the backend is hosted.
+
+## Product guardrails
+
+This frontend should preserve JSE Market Lab's positioning:
+
+- decision support, not financial advice
+- no buy/sell instructions
+- no prediction claims
+- no guaranteed returns
+- user agency remains clear
+- missing or weak data should be disclosed

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { ApiStatusCard } from '@/components/shared/ApiStatusCard';
 import { InfoCard } from '@/components/shared/InfoCard';
 
 export default function HomePage() {
@@ -22,6 +23,7 @@ export default function HomePage() {
       </section>
 
       <section className="grid">
+        <ApiStatusCard />
         <InfoCard title="Plan with structure" label="Portfolio">
           <p>
             Enter capital, review funded and unfunded setups, and keep reserve cash visible when the

--- a/frontend/components/shared/ApiStatusCard.tsx
+++ b/frontend/components/shared/ApiStatusCard.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getDataStatus } from '@/lib/api';
+import type { DataStatus } from '@/lib/types';
+import { InfoCard } from './InfoCard';
+
+export function ApiStatusCard() {
+  const [status, setStatus] = useState<DataStatus | null>(null);
+  const [message, setMessage] = useState('The frontend is ready. Add the backend URL when the API is hosted.');
+
+  useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_API_BASE_URL) {
+      return;
+    }
+
+    getDataStatus()
+      .then((payload) => setStatus(payload))
+      .catch(() => setMessage('The backend URL is configured, but the API is not reachable yet.'));
+  }, []);
+
+  if (status) {
+    return (
+      <InfoCard title="Data connection" label="API ready">
+        <p>Source: {status.dataset_source}</p>
+        <p>Rows loaded: {status.row_count}</p>
+        <p>Latest market date: {status.latest_market_date || 'Not available'}</p>
+      </InfoCard>
+    );
+  }
+
+  return (
+    <InfoCard title="Data connection" label="Frontend ready">
+      <p>{message}</p>
+    </InfoCard>
+  );
+}


### PR DESCRIPTION
## Summary

This PR keeps the focus on moving the frontend to Vercel without overbuilding product features before deployment.

It adds a Vercel-safe API connection layer so the Next.js frontend can deploy even before the FastAPI backend is hosted.

## What changed

- Added `frontend/.env.example` with `NEXT_PUBLIC_API_BASE_URL`
- Added `frontend/README.md` with local development and Vercel setup instructions
- Added `ApiStatusCard` to show whether the frontend is only deployed or connected to the backend
- Added the API status card to the homepage

## Product direction

This does not replace the placeholder product pages yet. That is intentional.

The goal of this slice is:

1. Make the Next.js frontend Vercel-ready
2. Avoid deployment failure when no hosted backend exists yet
3. Keep the backend connection configurable through environment variables
4. Preserve the decision-support positioning

## How to test locally

Without backend connection:

```bash
cd frontend
npm install
npm run dev
```

Open:

```text
http://localhost:3000
```

Expected result:

- homepage loads
- Data connection card shows frontend-ready status
- portfolio/ticker/review pages still load

With local backend connection:

In Terminal 1:

```bash
uvicorn backend.main:app --reload
```

In Terminal 2:

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000 npm run dev
```

Expected result:

- homepage loads
- Data connection card shows API-ready status and data status fields

## Vercel setup after merge

Use:

```text
Root Directory: frontend
Framework Preset: Next.js
Install Command: npm install
Build Command: npm run build
Output Directory: .next
```

Leave `NEXT_PUBLIC_API_BASE_URL` blank until the backend is hosted.

## Out of scope

- Full API-backed portfolio page
- Full API-backed ticker page
- Full API-backed review page
- Backend hosting
- Authentication
- Subscriptions
- Removing Streamlit
