### PR TITLE
Add platform navigation shell and user-intent landing pages

### DIFF
--- a/frontend/app/companies/page.tsx
+++ b/frontend/app/companies/page.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+import { InfoCard } from '@/components/shared/InfoCard';
+
+const modules = [
+  {
+    title: 'Company Pages',
+    label: 'Future anchor',
+    body: 'Company pages will combine ticker analysis, company context, dividend notes, earnings context, and tradability review.',
+  },
+  {
+    title: 'Ticker Analysis',
+    label: 'Working surface',
+    body: 'Use the current ticker page to review quick take, holding windows, risk context, and what to watch.',
+  },
+  {
+    title: 'Earnings and tradability',
+    label: 'Future context',
+    body: 'Future company views will add earnings scorecards and float/tradability context where data is available and rights are clear.',
+  },
+];
+
+export default function CompaniesPage() {
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Companies</span>
+        <h1>Research one company at a time.</h1>
+        <p>
+          Company pages will become the main place to connect market data, dashboard signals, dividend
+          context, earnings context, and research notes for a single ticker.
+        </p>
+      </section>
+
+      <section className="grid">
+        {modules.map((module) => (
+          <InfoCard key={module.title} title={module.title} label={module.label}>
+            <p>{module.body}</p>
+          </InfoCard>
+        ))}
+      </section>
+
+      <div className="button-row">
+        <Link className="button" href="/ticker/JMMBGL">
+          Open sample ticker
+        </Link>
+        <Link className="button secondary" href="/research">
+          View research direction
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/income/page.tsx
+++ b/frontend/app/income/page.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+import { InfoCard } from '@/components/shared/InfoCard';
+
+const incomeModules = [
+  {
+    title: 'Dividend View',
+    label: 'Future surface',
+    body: 'A future income-focused view for dividend notices, payment timing, yield context, and company dividend patterns.',
+  },
+  {
+    title: 'Company income profile',
+    label: 'Future company context',
+    body: 'A future company-level view connecting dividend history, earnings context, and risk notes for income investors.',
+  },
+  {
+    title: 'Portfolio income estimate',
+    label: 'Future planning',
+    body: 'A future estimate layer for simulated portfolio income. Dividend history will not be treated as a guarantee.',
+  },
+];
+
+export default function IncomePage() {
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Income</span>
+        <h1>Track dividend and income context with risk in view.</h1>
+        <p>
+          Income tools will help dividend-focused users review distributions, timing, company context,
+          and portfolio implications without implying that past dividends guarantee future income.
+        </p>
+      </section>
+
+      <section className="grid">
+        {incomeModules.map((module) => (
+          <InfoCard key={module.title} title={module.title} label={module.label}>
+            <p>{module.body}</p>
+          </InfoCard>
+        ))}
+      </section>
+
+      <div className="button-row">
+        <Link className="button" href="/companies">
+          Research companies
+        </Link>
+        <Link className="button secondary" href="/platform-preview">
+          View income roadmap
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/learn/page.tsx
+++ b/frontend/app/learn/page.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { InfoCard } from '@/components/shared/InfoCard';
+
+const topics = [
+  {
+    title: 'JSE basics',
+    body: 'Start with how stocks trade in Jamaica, what brokers do, and how to read basic market information.',
+  },
+  {
+    title: 'Holding windows',
+    body: 'Learn why the platform compares 5D, 10D, 20D, and 30D outcomes instead of treating every setup the same.',
+  },
+  {
+    title: 'Liquidity and spreads',
+    body: 'Understand why volume, entry/exit difficulty, and spread widening matter in the Jamaican market.',
+  },
+  {
+    title: 'Trading costs',
+    body: 'See how estimated charges can affect net returns and why fees should be confirmed with a licensed broker.',
+  },
+  {
+    title: 'Dividends',
+    body: 'Learn how dividend history, timing, and income context can support longer-term investor review.',
+  },
+  {
+    title: 'Decision support',
+    body: 'Understand what the dashboard can and cannot do. The platform supports review, not blind action.',
+  },
+];
+
+export default function LearnPage() {
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Learn</span>
+        <h1>Build your JSE foundation before using the tools.</h1>
+        <p>
+          Start here if you want plain-language education on the Jamaican market, trading costs,
+          liquidity, holding windows, dividends, and decision-support basics.
+        </p>
+      </section>
+
+      <section className="grid">
+        {topics.map((topic) => (
+          <InfoCard key={topic.title} title={topic.title} label="Education">
+            <p>{topic.body}</p>
+          </InfoCard>
+        ))}
+      </section>
+
+      <div className="button-row">
+        <Link className="button" href="/ticker/JMMBGL">
+          Try a sample ticker
+        </Link>
+        <Link className="button secondary" href="/tools">
+          View planning tools
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/market/page.tsx
+++ b/frontend/app/market/page.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+import { InfoCard } from '@/components/shared/InfoCard';
+
+const sections = [
+  {
+    title: 'Market Pulse',
+    label: 'Preview',
+    body: 'A future weekly view of broad market context, unusual movement, liquidity watch areas, and data-quality notes.',
+  },
+  {
+    title: 'Signals overview',
+    label: 'Future surface',
+    body: 'A future summary of recent signal activity by quality tier, holding window, liquidity, and risk context.',
+  },
+  {
+    title: 'Liquidity watch',
+    label: 'Future surface',
+    body: 'A future market-reality view for spotting thin trading, spread risk, and stocks that may be difficult to enter or exit.',
+  },
+];
+
+export default function MarketPage() {
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Market</span>
+        <h1>See the broader market context before drilling into one ticker.</h1>
+        <p>
+          Market views will help users understand what is happening across the JSE before reviewing a
+          company, setup, or portfolio plan.
+        </p>
+      </section>
+
+      <section className="grid">
+        {sections.map((section) => (
+          <InfoCard key={section.title} title={section.title} label={section.label}>
+            <p>{section.body}</p>
+          </InfoCard>
+        ))}
+      </section>
+
+      <div className="button-row">
+        <Link className="button" href="/ticker/JMMBGL">
+          Review sample ticker
+        </Link>
+        <Link className="button secondary" href="/platform-preview">
+          See future market modules
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,56 +2,85 @@ import Link from 'next/link';
 import { ApiStatusCard } from '@/components/shared/ApiStatusCard';
 import { InfoCard } from '@/components/shared/InfoCard';
 
+const intentCards = [
+  {
+    title: 'Learn how the JSE works',
+    label: 'Learn',
+    body: 'Start with plain-language education on market basics, liquidity, costs, dividends, and responsible decision support.',
+    href: '/learn',
+  },
+  {
+    title: 'See what is happening in the market',
+    label: 'Market',
+    body: 'Use market context to understand broad activity before drilling into one ticker or setup.',
+    href: '/market',
+  },
+  {
+    title: 'Research a company',
+    label: 'Companies',
+    body: 'Start from a company or ticker and connect signals, dividend context, earnings context, and tradability notes over time.',
+    href: '/companies',
+  },
+  {
+    title: 'Plan or test a setup',
+    label: 'Tools',
+    body: 'Use Portfolio Plan, Ticker Analysis, and Decision Audit to review setups with structure. Simulation tools are future work.',
+    href: '/tools',
+  },
+  {
+    title: 'Track dividend and income context',
+    label: 'Income',
+    body: 'Review the future income-focused direction for dividend context, company income profiles, and portfolio income planning.',
+    href: '/income',
+  },
+  {
+    title: 'View the product demo',
+    label: 'Demo',
+    body: 'Use Demo Mode and Platform Preview for advisor, partner, and stakeholder walkthroughs before official data/API authorization.',
+    href: '/demo',
+  },
+];
+
 export default function HomePage() {
   return (
     <div className="page-shell">
       <section className="hero">
-        <span className="eyebrow">Decision support for the JSE</span>
-        <h1>Understand the setup before you decide what to do.</h1>
+        <span className="eyebrow">Decision support and market intelligence for the JSE</span>
+        <h1>What are you trying to do today?</h1>
         <p>
-          JSE Market Lab helps Jamaican investors review opportunities with structure: signal context,
-          quality tiers, liquidity checks, holding windows, and portfolio rules.
+          JSE Market Lab helps Jamaican, Caribbean, and diaspora investors learn, research companies,
+          review market context, and use structured tools before making their own decisions.
         </p>
         <div className="button-row">
-          <Link className="button" href="/portfolio">
-            View Portfolio Plan
+          <Link className="button" href="/tools">
+            Open Tools
           </Link>
-          <Link className="button secondary" href="/ticker/JMMBGL">
-            Start with a ticker
+          <Link className="button secondary" href="/companies">
+            Research Companies
           </Link>
-          <Link className="button secondary" href="/platform-preview">
-            See Platform Preview
+          <Link className="button secondary" href="/demo">
+            View Demo
           </Link>
         </div>
       </section>
 
       <section className="grid">
         <ApiStatusCard />
-        <InfoCard title="Plan with structure" label="Portfolio">
-          <p>
-            Enter capital, review funded and unfunded setups, and keep reserve cash visible when the
-            system does not find enough fundable opportunities.
-          </p>
-        </InfoCard>
-        <InfoCard title="Learn one ticker at a time" label="Ticker">
-          <p>
-            Use ticker analysis to see quick takes, holding-window behavior, risk context, and what to
-            watch before acting.
-          </p>
-        </InfoCard>
-        <InfoCard title="Review the rules" label="Audit">
-          <p>
-            The review layer explains how ranking, quality, liquidity, and allocation rules shaped the
-            plan. It supports discipline, not blind action.
-          </p>
-        </InfoCard>
-        <InfoCard title="Show the platform vision" label="Demo">
-          <p>
-            Use Demo Mode and Platform Preview when walking advisors, partners, or testers through the
-            product before official JSE data/API authorization is confirmed.
-          </p>
-        </InfoCard>
+        {intentCards.map((card) => (
+          <InfoCard key={card.title} title={card.title} label={card.label}>
+            <p>{card.body}</p>
+            <Link href={card.href}>Start here</Link>
+          </InfoCard>
+        ))}
       </section>
+
+      <div className="notice">
+        <p>
+          JSE Market Lab is a decision-support platform. It helps users review information, risks,
+          costs, and context. It does not provide personal investment advice, execute trades, or hold
+          client funds.
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/app/research/page.tsx
+++ b/frontend/app/research/page.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+import { InfoCard } from '@/components/shared/InfoCard';
+
+const researchAreas = [
+  {
+    title: 'Research Hub',
+    label: 'Future surface',
+    body: 'A future place to organize company notes, market notes, event context, and source links once hosting and data-rights rules are clear.',
+  },
+  {
+    title: 'Company notes',
+    label: 'Future surface',
+    body: 'A future index of company-focused research notes connected to Company Pages and Ticker Analysis.',
+  },
+  {
+    title: 'Analyst Call Tracker',
+    label: 'Future surface',
+    body: 'A future tracker for analyst calls, company presentations, and event-based research context where available.',
+  },
+];
+
+export default function ResearchPage() {
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Research</span>
+        <h1>Organize company and market intelligence carefully.</h1>
+        <p>
+          Research surfaces are part of the platform vision, but public hosting, redistribution, and
+          monetization must stay gated until data-rights and compliance questions are resolved.
+        </p>
+      </section>
+
+      <section className="grid">
+        {researchAreas.map((area) => (
+          <InfoCard key={area.title} title={area.title} label={area.label}>
+            <p>{area.body}</p>
+          </InfoCard>
+        ))}
+      </section>
+
+      <div className="notice warning">
+        <p>
+          Research content should not be presented as official, licensed, or sponsored until sources,
+          rights, and disclosures are validated.
+        </p>
+      </div>
+
+      <div className="button-row">
+        <Link className="button" href="/companies">
+          Start with companies
+        </Link>
+        <Link className="button secondary" href="/platform-preview">
+          View research roadmap
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/tools/page.tsx
+++ b/frontend/app/tools/page.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { InfoCard } from '@/components/shared/InfoCard';
+
+const tools = [
+  {
+    title: 'Portfolio Plan',
+    label: 'Working tool',
+    body: 'Review funded setups, unfunded setups, cash reserve, and cost assumptions using the decision engine.',
+    href: '/portfolio',
+  },
+  {
+    title: 'Ticker Analysis',
+    label: 'Working tool',
+    body: 'Review one ticker at a time with quick take, holding-window behavior, risk context, and what to watch.',
+    href: '/ticker/JMMBGL',
+  },
+  {
+    title: 'Decision Audit',
+    label: 'Working tool',
+    body: 'Understand why the plan looks the way it does and which rules shaped the output.',
+    href: '/review',
+  },
+  {
+    title: 'Setup Tester',
+    label: 'Future simulation',
+    body: 'A future workflow for testing a setup using historical data before acting in the real market.',
+    href: '/platform-preview',
+  },
+  {
+    title: 'Paper Portfolio',
+    label: 'Future simulation',
+    body: 'A future practice portfolio for tracking simulated positions, outcomes, and lessons learned.',
+    href: '/platform-preview',
+  },
+  {
+    title: 'AI Helper',
+    label: 'Future assistant',
+    body: 'A future guided assistant for navigation and explanation, not stock picking or trade instructions.',
+    href: '/platform-preview',
+  },
+];
+
+export default function ToolsPage() {
+  return (
+    <div className="page-shell">
+      <section className="hero">
+        <span className="eyebrow">Tools</span>
+        <h1>Plan, review, and eventually test setups with structure.</h1>
+        <p>
+          Tools are where market information becomes a decision-support workflow. The current tools are
+          live; future simulation tools remain preview-only until the data, profile, and compliance layers
+          are ready.
+        </p>
+      </section>
+
+      <section className="grid">
+        {tools.map((tool) => (
+          <InfoCard key={tool.title} title={tool.title} label={tool.label}>
+            <p>{tool.body}</p>
+            <Link href={tool.href}>Open</Link>
+          </InfoCard>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/frontend/components/layout/Navigation.tsx
+++ b/frontend/components/layout/Navigation.tsx
@@ -2,11 +2,12 @@ import Link from 'next/link';
 
 const links = [
   { href: '/', label: 'Start Here' },
-  { href: '/portfolio', label: 'Portfolio Plan' },
-  { href: '/ticker/JMMBGL', label: 'Ticker Analysis' },
-  { href: '/review', label: 'Review' },
-  { href: '/demo', label: 'Demo Mode' },
-  { href: '/platform-preview', label: 'Platform Preview' },
+  { href: '/learn', label: 'Learn' },
+  { href: '/market', label: 'Market' },
+  { href: '/companies', label: 'Companies' },
+  { href: '/tools', label: 'Tools' },
+  { href: '/research', label: 'Research' },
+  { href: '/demo', label: 'Demo' },
 ];
 
 export function Navigation() {


### PR DESCRIPTION
## Summary

Implements the first frontend navigation shell based on the new platform information architecture and user journeys.

This shifts the site away from the old dashboard sequence and toward user-intent routing.

## What changed

Updated:

```text
frontend/components/layout/Navigation.tsx
frontend/app/page.tsx
```

Added platform landing pages:

```text
frontend/app/learn/page.tsx
frontend/app/market/page.tsx
frontend/app/companies/page.tsx
frontend/app/tools/page.tsx
frontend/app/income/page.tsx
frontend/app/research/page.tsx
```

## New navigation

```text
Start Here
Learn
Market
Companies
Tools
Research
Demo
```

## Homepage direction

The homepage now asks:

```text
What are you trying to do today?
```

and routes users by intent:

- Learn how the JSE works
- See what is happening in the market
- Research a company
- Plan or test a setup
- Track dividend and income context
- View the product demo

## New landing pages

### Learn

Education-first path for JSE basics, holding windows, liquidity, costs, dividends, and responsible decision-support.

### Market

Broad market context path for Market Pulse, signals overview, and liquidity watch previews.

### Companies

Company/ticker-centered path for future Company Pages and current Ticker Analysis.

### Tools

Working decision-support tools plus future Setup Tester, Paper Portfolio, and AI Helper previews.

### Income

Future dividend and income-focused path with risk-aware language.

### Research

Future research hub direction with clear compliance/data-rights caution.

## Product guardrails

This PR does not add:

- user accounts
- broker referral forms
- trade execution
- official JSE API integration
- public research hosting
- AI helper responses
- Setup Tester or Paper Portfolio logic

Future surfaces are labelled as future/preview/gated where appropriate.

## How to test locally

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=https://jse-market-lab.onrender.com NEXT_PUBLIC_DEMO_MODE=true npm run dev
```

Open:

```text
http://localhost:3000/
http://localhost:3000/learn
http://localhost:3000/market
http://localhost:3000/companies
http://localhost:3000/tools
http://localhost:3000/income
http://localhost:3000/research
http://localhost:3000/demo
```

Expected:

- navigation uses broader platform labels
- homepage uses user-intent routing cards
- all new landing pages load
- existing working pages remain linked from Tools/Companies
- demo and platform preview remain accessible
- no page implies investment advice, broker preference, trade execution, or official data authorization

## Related docs/issues

Related to:

- docs/platform_information_architecture_user_journeys.md
- #155