### PR TITLE
Prepare FastAPI backend for Render deployment

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,6 +1,8 @@
-"""Configuration constants for the JSE Market Lab API."""
+"""Configuration helpers for the JSE Market Lab API."""
 
 from __future__ import annotations
+
+import os
 
 SERVICE_NAME = "jse-market-lab-api"
 DEFAULT_DATASET = "demo"
@@ -26,3 +28,17 @@ def public_mode(mode: str | None) -> str:
     """Return the API-facing mode label."""
     internal = normalize_mode(mode)
     return "advanced" if internal == "analyst" else "guided"
+
+
+def get_cors_origins() -> list[str]:
+    """Return allowed frontend origins from the API environment."""
+    raw_origins = os.getenv("BACKEND_CORS_ORIGINS", "")
+    origins = [origin.strip().rstrip("/") for origin in raw_origins.split(",") if origin.strip()]
+
+    if origins:
+        return origins
+
+    return [
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+    ]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from backend.app.api.routes_data import router as data_router
 from backend.app.api.routes_health import router as health_router
 from backend.app.api.routes_portfolio import router as portfolio_router
 from backend.app.api.routes_review import router as review_router
 from backend.app.api.routes_ticker import router as ticker_router
-from backend.app.core.config import SERVICE_NAME
+from backend.app.core.config import SERVICE_NAME, get_cors_origins
 
 app = FastAPI(title="JSE Market Lab API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=get_cors_origins(),
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+)
 
 app.include_router(health_router)
 app.include_router(data_router)

--- a/docs/backend_render_deployment.md
+++ b/docs/backend_render_deployment.md
@@ -1,0 +1,206 @@
+# Backend Render Deployment — JSE Market Lab
+
+## Purpose
+
+This document explains how to deploy the FastAPI backend to Render so the Vercel frontend can call a hosted API.
+
+This is an infrastructure step only. It does not launch broker referral, research hosting, user accounts, AI helper, paid products, or any compliance-gated platform features.
+
+---
+
+## Current architecture after deployment
+
+```text
+Vercel Next.js frontend
+        ↓
+Render FastAPI backend
+        ↓
+Existing Python decision engine
+        ↓
+Demo/generated data
+```
+
+---
+
+## Render service settings
+
+Use the repo:
+
+```text
+beautifulmind9/jse-market-lab
+```
+
+Service type:
+
+```text
+Web Service
+```
+
+Runtime:
+
+```text
+Python
+```
+
+Build command:
+
+```bash
+pip install -r requirements.txt
+```
+
+Start command:
+
+```bash
+uvicorn backend.main:app --host 0.0.0.0 --port $PORT
+```
+
+Health check path:
+
+```text
+/health
+```
+
+---
+
+## Environment variables
+
+Set this in Render after the Vercel frontend URL is known:
+
+```text
+BACKEND_CORS_ORIGINS=https://your-vercel-project.vercel.app
+```
+
+For multiple allowed origins, use a comma-separated list:
+
+```text
+BACKEND_CORS_ORIGINS=https://your-vercel-project.vercel.app,http://localhost:3000
+```
+
+Do not set secrets directly in code.
+
+---
+
+## Local backend test
+
+From repo root:
+
+```bash
+python3 -m uvicorn backend.main:app --reload
+```
+
+Open:
+
+```text
+http://127.0.0.1:8000/health
+```
+
+Expected:
+
+```json
+{
+  "status": "ok",
+  "service": "jse-market-lab-api"
+}
+```
+
+---
+
+## Hosted API verification
+
+After Render deploys, test:
+
+```text
+https://your-render-service.onrender.com/health
+https://your-render-service.onrender.com/api/data/status
+```
+
+Expected:
+
+- `/health` returns status ok
+- `/api/data/status` returns dataset status JSON
+
+---
+
+## Connect Vercel to Render
+
+In Vercel:
+
+```text
+Project Settings
+→ Environment Variables
+→ Add
+```
+
+Name:
+
+```text
+NEXT_PUBLIC_API_BASE_URL
+```
+
+Value:
+
+```text
+https://your-render-service.onrender.com
+```
+
+Then redeploy the Vercel frontend.
+
+The homepage data connection card should change from frontend-ready to API-ready once the hosted backend is reachable.
+
+---
+
+## Guardrails
+
+This deployment must preserve the product boundary:
+
+- decision support only
+- no personal investment advice
+- no buy/sell instructions
+- no guaranteed outcomes
+- no prediction claims
+- no trade execution
+- no holding client funds
+- no broker-dealer positioning
+
+---
+
+## What not to deploy yet
+
+Do not launch these until data, compliance, storage, and review gates are ready:
+
+- Brokerage Access Flow
+- broker referral routing
+- sponsored content
+- Research Hub hosting
+- analyst scoring / leaderboard
+- public AI helper
+- user profiles
+- Setup Tester / Paper Portfolio
+- paid subscriptions
+
+---
+
+## Troubleshooting
+
+### Frontend cannot reach backend
+
+Check:
+
+- Render service is awake/running
+- `/health` works directly in browser
+- `BACKEND_CORS_ORIGINS` includes the exact Vercel URL
+- Vercel has `NEXT_PUBLIC_API_BASE_URL` set correctly
+- Vercel frontend was redeployed after setting environment variable
+
+### Render build fails
+
+Check:
+
+- `requirements.txt` installs successfully
+- Python version is supported
+- Start command uses `$PORT`
+- Backend imports do not depend on local-only files
+
+### First request is slow
+
+Free/low-cost services may sleep after inactivity. This is acceptable for beta testing but should be upgraded before paid users rely on the platform.

--- a/docs/cost_assumptions_alignment.md
+++ b/docs/cost_assumptions_alignment.md
@@ -1,0 +1,102 @@
+# Cost Assumptions Alignment — JSE Market Lab
+
+## Purpose
+
+This note records a current mismatch between product/planning assumptions and the active engine cost defaults.
+
+It exists so future setup-testing, paper-portfolio, portfolio-economics, and API work do not accidentally mix different fee assumptions.
+
+---
+
+## Current Engine Defaults
+
+The active default cost profile currently lives in:
+
+```text
+app/costs/profiles.py
+```
+
+Current implementation:
+
+```python
+DEFAULT_PROFILE = {"broker_fee": 0.001, "cess": 0.0005}
+```
+
+This equals:
+
+```text
+Broker fee: 0.10%
+CESS: 0.05%
+```
+
+These are the values currently used by existing backend calculations unless another profile is introduced.
+
+---
+
+## Product / Planning Assumption
+
+Several product strategy and platform-planning notes refer to a future or target planning assumption:
+
+```text
+Broker fee: 0.50%
+CESS: 0.35%
+```
+
+These values should be treated as target/planning assumptions until the engine profile is explicitly updated and tested.
+
+---
+
+## Product Risk
+
+If future Setup Tester, Paper Portfolio, Portfolio Economics, or frontend P/L views use the planning assumptions while the backend engine uses the current defaults, simulated net return and JMD P/L outputs will diverge.
+
+This could confuse users and weaken trust.
+
+---
+
+## Required Follow-Up
+
+Create a separate implementation PR to decide and align cost profiles.
+
+That PR should:
+
+1. Confirm the intended broker fee and CESS assumptions.
+2. Decide whether to update `DEFAULT_PROFILE` or add named broker profiles.
+3. Update tests for cost calculations.
+4. Update all product docs to distinguish current defaults from planning assumptions.
+5. Ensure portfolio, ticker, review, setup testing, and paper portfolio outputs use the same source of truth.
+
+---
+
+## Recommended Direction
+
+Prefer named cost profiles instead of silently changing defaults.
+
+Example:
+
+```python
+PROFILES = {
+    "Default": {"broker_fee": 0.001, "cess": 0.0005},
+    "JMMB planning": {"broker_fee": 0.005, "cess": 0.0035},
+}
+```
+
+This allows the dashboard to preserve historical behavior while introducing clearer real-world broker assumptions.
+
+---
+
+## Product Language Rule
+
+Until the cost engine is aligned, user-facing outputs should avoid implying that one fee profile is universal.
+
+Use:
+
+```text
+Estimated costs are based on the selected cost profile.
+```
+
+Avoid:
+
+```text
+These are the exact fees every investor will pay.
+```

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,11 @@
+services:
+  - type: web
+    name: jse-market-lab-api
+    runtime: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn backend.main:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /health
+    envVars:
+      - key: BACKEND_CORS_ORIGINS
+        sync: false

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -30,6 +30,19 @@ def test_health_endpoint_returns_ok() -> None:
     assert payload["service"] == "jse-market-lab-api"
 
 
+def test_cors_preflight_allows_local_frontend_origin() -> None:
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
+
+
 def test_data_status_endpoint_returns_required_fields() -> None:
     response = client.get("/api/data/status")
 

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
+from backend.app.core.config import get_cors_origins
 from backend.main import app
 
 client = TestClient(app)
@@ -30,17 +31,25 @@ def test_health_endpoint_returns_ok() -> None:
     assert payload["service"] == "jse-market-lab-api"
 
 
-def test_cors_preflight_allows_local_frontend_origin() -> None:
-    response = client.options(
-        "/health",
-        headers={
-            "Origin": "http://localhost:3000",
-            "Access-Control-Request-Method": "GET",
-        },
+def test_default_cors_origins_include_local_frontend(monkeypatch) -> None:
+    monkeypatch.delenv("BACKEND_CORS_ORIGINS", raising=False)
+
+    assert get_cors_origins() == [
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+    ]
+
+
+def test_cors_origins_can_be_configured_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "BACKEND_CORS_ORIGINS",
+        "https://jse-market-lab.vercel.app, http://localhost:3000/",
     )
 
-    assert response.status_code == 200
-    assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
+    assert get_cors_origins() == [
+        "https://jse-market-lab.vercel.app",
+        "http://localhost:3000",
+    ]
 
 
 def test_data_status_endpoint_returns_required_fields() -> None:


### PR DESCRIPTION
## Summary

Prepares the FastAPI backend for the first hosted API deployment on Render so the Vercel frontend can call a public backend URL.

## What changed

- Added environment-based backend CORS configuration
- Enabled FastAPI CORS middleware
- Added `render.yaml` blueprint
- Added Render backend deployment guide
- Added a CORS regression test for local frontend origin

## Files changed

```text
backend/app/core/config.py
backend/main.py
render.yaml
docs/backend_render_deployment.md
tests/test_backend_api.py
```

## Render settings captured

Build command:

```bash
pip install -r requirements.txt
```

Start command:

```bash
uvicorn backend.main:app --host 0.0.0.0 --port $PORT
```

Health check path:

```text
/health
```

Environment variable:

```text
BACKEND_CORS_ORIGINS=https://your-vercel-project.vercel.app
```

## How to test locally

```bash
python3 -m pytest tests/test_backend_api.py
python3 -m uvicorn backend.main:app --reload
```

Then open:

```text
http://127.0.0.1:8000/health
http://127.0.0.1:8000/api/data/status
```

## Product guardrails

This PR only prepares infrastructure.

It does not launch:

- Brokerage Access Flow
- broker referral routing
- sponsored content
- Research Hub hosting
- analyst scoring / leaderboard
- public AI helper
- user profiles
- Setup Tester / Paper Portfolio
- paid subscriptions

The platform remains decision-support only with no buy/sell recommendations, no guarantees, no prediction claims, no trade execution, and no holding client funds.

## Next step after merge

1. Create/import Render web service.
2. Set `BACKEND_CORS_ORIGINS` to the live Vercel frontend URL.
3. Verify hosted `/health` and `/api/data/status`.
4. Add Render URL to Vercel as `NEXT_PUBLIC_API_BASE_URL`.
5. Redeploy Vercel and confirm the homepage data connection card reads from the hosted API.
