### PR TITLE
Add demo mode platform preview for advisor walkthroughs

### DIFF
--- a/frontend/app/demo/page.tsx
+++ b/frontend/app/demo/page.tsx
@@ -6,6 +6,7 @@ const demoSurfaces = [
   'Portfolio Plan',
   'Ticker Analysis',
   'Decision Audit',
+  'Platform Preview',
   'Company Pages concept',
   'Market Pulse concept',
   'Research Hub concept',
@@ -73,8 +74,8 @@ export default function DemoPage() {
         <InfoCard title="4. Decision Audit" label="Trust layer">
           <p>Explain why the plan looks the way it does and how the rules guide discipline.</p>
         </InfoCard>
-        <InfoCard title="5. Future platform" label="Expansion">
-          <p>Discuss Research Hub, Company Pages, Market Pulse, Setup Tester, and AI Helper concepts.</p>
+        <InfoCard title="5. Platform Preview" label="Expansion">
+          <p>Show Research Hub, Company Pages, Market Pulse, Setup Tester, and AI Helper concepts.</p>
         </InfoCard>
         <InfoCard title="6. Compliance path" label="Before launch">
           <p>Explain that JSE/FSC/legal validation is needed before official data, referrals, or monetization.</p>
@@ -111,6 +112,9 @@ export default function DemoPage() {
         </Link>
         <Link className="button secondary" href="/ticker/JMMBGL">
           Open Ticker Analysis
+        </Link>
+        <Link className="button secondary" href="/platform-preview">
+          Open Platform Preview
         </Link>
       </div>
     </div>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -19,6 +19,9 @@ export default function HomePage() {
           <Link className="button secondary" href="/ticker/JMMBGL">
             Start with a ticker
           </Link>
+          <Link className="button secondary" href="/platform-preview">
+            See Platform Preview
+          </Link>
         </div>
       </section>
 
@@ -40,6 +43,12 @@ export default function HomePage() {
           <p>
             The review layer explains how ranking, quality, liquidity, and allocation rules shaped the
             plan. It supports discipline, not blind action.
+          </p>
+        </InfoCard>
+        <InfoCard title="Show the platform vision" label="Demo">
+          <p>
+            Use Demo Mode and Platform Preview when walking advisors, partners, or testers through the
+            product before official JSE data/API authorization is confirmed.
           </p>
         </InfoCard>
       </section>

--- a/frontend/app/platform-preview/page.tsx
+++ b/frontend/app/platform-preview/page.tsx
@@ -1,0 +1,121 @@
+import Link from 'next/link';
+import { InfoCard } from '@/components/shared/InfoCard';
+import { DEMO_MODE_MESSAGE } from '@/lib/demoMode';
+
+const futureModules = [
+  {
+    title: 'Research Hub',
+    label: 'Future surface',
+    body: 'A structured place to discover company research, market notes, source links, and saved reports once rights and hosting rules are validated.',
+  },
+  {
+    title: 'Company Pages',
+    label: 'Future surface',
+    body: 'Ticker-centered pages that combine company context, dashboard signals, dividend profile, earnings context, and tradability notes.',
+  },
+  {
+    title: 'Market Pulse',
+    label: 'Future surface',
+    body: 'A weekly market overview showing broad observations, unusual movement, liquidity warnings, and data-quality notes.',
+  },
+  {
+    title: 'Dividend View',
+    label: 'Future surface',
+    body: 'A focused view for income-oriented investors to track dividend notices, yield context, payment timing, and company patterns.',
+  },
+  {
+    title: 'Earnings Scorecard',
+    label: 'Future surface',
+    body: 'A research layer to help users review earnings events, company performance context, and post-result market behavior.',
+  },
+  {
+    title: 'Float / Tradability View',
+    label: 'Future surface',
+    body: 'A market-reality layer to help users understand whether a stock may be difficult to enter or exit because of float, volume, or liquidity.',
+  },
+  {
+    title: 'Setup Tester',
+    label: 'Future simulation',
+    body: 'A safe testing workflow where users can test an idea using historical market data without executing a trade or receiving advice.',
+  },
+  {
+    title: 'Paper Portfolio',
+    label: 'Future simulation',
+    body: 'A practice portfolio for tracking simulated positions, planned review dates, outcome review, and lessons learned.',
+  },
+  {
+    title: 'AI Helper',
+    label: 'Future assistant',
+    body: 'A grounded guide to help users navigate the platform, understand outputs, and review next steps without recommending trades.',
+  },
+];
+
+const gates = [
+  'Official JSE data rights / API access',
+  'Research hosting and source-use rules',
+  'Broker referral and account-opening boundaries',
+  'User profile privacy and database design',
+  'AI helper grounding and evaluation tests',
+  'Sponsored content and monetization disclosures',
+];
+
+export default function PlatformPreviewPage() {
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Platform Preview</span>
+        <h1>Where JSE Market Lab is going next.</h1>
+        <p>
+          This page shows future platform modules as mockups and product direction. These surfaces are
+          not fully launched features yet.
+        </p>
+      </section>
+
+      <div className="notice warning">
+        <p>{DEMO_MODE_MESSAGE}</p>
+      </div>
+
+      <section className="grid">
+        {futureModules.map((module) => (
+          <InfoCard key={module.title} title={module.title} label={module.label}>
+            <p>{module.body}</p>
+          </InfoCard>
+        ))}
+      </section>
+
+      <section className="hero compact">
+        <span className="eyebrow">Before these go live</span>
+        <h2>Compliance and data gates</h2>
+        <p>
+          These items need validation before the preview surfaces become public product features.
+        </p>
+      </section>
+
+      <section className="grid two">
+        <InfoCard title="What must be validated" label="Gates">
+          <div className="list-stack">
+            {gates.map((gate) => (
+              <p key={gate}>{gate}</p>
+            ))}
+          </div>
+        </InfoCard>
+        <InfoCard title="What can be shown now" label="Demo-safe">
+          <p>
+            The current demo can show the platform vision, decision-support workflow, API-backed core
+            dashboard pages, and future module concepts. It should not imply official live JSE data,
+            broker approval, or investment advice.
+          </p>
+        </InfoCard>
+      </section>
+
+      <div className="button-row">
+        <Link className="button" href="/demo">
+          View Demo Mode Guide
+        </Link>
+        <Link className="button secondary" href="/portfolio">
+          Back to Portfolio Plan
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/layout/Navigation.tsx
+++ b/frontend/components/layout/Navigation.tsx
@@ -6,6 +6,7 @@ const links = [
   { href: '/ticker/JMMBGL', label: 'Ticker Analysis' },
   { href: '/review', label: 'Review' },
   { href: '/demo', label: 'Demo Mode' },
+  { href: '/platform-preview', label: 'Platform Preview' },
 ];
 
 export function Navigation() {


### PR DESCRIPTION
## Summary

Adds a Platform Preview page and connects it to the existing Demo Mode flow so JSE Market Lab can be shown safely to advisors, partners, testers, and potential users before official JSE authorization/API integration is confirmed.

This keeps the distinction clear between:

- working API-backed product surfaces
- sample/internal/demo data
- future platform modules
- compliance-gated functionality

## What changed

Updated:

```text
frontend/components/layout/Navigation.tsx
frontend/app/page.tsx
frontend/app/demo/page.tsx
```

Added:

```text
frontend/app/platform-preview/page.tsx
```

## New Platform Preview page

The page safely previews future modules:

- Research Hub
- Company Pages
- Market Pulse
- Dividend View
- Earnings Scorecard
- Float / Tradability View
- Setup Tester
- Paper Portfolio
- AI Helper

Each is clearly marked as a future surface, future simulation, or future assistant.

## Demo and compliance guardrails

The preview explains that the platform still needs validation around:

- official JSE data rights / API access
- research hosting and source-use rules
- broker referral and account-opening boundaries
- user profile privacy and database design
- AI helper grounding and evaluation tests
- sponsored content and monetization disclosures

## Product guardrails

This PR does not add:

- official JSE API integration
- live data claims
- broker referral routing
- trade execution
- user accounts
- paid research
- public AI helper functionality
- buy/sell recommendations

## How to test locally

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=https://jse-market-lab.onrender.com NEXT_PUBLIC_DEMO_MODE=true npm run dev
```

Open:

```text
http://localhost:3000/
http://localhost:3000/demo
http://localhost:3000/platform-preview
```

Expected:

- homepage links to Platform Preview
- navigation includes Platform Preview
- Demo Mode guide links to Platform Preview
- Platform Preview loads future-module cards
- demo/data-rights language is clear
- no feature implies official JSE authorization, advice, broker recommendation, or trade execution

## Related issue

Related to #149.