### PR TITLE
Align neutral cost profiles across engine API frontend and docs

### DIFF
--- a/app/costs/profiles.py
+++ b/app/costs/profiles.py
@@ -1,19 +1,113 @@
-"""Broker cost profiles."""
+"""Broker and planning cost profiles.
+
+The profiles in this module are planning estimates, not fee guarantees.
+Actual fees may vary by broker, channel, transaction size, taxes, and account terms.
+"""
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, TypedDict
 
 
-DEFAULT_PROFILE = {"broker_fee": 0.001, "cess": 0.0005}
+class CostProfile(TypedDict):
+    """Cost profile values expressed as decimal rates."""
 
-PROFILES: Dict[str, Dict[str, float]] = {
-    "Default": DEFAULT_PROFILE,
+    broker_fee: float
+    cess: float
+
+
+class CostProfileMetadata(TypedDict):
+    """User-facing profile metadata."""
+
+    key: str
+    label: str
+    broker_fee: float
+    cess: float
+    verification_status: str
+    source: str
+    note: str
+
+
+DEFAULT_PROFILE_KEY = "conservative_estimate"
+
+# Preserve the legacy profile for backwards compatibility and historical comparisons.
+LEGACY_DEFAULT_PROFILE: CostProfile = {"broker_fee": 0.001, "cess": 0.0005}
+
+# Neutral planning profiles. These should not imply that any broker is preferred.
+PROFILES: Dict[str, CostProfileMetadata] = {
+    "legacy_default": {
+        "key": "legacy_default",
+        "label": "Legacy default estimate",
+        "broker_fee": 0.001,
+        "cess": 0.0005,
+        "verification_status": "legacy_internal",
+        "source": "Existing engine default retained for compatibility",
+        "note": "Historical internal default. Do not treat as a universal broker fee.",
+    },
+    "low_cost_estimate": {
+        "key": "low_cost_estimate",
+        "label": "Low-cost estimate",
+        "broker_fee": 0.005,
+        "cess": 0.0035,
+        "verification_status": "planning_estimate",
+        "source": "Internal planning assumption pending broker verification",
+        "note": "Illustrative estimate only. Confirm actual fees with the selected licensed broker.",
+    },
+    "conservative_estimate": {
+        "key": "conservative_estimate",
+        "label": "Conservative estimate",
+        "broker_fee": 0.02,
+        "cess": 0.0035,
+        "verification_status": "planning_estimate",
+        "source": "Internal planning assumption pending broker verification",
+        "note": "Higher-fee planning estimate for stress-testing costs. Confirm actual fees with the selected licensed broker.",
+    },
+    "high_cost_estimate": {
+        "key": "high_cost_estimate",
+        "label": "High-cost estimate",
+        "broker_fee": 0.025,
+        "cess": 0.0035,
+        "verification_status": "planning_estimate",
+        "source": "Internal planning assumption pending broker verification",
+        "note": "Upper-range planning estimate for cost sensitivity review. Confirm actual fees with the selected licensed broker.",
+    },
+}
+
+# Backwards-compatible constant used by older engine helpers.
+DEFAULT_PROFILE: CostProfile = {
+    "broker_fee": PROFILES[DEFAULT_PROFILE_KEY]["broker_fee"],
+    "cess": PROFILES[DEFAULT_PROFILE_KEY]["cess"],
 }
 
 
-def get_profile(name: str) -> Dict[str, float]:
-    """Return the cost profile for the given broker name."""
-    if name not in PROFILES:
-        raise ValueError(f"Unknown broker profile: {name}")
-    return PROFILES[name].copy()
+def get_profile(name: str | None = None) -> CostProfile:
+    """Return the cost profile rates for the given profile key or label."""
+    metadata = get_profile_metadata(name)
+    return {"broker_fee": metadata["broker_fee"], "cess": metadata["cess"]}
+
+
+def get_profile_metadata(name: str | None = None) -> CostProfileMetadata:
+    """Return profile metadata for the given profile key or label."""
+    profile_name = (name or DEFAULT_PROFILE_KEY).strip()
+    if profile_name in PROFILES:
+        return PROFILES[profile_name].copy()
+
+    normalized = profile_name.lower()
+    for profile in PROFILES.values():
+        if profile["label"].lower() == normalized:
+            return profile.copy()
+
+    raise ValueError(f"Unknown broker or cost profile: {name}")
+
+
+def list_profiles() -> list[CostProfileMetadata]:
+    """Return all available neutral cost profiles."""
+    return [profile.copy() for profile in PROFILES.values()]
+
+
+def get_cost_disclaimer() -> str:
+    """Return the standard cost-profile disclaimer."""
+    return (
+        "Estimated costs are based on the selected cost profile. Actual fees may vary by broker, "
+        "channel, transaction size, taxes, and account terms. Confirm fees with your licensed broker before acting."
+    )

--- a/app/costs/profiles.py
+++ b/app/costs/profiles.py
@@ -33,6 +33,12 @@ DEFAULT_PROFILE_KEY = "conservative_estimate"
 # Preserve the legacy profile for backwards compatibility and historical comparisons.
 LEGACY_DEFAULT_PROFILE: CostProfile = {"broker_fee": 0.001, "cess": 0.0005}
 
+# Older engine code may still request this exact profile name.
+LEGACY_PROFILE_ALIASES = {
+    "default": "legacy_default",
+    "Default": "legacy_default",
+}
+
 # Neutral planning profiles. These should not imply that any broker is preferred.
 PROFILES: Dict[str, CostProfileMetadata] = {
     "legacy_default": {
@@ -89,6 +95,10 @@ def get_profile(name: str | None = None) -> CostProfile:
 def get_profile_metadata(name: str | None = None) -> CostProfileMetadata:
     """Return profile metadata for the given profile key or label."""
     profile_name = (name or DEFAULT_PROFILE_KEY).strip()
+    alias_key = LEGACY_PROFILE_ALIASES.get(profile_name) or LEGACY_PROFILE_ALIASES.get(profile_name.lower())
+    if alias_key:
+        return PROFILES[alias_key].copy()
+
     if profile_name in PROFILES:
         return PROFILES[profile_name].copy()
 

--- a/app/demo/run_demo.py
+++ b/app/demo/run_demo.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pandas as pd
 
 from app.costs.engine import run_cost_engine
+from app.costs.profiles import DEFAULT_PROFILE_KEY
 from app.data.ingest import ingest_dataset
 from app.demo.language import get_explanatory_copy
 from app.events.earnings import tag_earnings_phase
@@ -33,6 +34,7 @@ def run_demo(
     canonical_df: pd.DataFrame | None = None,
     meta: dict | None = None,
     issues: dict | None = None,
+    cost_profile: str = DEFAULT_PROFILE_KEY,
 ) -> dict:
     """Run ingestion, cost, ranking, and phase metrics for demo data."""
     if canonical_df is None or meta is None or issues is None:
@@ -42,9 +44,10 @@ def run_demo(
 
     entries = canonical[["instrument", "date"]].rename(columns={"date": "entry_date"})
 
-    trades, summary_instrument, _, _ = run_cost_engine(
+    trades, summary_instrument, _, cost_config = run_cost_engine(
         df_prices=canonical,
         df_entries=entries,
+        broker_profile=cost_profile,
     )
     ranked = rank_instruments(summary_instrument, meta, "income_stability")
 
@@ -68,10 +71,9 @@ def run_demo(
         artifacts_dir.mkdir(parents=True, exist_ok=True)
         ranked.to_csv(artifacts_dir / "ranked.csv", index=False)
         phase_metrics.to_csv(artifacts_dir / "phase_metrics.csv", index=False)
-        meta_payload = {"meta": meta, "issues": issues}
+        meta_payload = {"meta": meta, "issues": issues, "cost_config": cost_config}
         (artifacts_dir / "meta.json").write_text(json.dumps(meta_payload, indent=2))
     except PermissionError as exc:
-        # Continue when running in restricted environments where local writes are unavailable.
         logger.warning("Demo artifacts not written due to restricted filesystem permissions: %s", exc)
     except OSError as exc:
         if exc.errno == errno.EROFS:
@@ -84,6 +86,7 @@ def run_demo(
         "phase_metrics": phase_metrics,
         "meta": meta,
         "issues": issues,
+        "cost_config": cost_config,
         "language_mode": language_mode,
         "explanatory_copy": get_explanatory_copy(language_mode),
     }

--- a/backend/app/api/routes_portfolio.py
+++ b/backend/app/api/routes_portfolio.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
 from backend.app.schemas.portfolio import PortfolioPlanRequest
 from backend.app.services.portfolio_service import get_portfolio_plan
@@ -10,8 +10,11 @@ router = APIRouter(prefix="/api/portfolio")
 
 @router.post("/plan")
 def create_portfolio_plan(request: PortfolioPlanRequest) -> dict:
-    return get_portfolio_plan(
-        capital=request.capital,
-        mode=request.mode,
-        cost_profile=request.cost_profile,
-    )
+    try:
+        return get_portfolio_plan(
+            capital=request.capital,
+            mode=request.mode,
+            cost_profile=request.cost_profile,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/backend/app/api/routes_portfolio.py
+++ b/backend/app/api/routes_portfolio.py
@@ -10,4 +10,8 @@ router = APIRouter(prefix="/api/portfolio")
 
 @router.post("/plan")
 def create_portfolio_plan(request: PortfolioPlanRequest) -> dict:
-    return get_portfolio_plan(capital=request.capital, mode=request.mode)
+    return get_portfolio_plan(
+        capital=request.capital,
+        mode=request.mode,
+        cost_profile=request.cost_profile,
+    )

--- a/backend/app/schemas/portfolio.py
+++ b/backend/app/schemas/portfolio.py
@@ -10,3 +10,4 @@ class PortfolioPlanRequest(BaseModel):
 
     capital: float = Field(default=100_000.0, ge=0)
     mode: str = "guided"
+    cost_profile: str = "conservative_estimate"

--- a/backend/app/services/engine_context.py
+++ b/backend/app/services/engine_context.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from app.analysis.ticker_drilldown import build_ticker_drilldown
 from app.analysis.ticker_intelligence import compute_ticker_metrics
+from app.costs.profiles import DEFAULT_PROFILE_KEY
 from app.data.ingest import ingest_dataset
 from app.data.processor import canonicalize_symbol
 from app.demo.run_demo import run_demo
@@ -18,11 +19,16 @@ from app.shell import build_analyst_dataset, coerce_trade_rows_from_ranked
 from backend.app.core.config import DEFAULT_DATASET, normalize_mode
 
 
-@lru_cache(maxsize=1)
-def get_engine_context() -> dict[str, Any]:
-    """Load the canonical dataset and derived demo outputs once per API process."""
+@lru_cache(maxsize=8)
+def get_engine_context(cost_profile: str = DEFAULT_PROFILE_KEY) -> dict[str, Any]:
+    """Load the canonical dataset and derived demo outputs by cost profile."""
     canonical_df, meta, issues = ingest_dataset(DEFAULT_DATASET)
-    payload = run_demo(canonical_df=canonical_df, meta=meta, issues=issues)
+    payload = run_demo(
+        canonical_df=canonical_df,
+        meta=meta,
+        issues=issues,
+        cost_profile=cost_profile,
+    )
     ranked_df = payload.get("ranked", pd.DataFrame())
     analyst_df = build_analyst_dataset(canonical_df, ranked_df)
     trade_rows = coerce_trade_rows_from_ranked(ranked_df) if not ranked_df.empty else []
@@ -30,15 +36,20 @@ def get_engine_context() -> dict[str, Any]:
         "canonical_df": canonical_df,
         "meta": meta or {},
         "issues": issues or {},
+        "cost_config": payload.get("cost_config", {}),
         "ranked_df": ranked_df,
         "analyst_df": analyst_df,
         "trade_rows": trade_rows,
     }
 
 
-def build_allocation_payload(capital: float, mode: str | None) -> dict[str, Any]:
+def build_allocation_payload(
+    capital: float,
+    mode: str | None,
+    cost_profile: str = DEFAULT_PROFILE_KEY,
+) -> dict[str, Any]:
     """Return allocations enriched with source trade rows."""
-    context = get_engine_context()
+    context = get_engine_context(cost_profile)
     trade_rows = context["trade_rows"]
     allocation_payload = generate_portfolio_allocation(
         trade_rows,
@@ -50,6 +61,7 @@ def build_allocation_payload(capital: float, mode: str | None) -> dict[str, Any]
     return {
         "allocations": enriched,
         "allocation_summary": allocation_payload,
+        "cost_config": context.get("cost_config", {}),
     }
 
 

--- a/backend/app/services/portfolio_service.py
+++ b/backend/app/services/portfolio_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.costs.profiles import get_cost_disclaimer, get_profile_metadata
 from backend.app.core.config import DISCLAIMER, public_mode
 from backend.app.services.engine_context import build_allocation_payload
 
@@ -51,7 +52,25 @@ def _trade_response(row: dict[str, Any], *, mode: str | None) -> dict[str, Any]:
     }
 
 
-def get_portfolio_plan(capital: float, mode: str | None = None) -> dict[str, Any]:
+def _cost_profile_payload(cost_profile: str | None) -> dict[str, Any]:
+    profile = get_profile_metadata(cost_profile)
+    return {
+        "key": profile["key"],
+        "label": profile["label"],
+        "broker_fee": profile["broker_fee"],
+        "cess": profile["cess"],
+        "verification_status": profile["verification_status"],
+        "source": profile["source"],
+        "note": profile["note"],
+        "disclaimer": get_cost_disclaimer(),
+    }
+
+
+def get_portfolio_plan(
+    capital: float,
+    mode: str | None = None,
+    cost_profile: str | None = None,
+) -> dict[str, Any]:
     """Return funded and unfunded portfolio plan data for the API."""
     safe_capital = max(float(capital or 0.0), 0.0)
     payload = build_allocation_payload(safe_capital, mode)
@@ -67,6 +86,7 @@ def get_portfolio_plan(capital: float, mode: str | None = None) -> dict[str, Any
     return {
         "capital": safe_capital,
         "mode": public_mode(mode),
+        "cost_profile": _cost_profile_payload(cost_profile),
         "funded_trades": funded,
         "unfunded_trades": unfunded,
         "reserve_cash": reserve_cash,

--- a/backend/app/services/portfolio_service.py
+++ b/backend/app/services/portfolio_service.py
@@ -73,7 +73,8 @@ def get_portfolio_plan(
 ) -> dict[str, Any]:
     """Return funded and unfunded portfolio plan data for the API."""
     safe_capital = max(float(capital or 0.0), 0.0)
-    payload = build_allocation_payload(safe_capital, mode)
+    cost_profile_payload = _cost_profile_payload(cost_profile)
+    payload = build_allocation_payload(safe_capital, mode, cost_profile_payload["key"])
     allocations = payload["allocations"]
     summary_payload = payload["allocation_summary"]
 
@@ -86,7 +87,7 @@ def get_portfolio_plan(
     return {
         "capital": safe_capital,
         "mode": public_mode(mode),
-        "cost_profile": _cost_profile_payload(cost_profile),
+        "cost_profile": cost_profile_payload,
         "funded_trades": funded,
         "unfunded_trades": unfunded,
         "reserve_cash": reserve_cash,

--- a/data/reference/broker_fee_profiles.csv
+++ b/data/reference/broker_fee_profiles.csv
@@ -1,0 +1,16 @@
+broker_name,channel,broker_commission_pct,minimum_fee_jmd,cess_pct,other_exchange_or_trade_fee_pct,gct_applies,source_url,source_date,verification_status,notes
+Barita Investments Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+BPM Financial Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+CUMAX Wealth Management Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+FHC Investments Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+GK Capital Management Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+Ideal Securities Broker Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+JMMB Securities Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+JN Fund Managers Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+M/VL Stockbrokers Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+Mayberry Investments Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+NCB Capital Markets Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+Proven Wealth Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+Sagicor Investments Jamaica Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+Scotia Investments Jamaica Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.
+VM Wealth Management Limited,Unverified,,,,,,,,unavailable_confirm_with_broker,Confirm official fee schedule directly with broker before using in product outputs.

--- a/docs/cost_assumptions_alignment.md
+++ b/docs/cost_assumptions_alignment.md
@@ -2,21 +2,61 @@
 
 ## Purpose
 
-This note records a current mismatch between product/planning assumptions and the active engine cost defaults.
+This note records the platform direction for aligning cost assumptions across the engine, API, frontend, documentation, and future simulation workflows.
 
 It exists so future setup-testing, paper-portfolio, portfolio-economics, and API work do not accidentally mix different fee assumptions.
 
 ---
 
-## Current Engine Defaults
+## Current Direction
 
-The active default cost profile currently lives in:
+JSE Market Lab should not use one broker as the universal default.
+
+Broker fees can vary by:
+
+- broker
+- trading channel
+- manual vs online workflow
+- transaction size
+- account type
+- taxes and other charges
+- future platform changes such as JTrader or broker portals
+
+Therefore, the product should support:
+
+1. Neutral planning profiles
+2. Broker-specific profiles only where verified
+3. A custom estimate / range-slider direction later
+4. Clear disclosure that all costs are estimates until confirmed by the broker
+
+---
+
+## Neutral Cost Profiles
+
+The active cost profile source lives in:
 
 ```text
 app/costs/profiles.py
 ```
 
-Current implementation:
+The product should use neutral names such as:
+
+```text
+Legacy default estimate
+Low-cost estimate
+Conservative estimate
+High-cost estimate
+Custom estimate, future
+Select broker profile, future once verified
+```
+
+Avoid naming a broker as the default planning profile.
+
+---
+
+## Legacy Engine Default
+
+The earlier engine default was:
 
 ```python
 DEFAULT_PROFILE = {"broker_fee": 0.001, "cess": 0.0005}
@@ -25,30 +65,55 @@ DEFAULT_PROFILE = {"broker_fee": 0.001, "cess": 0.0005}
 This equals:
 
 ```text
-Broker fee: 0.10%
-CESS: 0.05%
+Service charge estimate: 0.10%
+Market charge estimate: 0.05%
 ```
 
-These are the values currently used by existing backend calculations unless another profile is introduced.
+This should be treated as a legacy internal estimate, not a universal market fee.
 
 ---
 
-## Product / Planning Assumption
+## Planning Estimates
 
-Several product strategy and platform-planning notes refer to a future or target planning assumption:
+Several product strategy and platform-planning notes previously referred to:
 
 ```text
 Broker fee: 0.50%
 CESS: 0.35%
 ```
 
-These values should be treated as target/planning assumptions until the engine profile is explicitly updated and tested.
+These should now be treated as one possible planning estimate, not a universal broker profile and not a default named after any one broker.
+
+---
+
+## Broker Fee Research Table
+
+A broker fee research scaffold exists at:
+
+```text
+data/reference/broker_fee_profiles.csv
+```
+
+This file should capture:
+
+- broker name
+- channel
+- broker commission percentage
+- minimum fee, if known
+- market/exchange/cess assumptions, if stated
+- tax treatment, if stated
+- source URL
+- source date
+- verification status
+- notes
+
+Broker-specific fee profiles should only be exposed in the product after values are verified from official broker materials or direct broker confirmation.
 
 ---
 
 ## Product Risk
 
-If future Setup Tester, Paper Portfolio, Portfolio Economics, or frontend P/L views use the planning assumptions while the backend engine uses the current defaults, simulated net return and JMD P/L outputs will diverge.
+If future Setup Tester, Paper Portfolio, Portfolio Economics, or frontend P/L views use one assumption while backend logic uses another, simulated net return and JMD P/L outputs will diverge.
 
 This could confuse users and weaken trust.
 
@@ -56,47 +121,52 @@ This could confuse users and weaken trust.
 
 ## Required Follow-Up
 
-Create a separate implementation PR to decide and align cost profiles.
+Cost work should continue in stages:
 
-That PR should:
-
-1. Confirm the intended broker fee and CESS assumptions.
-2. Decide whether to update `DEFAULT_PROFILE` or add named broker profiles.
-3. Update tests for cost calculations.
-4. Update all product docs to distinguish current defaults from planning assumptions.
+1. Keep neutral cost profiles explicit in the engine/API/frontend.
+2. Research broker-specific fee schedules from official sources.
+3. Mark unverified broker data as unavailable / confirm with broker.
+4. Add a custom estimate slider later.
 5. Ensure portfolio, ticker, review, setup testing, and paper portfolio outputs use the same source of truth.
 
 ---
 
-## Recommended Direction
+## Recommended UI Direction
 
-Prefer named cost profiles instead of silently changing defaults.
+Use a cost selector with options such as:
 
-Example:
-
-```python
-PROFILES = {
-    "Default": {"broker_fee": 0.001, "cess": 0.0005},
-    "JMMB planning": {"broker_fee": 0.005, "cess": 0.0035},
-}
+```text
+Cost profile:
+- Low-cost estimate
+- Conservative estimate
+- High-cost estimate
+- Custom estimate, future
+- Select broker profile, future once verified
 ```
 
-This allows the dashboard to preserve historical behavior while introducing clearer real-world broker assumptions.
+For custom estimate later:
+
+```text
+Service charge slider
+Market charge / fee slider
+Minimum fee field, optional
+Other charges / taxes field, optional
+```
 
 ---
 
 ## Product Language Rule
 
-Until the cost engine is aligned, user-facing outputs should avoid implying that one fee profile is universal.
-
 Use:
 
 ```text
-Estimated costs are based on the selected cost profile.
+Estimated costs are based on the selected cost profile. Actual fees may vary by broker, channel, transaction size, taxes, and account terms. Confirm fees with your licensed broker before acting.
 ```
 
 Avoid:
 
 ```text
 These are the exact fees every investor will pay.
+This broker is best.
+This broker should be used by default.
 ```

--- a/frontend/app/portfolio/page.tsx
+++ b/frontend/app/portfolio/page.tsx
@@ -5,6 +5,7 @@ import { formatJmd, formatPercent } from '@/lib/formatters';
 import type { Trade } from '@/lib/types';
 
 const DEFAULT_CAPITAL = 100000;
+const DEFAULT_COST_PROFILE = 'conservative_estimate';
 
 function TradeCard({ trade, label }: { trade: Trade; label: string }) {
   return (
@@ -25,7 +26,7 @@ export default async function PortfolioPage() {
   let error: string | null = null;
 
   try {
-    plan = await getPortfolioPlan(DEFAULT_CAPITAL, 'guided');
+    plan = await getPortfolioPlan(DEFAULT_CAPITAL, 'guided', DEFAULT_COST_PROFILE);
   } catch {
     error = 'Portfolio plan data is not available right now. Please try again after the API is reachable.';
   }
@@ -58,14 +59,20 @@ export default async function PortfolioPage() {
               <MetricRow label="Unallocated cash" value={formatJmd(plan.reserve_cash)} />
               <p>Reserve cash is part of the plan when not enough setups meet the rules.</p>
             </InfoCard>
-            <InfoCard title="Unfunded setups" label="Discipline">
-              <MetricRow label="Held back by rules" value={plan.summary.unfunded_count} />
-              <p>Unfunded does not mean ignored. It means the rules held back capital.</p>
+            <InfoCard title="Cost assumptions" label="Estimate">
+              <MetricRow label="Profile" value={plan.cost_profile.label} />
+              <MetricRow label="Service charge" value={formatPercent(plan.cost_profile.broker_fee)} />
+              <MetricRow label="Market charge" value={formatPercent(plan.cost_profile.cess)} />
+              <p>{plan.cost_profile.note}</p>
             </InfoCard>
           </section>
 
           <div className="notice">
             <p>{plan.disclaimer}</p>
+          </div>
+
+          <div className="notice warning">
+            <p>{plan.cost_profile.disclaimer}</p>
           </div>
 
           <section className="hero compact">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -27,10 +27,14 @@ export function getDataStatus(): Promise<DataStatus> {
   return apiFetch<DataStatus>('/api/data/status');
 }
 
-export function getPortfolioPlan(capital: number, mode: ViewMode = 'guided'): Promise<PortfolioPlan> {
+export function getPortfolioPlan(
+  capital: number,
+  mode: ViewMode = 'guided',
+  costProfile = 'conservative_estimate',
+): Promise<PortfolioPlan> {
   return apiFetch<PortfolioPlan>('/api/portfolio/plan', {
     method: 'POST',
-    body: JSON.stringify({ capital, mode }),
+    body: JSON.stringify({ capital, mode, cost_profile: costProfile }),
   });
 }
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,5 +1,16 @@
 export type ViewMode = 'guided' | 'advanced';
 
+export type CostProfile = {
+  key: string;
+  label: string;
+  broker_fee: number;
+  cess: number;
+  verification_status: string;
+  source: string;
+  note: string;
+  disclaimer: string;
+};
+
 export type Trade = {
   ticker: string;
   company_name: string;
@@ -18,6 +29,7 @@ export type Trade = {
 export type PortfolioPlan = {
   capital: number;
   mode: ViewMode;
+  cost_profile: CostProfile;
   funded_trades: Trade[];
   unfunded_trades: Trade[];
   reserve_cash: number;

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
+from app.costs.profiles import get_profile
 from backend.app.core.config import get_cors_origins
 from backend.main import app
 
@@ -50,6 +51,10 @@ def test_cors_origins_can_be_configured_from_environment(monkeypatch) -> None:
         "https://jse-market-lab.vercel.app",
         "http://localhost:3000",
     ]
+
+
+def test_legacy_default_cost_profile_alias_still_resolves() -> None:
+    assert get_profile("Default") == {"broker_fee": 0.001, "cess": 0.0005}
 
 
 def test_data_status_endpoint_returns_required_fields() -> None:
@@ -101,6 +106,20 @@ def test_portfolio_plan_returns_selected_cost_profile_metadata() -> None:
     assert cost_profile["verification_status"] == "planning_estimate"
     assert "Confirm fees with your licensed broker" in cost_profile["disclaimer"]
     _assert_safe_language(cost_profile)
+
+
+def test_invalid_portfolio_cost_profile_returns_client_error() -> None:
+    response = client.post(
+        "/api/portfolio/plan",
+        json={
+            "capital": 100000,
+            "mode": "guided",
+            "cost_profile": "high-cost",
+        },
+    )
+
+    assert response.status_code == 422
+    assert "Unknown broker or cost profile" in response.json()["detail"]
 
 
 def test_ticker_analysis_endpoint_returns_decision_support_payload() -> None:

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -76,8 +76,31 @@ def test_portfolio_plan_endpoint_returns_decision_support_payload() -> None:
     assert "unfunded_trades" in payload
     assert "reserve_cash" in payload
     assert "summary" in payload
+    assert "cost_profile" in payload
     assert payload["disclaimer"] == "This is decision support, not financial advice."
     _assert_safe_language(payload)
+
+
+def test_portfolio_plan_returns_selected_cost_profile_metadata() -> None:
+    response = client.post(
+        "/api/portfolio/plan",
+        json={
+            "capital": 100000,
+            "mode": "guided",
+            "cost_profile": "high_cost_estimate",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    cost_profile = payload["cost_profile"]
+    assert cost_profile["key"] == "high_cost_estimate"
+    assert cost_profile["label"] == "High-cost estimate"
+    assert cost_profile["broker_fee"] == 0.025
+    assert cost_profile["cess"] == 0.0035
+    assert cost_profile["verification_status"] == "planning_estimate"
+    assert "Confirm fees with your licensed broker" in cost_profile["disclaimer"]
+    _assert_safe_language(cost_profile)
 
 
 def test_ticker_analysis_endpoint_returns_decision_support_payload() -> None:


### PR DESCRIPTION
## Summary

Aligns cost assumptions across the engine, API, frontend, tests, and docs using neutral cost profiles instead of naming or implying any broker as the default.

This keeps cost estimates explicit and user-safe before future Setup Tester, Paper Portfolio, Portfolio Economics, or simulated P/L work.

## What changed

Updated:

```text
app/costs/profiles.py
backend/app/api/routes_portfolio.py
backend/app/schemas/portfolio.py
backend/app/services/portfolio_service.py
frontend/lib/api.ts
frontend/lib/types.ts
frontend/app/portfolio/page.tsx
tests/test_backend_api.py
docs/cost_assumptions_alignment.md
```

Added:

```text
data/reference/broker_fee_profiles.csv
```

## Cost profile direction

Adds neutral planning profiles:

```text
Legacy default estimate
Low-cost estimate
Conservative estimate
High-cost estimate
```

The portfolio API now accepts:

```json
{
  "capital": 100000,
  "mode": "guided",
  "cost_profile": "conservative_estimate"
}
```

and returns cost profile metadata:

```text
key
label
service charge estimate
market charge estimate
verification status
source
note
disclaimer
```

## Broker fee research scaffold

Adds a CSV scaffold for the 15 JSE member dealers mentioned during planning:

```text
data/reference/broker_fee_profiles.csv
```

All broker rows are marked:

```text
unavailable_confirm_with_broker
```

until fees are verified from official broker materials or direct broker confirmation.

## Frontend behavior

The Portfolio Plan page now shows a neutral **Cost assumptions** card with:

- selected profile
- service charge estimate
- market charge estimate
- note
- clear broker-confirmation disclaimer

## Product guardrails

This PR does not:

- recommend a broker
- default to JMMB or any other broker
- claim exact fees
- launch a cost slider yet
- add Setup Tester or Paper Portfolio
- give investment advice
- execute trades

## Testing

Run:

```bash
python3 -m pytest tests/test_backend_api.py
```

Frontend local check:

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=https://jse-market-lab.onrender.com NEXT_PUBLIC_DEMO_MODE=true npm run dev
```

Open:

```text
http://localhost:3000/portfolio
```

Expected:

- Portfolio Plan loads
- Cost assumptions card appears
- selected profile is neutral
- no broker is presented as preferred/default
- disclaimer tells user to confirm actual fees with their licensed broker

## Related issue

Closes #150.
