### PR TITLE
Add demo mode disclosure for advisor-safe product demos

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,3 +4,7 @@
 # Production example:
 # NEXT_PUBLIC_API_BASE_URL=https://your-backend-host.example.com
 NEXT_PUBLIC_API_BASE_URL=
+
+# Set to true when showing the platform before official JSE data/API authorization.
+# This displays demo disclosures so advisors/testers understand the data is sample/transformed.
+NEXT_PUBLIC_DEMO_MODE=true

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -50,6 +50,18 @@ NEXT_PUBLIC_API_BASE_URL=https://your-backend-host.example.com
 
 If this variable is not set, the frontend still deploys and shows a frontend-ready status. API-backed product screens can be connected after the backend is hosted.
 
+## Demo mode
+
+Until official JSE data authorization/API access is confirmed, use demo mode when showing the site to advisors, testers, partners, or potential users.
+
+Set:
+
+```text
+NEXT_PUBLIC_DEMO_MODE=true
+```
+
+Demo mode displays a banner and `/demo` explanation page clarifying that the current experience uses sample or transformed historical data for product demonstration. It is not an official live JSE feed and is not financial advice.
+
 ## Product guardrails
 
 This frontend should preserve JSE Market Lab's positioning:
@@ -60,3 +72,4 @@ This frontend should preserve JSE Market Lab's positioning:
 - no guaranteed returns
 - user agency remains clear
 - missing or weak data should be disclosed
+- demo mode must not imply official JSE API/data authorization

--- a/frontend/app/demo/page.tsx
+++ b/frontend/app/demo/page.tsx
@@ -1,0 +1,118 @@
+import Link from 'next/link';
+import { InfoCard } from '@/components/shared/InfoCard';
+import { DEMO_MODE_MESSAGE } from '@/lib/demoMode';
+
+const demoSurfaces = [
+  'Portfolio Plan',
+  'Ticker Analysis',
+  'Decision Audit',
+  'Company Pages concept',
+  'Market Pulse concept',
+  'Research Hub concept',
+  'Setup Tester concept',
+  'AI Helper concept',
+];
+
+const notYetLive = [
+  'Official JSE API integration',
+  'Broker referral routing',
+  'Trade execution',
+  'User accounts or saved portfolios',
+  'Paid research or sponsored placements',
+  'Public AI helper responses',
+];
+
+export default function DemoPage() {
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Demo Mode</span>
+        <h1>What this demo is showing.</h1>
+        <p>{DEMO_MODE_MESSAGE}</p>
+      </section>
+
+      <section className="grid">
+        <InfoCard title="What is real" label="Working product">
+          <p>
+            The Vercel frontend, Render FastAPI backend, and API-backed Portfolio, Ticker Analysis,
+            and Decision Audit pages are working product surfaces.
+          </p>
+        </InfoCard>
+        <InfoCard title="What is sample/demo" label="Data status">
+          <p>
+            The current market data should be treated as internal sample or transformed historical data
+            for demonstration until official data rights and API access are confirmed.
+          </p>
+        </InfoCard>
+        <InfoCard title="What this is not" label="Boundary">
+          <p>
+            This is not financial advice, not an official JSE data feed, not broker/dealer activity, and
+            not a live trading system.
+          </p>
+        </InfoCard>
+      </section>
+
+      <section className="hero compact">
+        <span className="eyebrow">Advisor demo flow</span>
+        <h2>Suggested walkthrough</h2>
+        <p>
+          Use this order when showing the product to an advisor, partner, tester, or potential user.
+        </p>
+      </section>
+
+      <section className="grid">
+        <InfoCard title="1. Start Here" label="Context">
+          <p>Explain the product: market intelligence and decision support for Jamaican investors.</p>
+        </InfoCard>
+        <InfoCard title="2. Portfolio Plan" label="Decision engine">
+          <p>Show how capital, funded setups, unfunded setups, and reserve cash are structured.</p>
+        </InfoCard>
+        <InfoCard title="3. Ticker Analysis" label="Single-company view">
+          <p>Open one ticker to show holding windows, risk context, and what to review.</p>
+        </InfoCard>
+        <InfoCard title="4. Decision Audit" label="Trust layer">
+          <p>Explain why the plan looks the way it does and how the rules guide discipline.</p>
+        </InfoCard>
+        <InfoCard title="5. Future platform" label="Expansion">
+          <p>Discuss Research Hub, Company Pages, Market Pulse, Setup Tester, and AI Helper concepts.</p>
+        </InfoCard>
+        <InfoCard title="6. Compliance path" label="Before launch">
+          <p>Explain that JSE/FSC/legal validation is needed before official data, referrals, or monetization.</p>
+        </InfoCard>
+      </section>
+
+      <section className="grid two">
+        <InfoCard title="Demo surfaces" label="Can be shown">
+          <div className="list-stack">
+            {demoSurfaces.map((surface) => (
+              <p key={surface}>{surface}</p>
+            ))}
+          </div>
+        </InfoCard>
+        <InfoCard title="Not live yet" label="Gated">
+          <div className="list-stack">
+            {notYetLive.map((item) => (
+              <p key={item}>{item}</p>
+            ))}
+          </div>
+        </InfoCard>
+      </section>
+
+      <div className="notice warning">
+        <p>
+          Before public launch, JSE Market Lab still needs validation around data rights, research
+          hosting, broker access flows, sponsored content, paid products, and AI-assisted explanations.
+        </p>
+      </div>
+
+      <div className="button-row">
+        <Link className="button" href="/portfolio">
+          View Portfolio Plan
+        </Link>
+        <Link className="button secondary" href="/ticker/JMMBGL">
+          Open Ticker Analysis
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -29,6 +29,29 @@ a {
   padding: 32px 20px 56px;
 }
 
+.demo-banner {
+  background: var(--warning-soft);
+  border-bottom: 1px solid #f59e0b;
+  color: var(--warning-text);
+  font-size: 14px;
+}
+
+.demo-banner-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 10px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.demo-banner a {
+  font-weight: 800;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
 .navbar {
   border-bottom: 1px solid var(--border);
   background: var(--surface);
@@ -202,6 +225,11 @@ p {
 }
 
 @media (max-width: 780px) {
+  .demo-banner-inner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
   .navbar-inner {
     align-items: flex-start;
     flex-direction: column;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import { Navigation } from '@/components/layout/Navigation';
+import { DemoModeBanner } from '@/components/shared/DemoModeBanner';
 
 export const metadata: Metadata = {
   title: 'JSE Market Lab',
@@ -11,6 +12,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
+        <DemoModeBanner />
         <Navigation />
         <main>{children}</main>
       </body>

--- a/frontend/components/layout/Navigation.tsx
+++ b/frontend/components/layout/Navigation.tsx
@@ -5,6 +5,7 @@ const links = [
   { href: '/portfolio', label: 'Portfolio Plan' },
   { href: '/ticker/JMMBGL', label: 'Ticker Analysis' },
   { href: '/review', label: 'Review' },
+  { href: '/demo', label: 'Demo Mode' },
 ];
 
 export function Navigation() {

--- a/frontend/components/shared/DemoModeBanner.tsx
+++ b/frontend/components/shared/DemoModeBanner.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import { DEMO_MODE_MESSAGE, isDemoMode } from '@/lib/demoMode';
+
+export function DemoModeBanner() {
+  if (!isDemoMode()) {
+    return null;
+  }
+
+  return (
+    <div className="demo-banner" role="note">
+      <div className="demo-banner-inner">
+        <span>{DEMO_MODE_MESSAGE}</span>
+        <Link href="/demo">What this means</Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/demoMode.ts
+++ b/frontend/lib/demoMode.ts
@@ -1,0 +1,8 @@
+export function isDemoMode(): boolean {
+  return process.env.NEXT_PUBLIC_DEMO_MODE === 'true';
+}
+
+export const DEMO_MODE_MESSAGE =
+  'Demo Mode — This view uses sample or transformed historical data to demonstrate the product experience. It is not an official live JSE feed and is not financial advice.';
+
+export const DEMO_MODE_SHORT_LABEL = 'Demo mode';


### PR DESCRIPTION
## Summary

Adds a visible demo-mode disclosure layer so JSE Market Lab can be safely shown to advisors, testers, partners, and potential users before official JSE data/API authorization is confirmed.

This PR supports #144.

## What changed

Added:

```text
frontend/lib/demoMode.ts
frontend/components/shared/DemoModeBanner.tsx
frontend/app/demo/page.tsx
```

Updated:

```text
frontend/app/layout.tsx
frontend/components/layout/Navigation.tsx
frontend/app/globals.css
frontend/.env.example
frontend/README.md
```

## Product behavior

When this environment variable is set:

```text
NEXT_PUBLIC_DEMO_MODE=true
```

The frontend displays a persistent banner:

```text
Demo Mode — This view uses sample or transformed historical data to demonstrate the product experience. It is not an official live JSE feed and is not financial advice.
```

The banner links to:

```text
/demo
```

The `/demo` page explains:

- what is working product
- what is sample/demo data
- what is not live yet
- suggested advisor demo flow
- compliance/data-rights guardrails

## Why this matters

Until JSE data authorization/API access is confirmed, the product needs a safe demo state that does not imply:

- official live JSE data feed
- investment advice
- broker/dealer activity
- trade execution
- live production readiness

## How to test locally

From repo root:

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=https://jse-market-lab.onrender.com NEXT_PUBLIC_DEMO_MODE=true npm run dev
```

Open:

```text
http://localhost:3000
http://localhost:3000/demo
http://localhost:3000/portfolio
http://localhost:3000/ticker/JMMBGL
http://localhost:3000/review
```

Expected:

- global demo banner appears
- `/demo` page loads
- main API-backed pages still load
- banner copy is visible on desktop and mobile
- no buy/sell, prediction, or official-data claims are introduced

## Vercel setup after merge

Add this environment variable in Vercel:

```text
NEXT_PUBLIC_DEMO_MODE=true
```

Apply to Production and Preview if the preview should also show demo disclosures.

Then redeploy.

## Product guardrails

This PR does not add:

- official JSE API integration
- broker referral routing
- research hosting
- sponsored content
- trade execution
- user accounts
- AI helper
- paid products

It only adds disclosure and demo explanation UI.