### PR TITLE
Polish API-backed frontend pages

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,7 +1,20 @@
+:root {
+  --background: #f7f8fb;
+  --surface: #ffffff;
+  --surface-soft: #f1f5f9;
+  --foreground: #111827;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+  --accent: #0f766e;
+  --accent-soft: #ccfbf1;
+  --warning-soft: #fef3c7;
+  --warning-text: #92400e;
+}
+
 body {
   margin: 0;
-  background: #f7f8fb;
-  color: #111827;
+  background: var(--background);
+  color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
 
@@ -17,8 +30,8 @@ a {
 }
 
 .navbar {
-  border-bottom: 1px solid #e5e7eb;
-  background: #ffffff;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
 }
 
 .navbar-inner {
@@ -38,7 +51,7 @@ a {
 .nav-links {
   display: flex;
   gap: 12px;
-  color: #6b7280;
+  color: var(--muted);
   font-size: 14px;
 }
 
@@ -48,8 +61,12 @@ a {
   padding: 36px 0 24px;
 }
 
+.hero.compact {
+  padding: 28px 0 16px;
+}
+
 .eyebrow {
-  color: #0f766e;
+  color: var(--accent);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -66,8 +83,12 @@ h2 {
   margin: 0 0 10px;
 }
 
+h3 {
+  margin: 0 0 8px;
+}
+
 p {
-  color: #6b7280;
+  color: var(--muted);
   line-height: 1.65;
 }
 
@@ -75,13 +96,27 @@ p {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 16px;
+  margin-bottom: 18px;
+}
+
+.grid.two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .card {
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 18px;
   padding: 20px;
+  min-width: 0;
+}
+
+.card p:last-child {
+  margin-bottom: 0;
+}
+
+.card-highlight {
+  background: var(--surface-soft);
 }
 
 .pill {
@@ -89,10 +124,60 @@ p {
   width: fit-content;
   padding: 7px 10px;
   border-radius: 999px;
-  background: #ccfbf1;
-  color: #0f766e;
+  background: var(--accent-soft);
+  color: var(--accent);
   font-size: 13px;
   font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.notice {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface-soft);
+  padding: 16px 18px;
+  margin: 18px 0;
+}
+
+.notice.warning {
+  background: var(--warning-soft);
+  color: var(--warning-text);
+}
+
+.notice p {
+  margin: 0;
+}
+
+.metric-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  border-top: 1px solid var(--border);
+  padding: 10px 0;
+}
+
+.metric-row:first-of-type {
+  border-top: 0;
+}
+
+.metric-label {
+  color: var(--muted);
+}
+
+.metric-value {
+  color: var(--foreground);
+  font-weight: 800;
+  text-align: right;
+}
+
+.list-stack {
+  display: grid;
+  gap: 10px;
+}
+
+.list-stack p {
+  margin: 0;
 }
 
 .button-row {
@@ -106,14 +191,14 @@ p {
   border-radius: 12px;
   padding: 12px 16px;
   font-weight: 700;
-  background: #111827;
+  background: var(--foreground);
   color: white;
 }
 
 .button.secondary {
   background: white;
-  color: #111827;
-  border: 1px solid #e5e7eb;
+  color: var(--foreground);
+  border: 1px solid var(--border);
 }
 
 @media (max-width: 780px) {
@@ -126,7 +211,22 @@ p {
     flex-wrap: wrap;
   }
 
-  .grid {
+  h1 {
+    font-size: 36px;
+  }
+
+  .grid,
+  .grid.two {
     grid-template-columns: 1fr;
+  }
+
+  .metric-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .metric-value {
+    text-align: left;
   }
 }

--- a/frontend/app/portfolio/page.tsx
+++ b/frontend/app/portfolio/page.tsx
@@ -1,4 +1,5 @@
 import { InfoCard } from '@/components/shared/InfoCard';
+import { MetricRow } from '@/components/shared/MetricRow';
 import { getPortfolioPlan } from '@/lib/api';
 import { formatJmd, formatPercent } from '@/lib/formatters';
 import type { Trade } from '@/lib/types';
@@ -9,10 +10,11 @@ function TradeCard({ trade, label }: { trade: Trade; label: string }) {
   return (
     <InfoCard title={trade.ticker} label={label}>
       <p>{trade.company_name}</p>
-      <p>Tier: {trade.tier}</p>
-      <p>Holding window: {trade.holding_window}</p>
-      <p>Allocation: {formatJmd(trade.allocation_amount)} ({formatPercent(trade.allocation_pct)})</p>
-      <p>Liquidity: {trade.liquidity_status}</p>
+      <MetricRow label="Tier" value={trade.tier} />
+      <MetricRow label="Holding window" value={trade.holding_window} />
+      <MetricRow label="Allocation" value={formatJmd(trade.allocation_amount)} />
+      <MetricRow label="Allocation share" value={formatPercent(trade.allocation_pct)} />
+      <MetricRow label="Liquidity" value={trade.liquidity_status} />
       <p>{trade.reason}</p>
     </InfoCard>
   );
@@ -49,20 +51,24 @@ export default async function PortfolioPage() {
         <>
           <section className="grid">
             <InfoCard title="Funded setups" label="Summary">
-              <p>{plan.summary.funded_count} setups funded for review.</p>
-              <p>Total allocated: {formatJmd(plan.summary.total_allocated)}</p>
+              <MetricRow label="Funded for review" value={plan.summary.funded_count} />
+              <MetricRow label="Total allocated" value={formatJmd(plan.summary.total_allocated)} />
             </InfoCard>
             <InfoCard title="Cash reserve" label="Risk control">
-              <p>{formatJmd(plan.reserve_cash)} remains unallocated.</p>
+              <MetricRow label="Unallocated cash" value={formatJmd(plan.reserve_cash)} />
               <p>Reserve cash is part of the plan when not enough setups meet the rules.</p>
             </InfoCard>
             <InfoCard title="Unfunded setups" label="Discipline">
-              <p>{plan.summary.unfunded_count} setups were not funded.</p>
+              <MetricRow label="Held back by rules" value={plan.summary.unfunded_count} />
               <p>Unfunded does not mean ignored. It means the rules held back capital.</p>
             </InfoCard>
           </section>
 
-          <section className="hero">
+          <div className="notice">
+            <p>{plan.disclaimer}</p>
+          </div>
+
+          <section className="hero compact">
             <span className="eyebrow">Funded for review</span>
             <h2>Top funded setups</h2>
           </section>
@@ -72,7 +78,7 @@ export default async function PortfolioPage() {
             ))}
           </section>
 
-          <section className="hero">
+          <section className="hero compact">
             <span className="eyebrow">Not funded</span>
             <h2>Held back by rules</h2>
           </section>
@@ -80,10 +86,6 @@ export default async function PortfolioPage() {
             {plan.unfunded_trades.slice(0, 6).map((trade) => (
               <TradeCard key={trade.ticker} trade={trade} label="Not funded" />
             ))}
-          </section>
-
-          <section className="hero">
-            <p>{plan.disclaimer}</p>
           </section>
         </>
       )}

--- a/frontend/app/review/page.tsx
+++ b/frontend/app/review/page.tsx
@@ -1,15 +1,14 @@
 import { InfoCard } from '@/components/shared/InfoCard';
+import { TextStack } from '@/components/shared/TextStack';
 import { getDecisionAudit } from '@/lib/api';
 import { formatJmd } from '@/lib/formatters';
 
 const DEFAULT_CAPITAL = 100000;
 
-function BulletCard({ title, label, lines }: { title: string; label: string; lines: string[] }) {
+function TextCard({ title, label, lines }: { title: string; label: string; lines: string[] }) {
   return (
     <InfoCard title={title} label={label}>
-      {lines.map((line) => (
-        <p key={line}>{line}</p>
-      ))}
+      <TextStack lines={lines} />
     </InfoCard>
   );
 }
@@ -43,19 +42,20 @@ export default async function ReviewPage() {
         </section>
       ) : (
         <>
-          <section className="grid">
-            <BulletCard title="Summary" label={audit.mode} lines={audit.summary} />
-            <BulletCard title="Why trades were funded" label="Rationale" lines={audit.funded_rationale} />
-            <BulletCard title="Why trades were not funded" label="Discipline" lines={audit.unfunded_rationale} />
-          </section>
+          <div className="notice">
+            <p>{audit.disclaimer}</p>
+          </div>
 
           <section className="grid">
-            <BulletCard title="Rules applied" label="Method" lines={audit.rules_applied} />
+            <TextCard title="Summary" label={audit.mode} lines={audit.summary} />
+            <TextCard title="Why trades were funded" label="Rationale" lines={audit.funded_rationale} />
+            <TextCard title="Why trades were not funded" label="Discipline" lines={audit.unfunded_rationale} />
+          </section>
+
+          <section className="grid two">
+            <TextCard title="Rules applied" label="Method" lines={audit.rules_applied} />
             <InfoCard title="Cash reserve" label="Risk control">
               <p>{audit.cash_reserve_explanation}</p>
-            </InfoCard>
-            <InfoCard title="Decision boundary" label="Reminder">
-              <p>{audit.disclaimer}</p>
             </InfoCard>
           </section>
         </>

--- a/frontend/app/ticker/[ticker]/page.tsx
+++ b/frontend/app/ticker/[ticker]/page.tsx
@@ -1,4 +1,6 @@
 import { InfoCard } from '@/components/shared/InfoCard';
+import { MetricRow } from '@/components/shared/MetricRow';
+import { TextStack } from '@/components/shared/TextStack';
 import { getTickerAnalysis } from '@/lib/api';
 import { formatPercent } from '@/lib/formatters';
 
@@ -40,49 +42,42 @@ export default async function TickerPage({ params }: TickerPageProps) {
         <>
           <section className="grid">
             <InfoCard title="Quick take" label={analysis.mode}>
-              {analysis.quick_take.map((line) => (
-                <p key={line}>{line}</p>
-              ))}
+              <TextStack lines={analysis.quick_take} />
             </InfoCard>
             <InfoCard title="Best holding window" label="Current sample">
-              <p>{analysis.best_holding_window || 'Not enough data yet'}</p>
+              <MetricRow label="Best window" value={analysis.best_holding_window || 'Not enough data yet'} />
               <p>Use this as context, not a prediction.</p>
             </InfoCard>
             <InfoCard title="What to watch" label="Risk context">
-              {analysis.what_to_watch.map((line) => (
-                <p key={line}>{line}</p>
-              ))}
+              <TextStack lines={analysis.what_to_watch} />
             </InfoCard>
           </section>
 
-          <section className="hero">
+          <div className="notice">
+            <p>{analysis.disclaimer}</p>
+          </div>
+
+          <section className="hero compact">
             <span className="eyebrow">Holding windows</span>
             <h2>Historical signal behavior</h2>
           </section>
           <section className="grid">
             {analysis.holding_windows.map((window) => (
               <InfoCard key={window.holding_window} title={window.holding_window} label="Window">
-                <p>Signals: {window.count}</p>
-                <p>Win rate: {formatPercent(window.win_rate)}</p>
-                <p>Median return: {formatPercent(window.median_return)}</p>
-                <p>Average return: {formatPercent(window.average_return)}</p>
+                <MetricRow label="Signals" value={window.count} />
+                <MetricRow label="Win rate" value={formatPercent(window.win_rate)} />
+                <MetricRow label="Median return" value={formatPercent(window.median_return)} />
+                <MetricRow label="Average return" value={formatPercent(window.average_return)} />
               </InfoCard>
             ))}
           </section>
 
-          <section className="grid">
+          <section className="grid two">
             <InfoCard title="Risk profile" label="Review">
-              {analysis.risk_profile.map((line) => (
-                <p key={line}>{line}</p>
-              ))}
+              <TextStack lines={analysis.risk_profile} />
             </InfoCard>
             <InfoCard title="Execution behavior" label="Market reality">
-              {analysis.execution_behavior.map((line) => (
-                <p key={line}>{line}</p>
-              ))}
-            </InfoCard>
-            <InfoCard title="Decision boundary" label="Reminder">
-              <p>{analysis.disclaimer}</p>
+              <TextStack lines={analysis.execution_behavior} />
             </InfoCard>
           </section>
         </>

--- a/frontend/components/shared/MetricRow.tsx
+++ b/frontend/components/shared/MetricRow.tsx
@@ -1,0 +1,13 @@
+type MetricRowProps = {
+  label: string;
+  value: string | number;
+};
+
+export function MetricRow({ label, value }: MetricRowProps) {
+  return (
+    <div className="metric-row">
+      <span className="metric-label">{label}</span>
+      <span className="metric-value">{value}</span>
+    </div>
+  );
+}

--- a/frontend/components/shared/TextStack.tsx
+++ b/frontend/components/shared/TextStack.tsx
@@ -1,0 +1,17 @@
+type TextStackProps = {
+  lines: string[];
+};
+
+export function TextStack({ lines }: TextStackProps) {
+  if (lines.length === 0) {
+    return <p>No details available yet.</p>;
+  }
+
+  return (
+    <div className="list-stack">
+      {lines.map((line) => (
+        <p key={line}>{line}</p>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Polishes the live API-backed frontend pages now that the Vercel frontend is connected to the Render FastAPI backend.

This PR improves readability and scanability without changing backend logic or adding new platform features.

## What changed

Added shared display components:

```text
frontend/components/shared/MetricRow.tsx
frontend/components/shared/TextStack.tsx
```

Updated shared styling:

```text
frontend/app/globals.css
```

Polished API-backed pages:

```text
frontend/app/portfolio/page.tsx
frontend/app/ticker/[ticker]/page.tsx
frontend/app/review/page.tsx
```

## Improvements

- clearer metric rows for portfolio/ticker stats
- cleaner text stacks for quick take, risks, explanations, and review rationale
- less cramped card layout
- improved mobile behavior for metric rows
- visible disclaimer/decision-support notices near the top of API-backed pages
- better section spacing for funded/unfunded and holding-window sections

## Product guardrails

This PR keeps the platform decision-support only.

It does not add:

- buy/sell recommendations
- prediction language
- trade execution
- broker routing
- user profiles
- setup tester / paper portfolio
- AI helper functionality
- paid features

## How to test locally

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=https://jse-market-lab.onrender.com npm run dev
```

Open:

```text
http://localhost:3000/portfolio
http://localhost:3000/ticker/JMMBGL
http://localhost:3000/review
```

Expected:

- pages still load API-backed content
- cards are easier to scan
- metric rows display neatly
- disclaimer notices remain visible
- mobile layout remains readable

## Vercel preview

Use the Vercel preview deployment for this PR to review page layout before merging to production.