### PR TITLE
Render frontend pages from backend API data

### DIFF
--- a/frontend/app/portfolio/page.tsx
+++ b/frontend/app/portfolio/page.tsx
@@ -1,35 +1,92 @@
 import { InfoCard } from '@/components/shared/InfoCard';
+import { getPortfolioPlan } from '@/lib/api';
+import { formatJmd, formatPercent } from '@/lib/formatters';
+import type { Trade } from '@/lib/types';
 
-const sampleTrades = [
-  { ticker: 'JMMBGL', tier: 'A', window: '20D', status: 'Funded for review' },
-  { ticker: 'GK', tier: 'B', window: '10D', status: 'Funded for review' },
-  { ticker: 'XYZ', tier: 'C', window: '5D', status: 'Watch only' },
-];
+const DEFAULT_CAPITAL = 100000;
 
-export default function PortfolioPage() {
+function TradeCard({ trade, label }: { trade: Trade; label: string }) {
+  return (
+    <InfoCard title={trade.ticker} label={label}>
+      <p>{trade.company_name}</p>
+      <p>Tier: {trade.tier}</p>
+      <p>Holding window: {trade.holding_window}</p>
+      <p>Allocation: {formatJmd(trade.allocation_amount)} ({formatPercent(trade.allocation_pct)})</p>
+      <p>Liquidity: {trade.liquidity_status}</p>
+      <p>{trade.reason}</p>
+    </InfoCard>
+  );
+}
+
+export default async function PortfolioPage() {
+  let plan;
+  let error: string | null = null;
+
+  try {
+    plan = await getPortfolioPlan(DEFAULT_CAPITAL, 'guided');
+  } catch {
+    error = 'Portfolio plan data is not available right now. Please try again after the API is reachable.';
+  }
+
   return (
     <div className="page-shell">
       <section className="hero">
         <span className="eyebrow">Portfolio Plan</span>
-        <h1>Your capital plan will live here.</h1>
+        <h1>Review a sample capital plan.</h1>
         <p>
-          This page will call the FastAPI portfolio endpoint and render funded trades, unfunded trades,
-          reserve cash, and rule-based explanations.
+          This page uses the hosted FastAPI backend to show funded trades, unfunded trades, reserve
+          cash, and rule-based explanations for a sample {formatJmd(DEFAULT_CAPITAL)} guided plan.
         </p>
       </section>
 
-      <section className="grid">
-        {sampleTrades.map((trade) => (
-          <InfoCard key={trade.ticker} title={trade.ticker} label={trade.status}>
-            <p>Tier: {trade.tier}</p>
-            <p>Holding window: {trade.window}</p>
-            <p>
-              This placeholder keeps the frontend structure ready while API integration is added in the
-              next slice.
-            </p>
+      {error || !plan ? (
+        <section className="grid">
+          <InfoCard title="Portfolio data unavailable" label="API status">
+            <p>{error}</p>
           </InfoCard>
-        ))}
-      </section>
+        </section>
+      ) : (
+        <>
+          <section className="grid">
+            <InfoCard title="Funded setups" label="Summary">
+              <p>{plan.summary.funded_count} setups funded for review.</p>
+              <p>Total allocated: {formatJmd(plan.summary.total_allocated)}</p>
+            </InfoCard>
+            <InfoCard title="Cash reserve" label="Risk control">
+              <p>{formatJmd(plan.reserve_cash)} remains unallocated.</p>
+              <p>Reserve cash is part of the plan when not enough setups meet the rules.</p>
+            </InfoCard>
+            <InfoCard title="Unfunded setups" label="Discipline">
+              <p>{plan.summary.unfunded_count} setups were not funded.</p>
+              <p>Unfunded does not mean ignored. It means the rules held back capital.</p>
+            </InfoCard>
+          </section>
+
+          <section className="hero">
+            <span className="eyebrow">Funded for review</span>
+            <h2>Top funded setups</h2>
+          </section>
+          <section className="grid">
+            {plan.funded_trades.slice(0, 6).map((trade) => (
+              <TradeCard key={trade.ticker} trade={trade} label="Funded" />
+            ))}
+          </section>
+
+          <section className="hero">
+            <span className="eyebrow">Not funded</span>
+            <h2>Held back by rules</h2>
+          </section>
+          <section className="grid">
+            {plan.unfunded_trades.slice(0, 6).map((trade) => (
+              <TradeCard key={trade.ticker} trade={trade} label="Not funded" />
+            ))}
+          </section>
+
+          <section className="hero">
+            <p>{plan.disclaimer}</p>
+          </section>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/app/review/page.tsx
+++ b/frontend/app/review/page.tsx
@@ -1,36 +1,65 @@
 import { InfoCard } from '@/components/shared/InfoCard';
+import { getDecisionAudit } from '@/lib/api';
+import { formatJmd } from '@/lib/formatters';
 
-export default function ReviewPage() {
+const DEFAULT_CAPITAL = 100000;
+
+function BulletCard({ title, label, lines }: { title: string; label: string; lines: string[] }) {
+  return (
+    <InfoCard title={title} label={label}>
+      {lines.map((line) => (
+        <p key={line}>{line}</p>
+      ))}
+    </InfoCard>
+  );
+}
+
+export default async function ReviewPage() {
+  let audit;
+  let error: string | null = null;
+
+  try {
+    audit = await getDecisionAudit(DEFAULT_CAPITAL, 'guided');
+  } catch {
+    error = 'Decision audit data is not available right now. Please try again after the API is reachable.';
+  }
+
   return (
     <div className="page-shell">
       <section className="hero">
         <span className="eyebrow">Decision Audit</span>
         <h1>Review why the plan looks the way it does.</h1>
         <p>
-          This page will explain funded rationale, unfunded rationale, rules applied, and cash reserve
-          logic in simple decision-support language.
+          This page uses the hosted FastAPI backend to explain funded rationale, unfunded rationale,
+          rules applied, and cash reserve logic for a sample {formatJmd(DEFAULT_CAPITAL)} guided plan.
         </p>
       </section>
 
-      <section className="grid">
-        <InfoCard title="Why trades were funded" label="Rationale">
-          <p>
-            Shows which quality, confidence, and portfolio rules supported funding for review.
-          </p>
-        </InfoCard>
-        <InfoCard title="Why trades were not funded" label="Discipline">
-          <p>
-            Explains liquidity failures, Tier C handling, allocation limits, and other constraints without
-            forcing weak setups into the plan.
-          </p>
-        </InfoCard>
-        <InfoCard title="Cash reserve" label="Risk control">
-          <p>
-            Keeps unallocated capital visible so the user understands reserve cash is part of the plan,
-            not a mistake.
-          </p>
-        </InfoCard>
-      </section>
+      {error || !audit ? (
+        <section className="grid">
+          <InfoCard title="Decision audit unavailable" label="API status">
+            <p>{error}</p>
+          </InfoCard>
+        </section>
+      ) : (
+        <>
+          <section className="grid">
+            <BulletCard title="Summary" label={audit.mode} lines={audit.summary} />
+            <BulletCard title="Why trades were funded" label="Rationale" lines={audit.funded_rationale} />
+            <BulletCard title="Why trades were not funded" label="Discipline" lines={audit.unfunded_rationale} />
+          </section>
+
+          <section className="grid">
+            <BulletCard title="Rules applied" label="Method" lines={audit.rules_applied} />
+            <InfoCard title="Cash reserve" label="Risk control">
+              <p>{audit.cash_reserve_explanation}</p>
+            </InfoCard>
+            <InfoCard title="Decision boundary" label="Reminder">
+              <p>{audit.disclaimer}</p>
+            </InfoCard>
+          </section>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/app/ticker/[ticker]/page.tsx
+++ b/frontend/app/ticker/[ticker]/page.tsx
@@ -1,4 +1,6 @@
 import { InfoCard } from '@/components/shared/InfoCard';
+import { getTickerAnalysis } from '@/lib/api';
+import { formatPercent } from '@/lib/formatters';
 
 type TickerPageProps = {
   params: {
@@ -6,8 +8,16 @@ type TickerPageProps = {
   };
 };
 
-export default function TickerPage({ params }: TickerPageProps) {
+export default async function TickerPage({ params }: TickerPageProps) {
   const ticker = params.ticker.toUpperCase();
+  let analysis;
+  let error: string | null = null;
+
+  try {
+    analysis = await getTickerAnalysis(ticker, 'guided');
+  } catch {
+    error = 'Ticker analysis is not available right now. Please try again after the API is reachable.';
+  }
 
   return (
     <div className="page-shell">
@@ -15,31 +25,68 @@ export default function TickerPage({ params }: TickerPageProps) {
         <span className="eyebrow">Ticker Analysis</span>
         <h1>{ticker}</h1>
         <p>
-          This page will show quick take, best holding window, risk profile, execution behavior, and
-          what to watch for a single ticker.
+          Review quick take, holding-window behavior, risk profile, execution behavior, and what to
+          watch before making your own decision.
         </p>
       </section>
 
-      <section className="grid">
-        <InfoCard title="Quick take" label="Guided">
-          <p>
-            The API-backed summary will explain whether the ticker has enough completed signal
-            history for a clean read.
-          </p>
-        </InfoCard>
-        <InfoCard title="Holding windows" label="5D / 10D / 20D / 30D">
-          <p>
-            This section will compare typical behavior across available holding windows using median
-            return first, with average return as supporting context.
-          </p>
-        </InfoCard>
-        <InfoCard title="What to watch" label="Risk context">
-          <p>
-            The dashboard will highlight liquidity, volume support, volatility, and any incomplete data
-            before the user makes their own decision.
-          </p>
-        </InfoCard>
-      </section>
+      {error || !analysis ? (
+        <section className="grid">
+          <InfoCard title="Ticker data unavailable" label="API status">
+            <p>{error}</p>
+          </InfoCard>
+        </section>
+      ) : (
+        <>
+          <section className="grid">
+            <InfoCard title="Quick take" label={analysis.mode}>
+              {analysis.quick_take.map((line) => (
+                <p key={line}>{line}</p>
+              ))}
+            </InfoCard>
+            <InfoCard title="Best holding window" label="Current sample">
+              <p>{analysis.best_holding_window || 'Not enough data yet'}</p>
+              <p>Use this as context, not a prediction.</p>
+            </InfoCard>
+            <InfoCard title="What to watch" label="Risk context">
+              {analysis.what_to_watch.map((line) => (
+                <p key={line}>{line}</p>
+              ))}
+            </InfoCard>
+          </section>
+
+          <section className="hero">
+            <span className="eyebrow">Holding windows</span>
+            <h2>Historical signal behavior</h2>
+          </section>
+          <section className="grid">
+            {analysis.holding_windows.map((window) => (
+              <InfoCard key={window.holding_window} title={window.holding_window} label="Window">
+                <p>Signals: {window.count}</p>
+                <p>Win rate: {formatPercent(window.win_rate)}</p>
+                <p>Median return: {formatPercent(window.median_return)}</p>
+                <p>Average return: {formatPercent(window.average_return)}</p>
+              </InfoCard>
+            ))}
+          </section>
+
+          <section className="grid">
+            <InfoCard title="Risk profile" label="Review">
+              {analysis.risk_profile.map((line) => (
+                <p key={line}>{line}</p>
+              ))}
+            </InfoCard>
+            <InfoCard title="Execution behavior" label="Market reality">
+              {analysis.execution_behavior.map((line) => (
+                <p key={line}>{line}</p>
+              ))}
+            </InfoCard>
+            <InfoCard title="Decision boundary" label="Reminder">
+              <p>{analysis.disclaimer}</p>
+            </InfoCard>
+          </section>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,9 +2,14 @@ import type { DataStatus, DecisionAudit, PortfolioPlan, TickerAnalysis, ViewMode
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8000';
 
+export function getApiBaseUrl(): string {
+  return API_BASE_URL;
+}
+
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(API_BASE_URL + path, {
     ...init,
+    cache: 'no-store',
     headers: {
       'Content-Type': 'application/json',
       ...(init?.headers || {}),


### PR DESCRIPTION
## Summary

Replaces the initial placeholder frontend pages with lightweight API-backed rendering from the hosted FastAPI backend.

This keeps the scope focused on the Vercel migration: the pages now display real backend payloads, but no new platform features are introduced yet.

## What changed

Updated:

```text
frontend/lib/api.ts
frontend/app/portfolio/page.tsx
frontend/app/ticker/[ticker]/page.tsx
frontend/app/review/page.tsx
```

## Page behavior

### Portfolio Plan

`/portfolio` now calls:

```text
POST /api/portfolio/plan
```

and renders:

- funded setup summary
- cash reserve
- unfunded setup summary
- top funded setups
- top unfunded setups
- disclaimer

### Ticker Analysis

`/ticker/[ticker]` now calls:

```text
GET /api/ticker/{ticker}/analysis
```

and renders:

- quick take
- best holding window
- what to watch
- holding-window stats
- risk profile
- execution behavior
- disclaimer

### Decision Audit

`/review` now calls:

```text
GET /api/review/decision-audit
```

and renders:

- summary
- funded rationale
- unfunded rationale
- rules applied
- cash reserve explanation
- disclaimer

## API behavior

`frontend/lib/api.ts` now sets:

```text
cache: no-store
```

so frontend pages do not freeze stale backend data into the build.

## Product guardrails

This PR preserves the decision-support boundary:

- no buy/sell instructions
- no guaranteed outcomes
- no prediction claims
- no trade execution
- no broker referral flow
- no user profiles
- no setup tester / paper portfolio
- no AI helper launch

## How to test locally

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=https://jse-market-lab.onrender.com npm run dev
```

Open:

```text
http://localhost:3000/portfolio
http://localhost:3000/ticker/JMMBGL
http://localhost:3000/review
```

Expected:

- pages load
- API-backed cards render
- no placeholder-only text remains on these pages
- decision-support disclaimers remain visible

## Vercel preview test

Vercel should create a preview deployment for this PR. The preview should use the existing `NEXT_PUBLIC_API_BASE_URL` environment variable if it is available to Preview, or show graceful API-unavailable fallback cards if it is not.
