### PR TITLE
Add homepage market snapshot section

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -29,6 +29,10 @@ a {
   padding: 32px 20px 56px;
 }
 
+.market-home-shell {
+  padding-top: 24px;
+}
+
 .demo-banner {
   background: var(--warning-soft);
   border-bottom: 1px solid #f59e0b;
@@ -86,6 +90,24 @@ a {
 
 .hero.compact {
   padding: 28px 0 16px;
+}
+
+.home-positioning {
+  align-items: end;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  padding: 14px 0 10px;
+}
+
+.home-positioning h1 {
+  font-size: 34px;
+  margin-top: 10px;
+}
+
+.home-positioning p {
+  margin-bottom: 0;
+  max-width: 820px;
 }
 
 .eyebrow {
@@ -146,7 +168,7 @@ p {
   background: white;
   border: 1px solid var(--border);
   border-top: 6px solid #08245c;
-  margin: 10px 0 28px;
+  margin: 0 0 26px;
   box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
 }
 
@@ -453,10 +475,15 @@ p {
 }
 
 @media (max-width: 900px) {
+  .home-positioning,
   .market-tape,
   .market-front-grid,
   .market-content-grid {
     grid-template-columns: 1fr;
+  }
+
+  .home-positioning {
+    align-items: start;
   }
 
   .tape-item,
@@ -486,8 +513,9 @@ p {
     flex-wrap: wrap;
   }
 
-  h1 {
-    font-size: 36px;
+  h1,
+  .home-positioning h1 {
+    font-size: 32px;
   }
 
   .grid,

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -142,84 +142,232 @@ p {
   background: var(--surface-soft);
 }
 
-.market-snapshot {
-  background: #0f172a;
-  color: white;
-  border-radius: 24px;
-  padding: 24px;
-  margin: 10px 0 26px;
+.market-front {
+  background: white;
+  border: 1px solid var(--border);
+  border-top: 6px solid #08245c;
+  margin: 10px 0 28px;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+}
+
+.market-tape {
   display: grid;
-  gap: 20px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-bottom: 1px solid var(--border);
+  background: #f8fafc;
 }
 
-.market-snapshot p {
-  color: #cbd5e1;
+.tape-item {
+  border-right: 1px solid var(--border);
+  padding: 12px 14px;
 }
 
-.market-snapshot .eyebrow {
+.tape-item:last-child {
+  border-right: 0;
+}
+
+.tape-item span {
+  color: #64748b;
+  display: block;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tape-item strong {
+  color: #08245c;
+  display: block;
+  font-size: 17px;
+  margin-top: 4px;
+}
+
+.tape-item.warn strong {
+  color: #b45309;
+}
+
+.market-front-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.market-lede-panel {
+  background: #08162f;
+  color: white;
+  padding: 28px;
+}
+
+.market-lede-panel .eyebrow {
   color: #5eead4;
 }
 
-.snapshot-lead h2 {
+.market-lede-panel h2 {
   color: white;
-  font-size: 30px;
+  font-size: 34px;
+  line-height: 1.05;
+  margin: 8px 0 12px;
 }
 
-.snapshot-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
+.market-lede-panel p {
+  color: #cbd5e1;
+  max-width: 620px;
 }
 
-.snapshot-card {
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 16px;
-  padding: 16px;
-}
-
-.snapshot-card span,
-.snapshot-label {
-  color: #99f6e4;
-  display: block;
-  font-size: 12px;
-  font-weight: 800;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  margin-bottom: 8px;
-}
-
-.snapshot-card strong {
-  display: block;
-  font-size: 22px;
-  margin-bottom: 4px;
-}
-
-.snapshot-card p {
-  margin: 0;
-}
-
-.snapshot-strip {
-  display: grid;
-  grid-template-columns: 1.4fr 1fr;
-  gap: 16px;
-  border-top: 1px solid rgba(255, 255, 255, 0.14);
-  padding-top: 16px;
-}
-
-.snapshot-tickers {
+.market-lede-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  margin-top: 18px;
 }
 
-.snapshot-tickers a {
-  background: rgba(94, 234, 212, 0.12);
-  border: 1px solid rgba(94, 234, 212, 0.25);
-  border-radius: 999px;
-  color: #ccfbf1;
+.market-lede-actions a {
+  background: white;
+  color: #08162f;
+  font-weight: 900;
+  padding: 10px 12px;
+}
+
+.quote-panel {
+  background: #f8fafc;
+  border-left: 1px solid var(--border);
+  padding: 24px;
+}
+
+.quote-panel-header {
+  align-items: center;
+  border-bottom: 3px solid #08245c;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 10px;
+}
+
+.quote-panel-header span {
+  color: #08245c;
+  font-size: 20px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.quote-panel-header strong {
+  background: #ccfbf1;
+  color: #0f766e;
+  font-size: 12px;
+  padding: 6px 8px;
+}
+
+.quote-metrics {
+  display: grid;
+  gap: 0;
+  margin-top: 12px;
+}
+
+.quote-metrics div {
+  align-items: baseline;
+  border-bottom: 1px dashed #cbd5e1;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 13px 0;
+}
+
+.quote-metrics span {
+  color: #64748b;
   font-weight: 800;
-  padding: 8px 10px;
+}
+
+.quote-metrics strong {
+  color: #111827;
+  font-size: 22px;
+}
+
+.market-content-grid {
+  display: grid;
+  grid-template-columns: 1.15fr 0.85fr;
+}
+
+.market-module {
+  padding: 22px 24px;
+}
+
+.market-module.wide {
+  border-right: 1px solid var(--border);
+}
+
+.module-heading {
+  align-items: center;
+  border-top: 5px solid #08245c;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding-top: 14px;
+  margin-bottom: 12px;
+}
+
+.module-heading h3 {
+  color: #08245c;
+  font-size: 24px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.module-heading a {
+  color: #0f766e;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.market-table {
+  display: grid;
+}
+
+.market-table-head,
+.market-table-row {
+  display: grid;
+  grid-template-columns: 1.4fr 0.6fr 0.8fr 0.9fr;
+  gap: 12px;
+}
+
+.market-table-head {
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  padding: 10px 0;
+  text-transform: uppercase;
+}
+
+.market-table-row {
+  align-items: center;
+  border-top: 1px solid var(--border);
+  padding: 12px 0;
+}
+
+.market-table-row strong {
+  color: #111827;
+  font-size: 18px;
+}
+
+.market-table-row span {
+  color: #0f766e;
+  font-weight: 900;
+}
+
+.market-news-list {
+  display: grid;
+  gap: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.market-news-list li {
+  border-bottom: 1px dashed #cbd5e1;
+  color: #111827;
+  font-weight: 800;
+  line-height: 1.45;
+  padding-bottom: 12px;
 }
 
 .pill {
@@ -305,9 +453,21 @@ p {
 }
 
 @media (max-width: 900px) {
-  .snapshot-grid,
-  .snapshot-strip {
+  .market-tape,
+  .market-front-grid,
+  .market-content-grid {
     grid-template-columns: 1fr;
+  }
+
+  .tape-item,
+  .quote-panel,
+  .market-module.wide {
+    border-right: 0;
+  }
+
+  .quote-panel {
+    border-left: 0;
+    border-top: 1px solid var(--border);
   }
 }
 
@@ -335,13 +495,21 @@ p {
     grid-template-columns: 1fr;
   }
 
-  .market-snapshot {
-    border-radius: 18px;
+  .market-lede-panel,
+  .quote-panel,
+  .market-module {
     padding: 18px;
   }
 
-  .snapshot-lead h2 {
-    font-size: 25px;
+  .market-lede-panel h2 {
+    font-size: 28px;
+  }
+
+  .market-table-head,
+  .market-table-row {
+    grid-template-columns: 1.2fr 0.6fr 0.7fr 0.8fr;
+    gap: 8px;
+    font-size: 13px;
   }
 
   .metric-row {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -142,6 +142,86 @@ p {
   background: var(--surface-soft);
 }
 
+.market-snapshot {
+  background: #0f172a;
+  color: white;
+  border-radius: 24px;
+  padding: 24px;
+  margin: 10px 0 26px;
+  display: grid;
+  gap: 20px;
+}
+
+.market-snapshot p {
+  color: #cbd5e1;
+}
+
+.market-snapshot .eyebrow {
+  color: #5eead4;
+}
+
+.snapshot-lead h2 {
+  color: white;
+  font-size: 30px;
+}
+
+.snapshot-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.snapshot-card {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.snapshot-card span,
+.snapshot-label {
+  color: #99f6e4;
+  display: block;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.snapshot-card strong {
+  display: block;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+
+.snapshot-card p {
+  margin: 0;
+}
+
+.snapshot-strip {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.14);
+  padding-top: 16px;
+}
+
+.snapshot-tickers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.snapshot-tickers a {
+  background: rgba(94, 234, 212, 0.12);
+  border: 1px solid rgba(94, 234, 212, 0.25);
+  border-radius: 999px;
+  color: #ccfbf1;
+  font-weight: 800;
+  padding: 8px 10px;
+}
+
 .pill {
   display: inline-flex;
   width: fit-content;
@@ -224,6 +304,13 @@ p {
   border: 1px solid var(--border);
 }
 
+@media (max-width: 900px) {
+  .snapshot-grid,
+  .snapshot-strip {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 780px) {
   .demo-banner-inner {
     align-items: flex-start;
@@ -246,6 +333,15 @@ p {
   .grid,
   .grid.two {
     grid-template-columns: 1fr;
+  }
+
+  .market-snapshot {
+    border-radius: 18px;
+    padding: 18px;
+  }
+
+  .snapshot-lead h2 {
+    font-size: 25px;
   }
 
   .metric-row {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { ApiStatusCard } from '@/components/shared/ApiStatusCard';
+import { HomeMarketSnapshot } from '@/components/shared/HomeMarketSnapshot';
 import { InfoCard } from '@/components/shared/InfoCard';
 
 const intentCards = [
@@ -46,10 +47,10 @@ export default function HomePage() {
     <div className="page-shell">
       <section className="hero">
         <span className="eyebrow">Decision support and market intelligence for the JSE</span>
-        <h1>What are you trying to do today?</h1>
+        <h1>Start with the market, then choose your path.</h1>
         <p>
-          JSE Market Lab helps Jamaican, Caribbean, and diaspora investors learn, research companies,
-          review market context, and use structured tools before making their own decisions.
+          JSE Market Lab helps Jamaican, Caribbean, and diaspora investors see market context, learn,
+          research companies, and use structured tools before making their own decisions.
         </p>
         <div className="button-row">
           <Link className="button" href="/tools">
@@ -62,6 +63,13 @@ export default function HomePage() {
             View Demo
           </Link>
         </div>
+      </section>
+
+      <HomeMarketSnapshot />
+
+      <section className="hero compact">
+        <span className="eyebrow">Choose your path</span>
+        <h2>What are you trying to do today?</h2>
       </section>
 
       <section className="grid">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -44,14 +44,18 @@ const intentCards = [
 
 export default function HomePage() {
   return (
-    <div className="page-shell">
-      <section className="hero">
-        <span className="eyebrow">Decision support and market intelligence for the JSE</span>
-        <h1>Start with the market, then choose your path.</h1>
-        <p>
-          JSE Market Lab helps Jamaican, Caribbean, and diaspora investors see market context, learn,
-          research companies, and use structured tools before making their own decisions.
-        </p>
+    <div className="page-shell market-home-shell">
+      <HomeMarketSnapshot />
+
+      <section className="home-positioning">
+        <div>
+          <span className="eyebrow">Decision support and market intelligence for the JSE</span>
+          <h1>Start with the market, then choose your path.</h1>
+          <p>
+            JSE Market Lab helps Jamaican, Caribbean, and diaspora investors see market context,
+            learn, research companies, and use structured tools before making their own decisions.
+          </p>
+        </div>
         <div className="button-row">
           <Link className="button" href="/tools">
             Open Tools
@@ -64,8 +68,6 @@ export default function HomePage() {
           </Link>
         </div>
       </section>
-
-      <HomeMarketSnapshot />
 
       <section className="hero compact">
         <span className="eyebrow">Choose your path</span>

--- a/frontend/components/shared/HomeMarketSnapshot.tsx
+++ b/frontend/components/shared/HomeMarketSnapshot.tsx
@@ -1,0 +1,99 @@
+import Link from 'next/link';
+import { getDataStatus, getPortfolioPlan } from '@/lib/api';
+import { formatJmd, formatPercent } from '@/lib/formatters';
+
+const SNAPSHOT_CAPITAL = 100000;
+
+export async function HomeMarketSnapshot() {
+  let status;
+  let plan;
+  let unavailable = false;
+
+  try {
+    [status, plan] = await Promise.all([
+      getDataStatus(),
+      getPortfolioPlan(SNAPSHOT_CAPITAL, 'guided', 'conservative_estimate'),
+    ]);
+  } catch {
+    unavailable = true;
+  }
+
+  if (unavailable || !status || !plan) {
+    return (
+      <section className="market-snapshot">
+        <div>
+          <span className="eyebrow">Demo Market Snapshot</span>
+          <h2>Market snapshot unavailable</h2>
+          <p>
+            The homepage snapshot could not reach the API right now. The platform pages are still
+            available for navigation and demo review.
+          </p>
+        </div>
+        <div className="snapshot-card">
+          <span>Mode</span>
+          <strong>Demo / internal data</strong>
+          <p>Not an official live JSE feed.</p>
+        </div>
+      </section>
+    );
+  }
+
+  const funded = plan.funded_trades.slice(0, 3);
+  const unfundedCount = plan.summary.unfunded_count;
+
+  return (
+    <section className="market-snapshot">
+      <div className="snapshot-lead">
+        <span className="eyebrow">Demo Market Snapshot</span>
+        <h2>Latest available market view</h2>
+        <p>
+          A live-looking homepage preview using the current internal dataset. This demonstrates the
+          market-intelligence experience and is not an official live JSE feed.
+        </p>
+      </div>
+
+      <div className="snapshot-grid">
+        <div className="snapshot-card">
+          <span>Market mode</span>
+          <strong>Demo / internal</strong>
+          <p>Latest available prepared dataset.</p>
+        </div>
+        <div className="snapshot-card">
+          <span>Latest market date</span>
+          <strong>{status.latest_market_date || 'Not available'}</strong>
+          <p>{status.dataset_source}</p>
+        </div>
+        <div className="snapshot-card">
+          <span>Rows loaded</span>
+          <strong>{status.row_count.toLocaleString()}</strong>
+          <p>Used for demo analysis and routing.</p>
+        </div>
+        <div className="snapshot-card">
+          <span>Sample capital plan</span>
+          <strong>{formatJmd(plan.summary.total_allocated)}</strong>
+          <p>{formatJmd(plan.reserve_cash)} held as reserve.</p>
+        </div>
+      </div>
+
+      <div className="snapshot-strip">
+        <div>
+          <span className="snapshot-label">Top funded demo setups</span>
+          <div className="snapshot-tickers">
+            {funded.map((trade) => (
+              <Link key={trade.ticker} href={'/ticker/' + encodeURIComponent(trade.ticker)}>
+                {trade.ticker} · {trade.holding_window} · {formatPercent(trade.allocation_pct)}
+              </Link>
+            ))}
+          </div>
+        </div>
+        <div>
+          <span className="snapshot-label">Watch areas</span>
+          <p>
+            {unfundedCount} setups held back by rules. Review liquidity, cost assumptions, and data
+            status before interpreting outputs.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/shared/HomeMarketSnapshot.tsx
+++ b/frontend/components/shared/HomeMarketSnapshot.tsx
@@ -4,6 +4,77 @@ import { formatJmd, formatPercent } from '@/lib/formatters';
 
 const SNAPSHOT_CAPITAL = 100000;
 
+const demoFallback = {
+  latestMarketDate: 'Latest available demo date',
+  datasetSource: 'Demo/internal market dataset',
+  rowsLoaded: '57,656+',
+  allocated: '$70,000',
+  reserve: '$30,000',
+  tickers: [
+    { ticker: 'JPS9.5', label: '5D · 30%' },
+    { ticker: 'WIPT', label: '30D · 30%' },
+    { ticker: 'TJH8.0', label: '5D · 10%' },
+  ],
+};
+
+function DemoFallbackSnapshot() {
+  return (
+    <section className="market-snapshot">
+      <div className="snapshot-lead">
+        <span className="eyebrow">Demo Market Snapshot</span>
+        <h2>Latest available market view</h2>
+        <p>
+          A live-looking homepage preview using demo/internal market data. This keeps the walkthrough
+          useful even when the API is waking up or temporarily unreachable.
+        </p>
+      </div>
+
+      <div className="snapshot-grid">
+        <div className="snapshot-card">
+          <span>Market mode</span>
+          <strong>Demo / internal</strong>
+          <p>Not an official live JSE feed.</p>
+        </div>
+        <div className="snapshot-card">
+          <span>Latest market date</span>
+          <strong>{demoFallback.latestMarketDate}</strong>
+          <p>{demoFallback.datasetSource}</p>
+        </div>
+        <div className="snapshot-card">
+          <span>Rows loaded</span>
+          <strong>{demoFallback.rowsLoaded}</strong>
+          <p>Sample dataset for product demonstration.</p>
+        </div>
+        <div className="snapshot-card">
+          <span>Sample capital plan</span>
+          <strong>{demoFallback.allocated}</strong>
+          <p>{demoFallback.reserve} held as reserve.</p>
+        </div>
+      </div>
+
+      <div className="snapshot-strip">
+        <div>
+          <span className="snapshot-label">Demo setup examples</span>
+          <div className="snapshot-tickers">
+            {demoFallback.tickers.map((item) => (
+              <Link key={item.ticker} href={'/ticker/' + encodeURIComponent(item.ticker)}>
+                {item.ticker} · {item.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+        <div>
+          <span className="snapshot-label">Watch areas</span>
+          <p>
+            Review liquidity, cost assumptions, data status, and holding-window behavior before
+            interpreting any output.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export async function HomeMarketSnapshot() {
   let status;
   let plan;
@@ -19,23 +90,7 @@ export async function HomeMarketSnapshot() {
   }
 
   if (unavailable || !status || !plan) {
-    return (
-      <section className="market-snapshot">
-        <div>
-          <span className="eyebrow">Demo Market Snapshot</span>
-          <h2>Market snapshot unavailable</h2>
-          <p>
-            The homepage snapshot could not reach the API right now. The platform pages are still
-            available for navigation and demo review.
-          </p>
-        </div>
-        <div className="snapshot-card">
-          <span>Mode</span>
-          <strong>Demo / internal data</strong>
-          <p>Not an official live JSE feed.</p>
-        </div>
-      </section>
-    );
+    return <DemoFallbackSnapshot />;
   }
 
   const funded = plan.funded_trades.slice(0, 3);

--- a/frontend/components/shared/HomeMarketSnapshot.tsx
+++ b/frontend/components/shared/HomeMarketSnapshot.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { getDataStatus, getPortfolioPlan } from '@/lib/api';
+import { getDataStatus, getPortfolioPlan, hasConfiguredApiBaseUrl } from '@/lib/api';
 import { formatJmd, formatPercent } from '@/lib/formatters';
 import type { PortfolioPlan, Trade } from '@/lib/types';
 
@@ -168,7 +168,24 @@ function MarketFrontPage({
   );
 }
 
+function renderDemoFallback() {
+  return (
+    <MarketFrontPage
+      latestDate={demoFallback.latestMarketDate}
+      datasetSource={demoFallback.datasetSource}
+      rowsLoaded={demoFallback.rowsLoaded}
+      allocated={demoFallback.allocated}
+      reserve={demoFallback.reserve}
+      unfundedCount={demoFallback.unfundedCount}
+    />
+  );
+}
+
 export async function HomeMarketSnapshot() {
+  if (!hasConfiguredApiBaseUrl()) {
+    return renderDemoFallback();
+  }
+
   let status;
   let plan;
   let unavailable = false;
@@ -183,16 +200,7 @@ export async function HomeMarketSnapshot() {
   }
 
   if (unavailable || !status || !plan) {
-    return (
-      <MarketFrontPage
-        latestDate={demoFallback.latestMarketDate}
-        datasetSource={demoFallback.datasetSource}
-        rowsLoaded={demoFallback.rowsLoaded}
-        allocated={demoFallback.allocated}
-        reserve={demoFallback.reserve}
-        unfundedCount={demoFallback.unfundedCount}
-      />
-    );
+    return renderDemoFallback();
   }
 
   return (

--- a/frontend/components/shared/HomeMarketSnapshot.tsx
+++ b/frontend/components/shared/HomeMarketSnapshot.tsx
@@ -1,74 +1,167 @@
 import Link from 'next/link';
 import { getDataStatus, getPortfolioPlan } from '@/lib/api';
 import { formatJmd, formatPercent } from '@/lib/formatters';
+import type { PortfolioPlan, Trade } from '@/lib/types';
 
 const SNAPSHOT_CAPITAL = 100000;
 
 const demoFallback = {
-  latestMarketDate: 'Latest available demo date',
+  latestMarketDate: '2026-04-24',
   datasetSource: 'Demo/internal market dataset',
   rowsLoaded: '57,656+',
   allocated: '$70,000',
   reserve: '$30,000',
+  unfundedCount: 6,
   tickers: [
-    { ticker: 'JPS9.5', label: '5D · 30%' },
-    { ticker: 'WIPT', label: '30D · 30%' },
-    { ticker: 'TJH8.0', label: '5D · 10%' },
+    { ticker: 'JPS9.5', window: '5D', tier: 'A', allocation: '30%' },
+    { ticker: 'WIPT', window: '30D', tier: 'A', allocation: '30%' },
+    { ticker: 'TJH8.0', window: '5D', tier: 'A', allocation: '10%' },
   ],
 };
 
-function DemoFallbackSnapshot() {
+function MarketTape({ rowsLoaded, latestDate }: { rowsLoaded: string; latestDate: string }) {
+  const tape = [
+    { label: 'JSE LAB MODE', value: 'DEMO', tone: 'neutral' },
+    { label: 'LATEST DATA', value: latestDate, tone: 'neutral' },
+    { label: 'ROWS', value: rowsLoaded, tone: 'neutral' },
+    { label: 'FEED', value: 'INTERNAL', tone: 'neutral' },
+    { label: 'STATUS', value: 'NOT LIVE JSE', tone: 'warn' },
+  ];
+
   return (
-    <section className="market-snapshot">
-      <div className="snapshot-lead">
-        <span className="eyebrow">Demo Market Snapshot</span>
-        <h2>Latest available market view</h2>
-        <p>
-          A live-looking homepage preview using demo/internal market data. This keeps the walkthrough
-          useful even when the API is waking up or temporarily unreachable.
-        </p>
-      </div>
+    <div className="market-tape" aria-label="Demo market status tape">
+      {tape.map((item) => (
+        <div key={item.label} className={'tape-item ' + item.tone}>
+          <span>{item.label}</span>
+          <strong>{item.value}</strong>
+        </div>
+      ))}
+    </div>
+  );
+}
 
-      <div className="snapshot-grid">
-        <div className="snapshot-card">
-          <span>Market mode</span>
-          <strong>Demo / internal</strong>
-          <p>Not an official live JSE feed.</p>
-        </div>
-        <div className="snapshot-card">
-          <span>Latest market date</span>
-          <strong>{demoFallback.latestMarketDate}</strong>
-          <p>{demoFallback.datasetSource}</p>
-        </div>
-        <div className="snapshot-card">
-          <span>Rows loaded</span>
-          <strong>{demoFallback.rowsLoaded}</strong>
-          <p>Sample dataset for product demonstration.</p>
-        </div>
-        <div className="snapshot-card">
-          <span>Sample capital plan</span>
-          <strong>{demoFallback.allocated}</strong>
-          <p>{demoFallback.reserve} held as reserve.</p>
-        </div>
+function SetupRows({ trades }: { trades: Array<Pick<Trade, 'ticker' | 'holding_window' | 'tier' | 'allocation_pct'>> }) {
+  return (
+    <div className="market-table">
+      <div className="market-table-head">
+        <span>Ticker</span>
+        <span>Tier</span>
+        <span>Window</span>
+        <span>Allocation</span>
       </div>
+      {trades.map((trade) => (
+        <Link className="market-table-row" key={trade.ticker} href={'/ticker/' + encodeURIComponent(trade.ticker)}>
+          <strong>{trade.ticker}</strong>
+          <span>{trade.tier || '—'}</span>
+          <span>{trade.holding_window || '—'}</span>
+          <span>{formatPercent(trade.allocation_pct)}</span>
+        </Link>
+      ))}
+    </div>
+  );
+}
 
-      <div className="snapshot-strip">
-        <div>
-          <span className="snapshot-label">Demo setup examples</span>
-          <div className="snapshot-tickers">
-            {demoFallback.tickers.map((item) => (
-              <Link key={item.ticker} href={'/ticker/' + encodeURIComponent(item.ticker)}>
-                {item.ticker} · {item.label}
-              </Link>
-            ))}
+function DemoSetupRows() {
+  return (
+    <div className="market-table">
+      <div className="market-table-head">
+        <span>Ticker</span>
+        <span>Tier</span>
+        <span>Window</span>
+        <span>Allocation</span>
+      </div>
+      {demoFallback.tickers.map((trade) => (
+        <Link className="market-table-row" key={trade.ticker} href={'/ticker/' + encodeURIComponent(trade.ticker)}>
+          <strong>{trade.ticker}</strong>
+          <span>{trade.tier}</span>
+          <span>{trade.window}</span>
+          <span>{trade.allocation}</span>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function MarketFrontPage({
+  latestDate,
+  datasetSource,
+  rowsLoaded,
+  allocated,
+  reserve,
+  unfundedCount,
+  plan,
+}: {
+  latestDate: string;
+  datasetSource: string;
+  rowsLoaded: string;
+  allocated: string;
+  reserve: string;
+  unfundedCount: number;
+  plan?: PortfolioPlan;
+}) {
+  const funded = plan?.funded_trades.slice(0, 3) ?? [];
+
+  return (
+    <section className="market-front">
+      <MarketTape rowsLoaded={rowsLoaded} latestDate={latestDate} />
+
+      <div className="market-front-grid">
+        <div className="market-lede-panel">
+          <span className="eyebrow">Demo Market Snapshot</span>
+          <h2>Latest available JSE market view</h2>
+          <p>
+            Demo/internal data shaped into a market-front page experience. This is not an official live
+            JSE feed.
+          </p>
+          <div className="market-lede-actions">
+            <Link href="/market">Market</Link>
+            <Link href="/companies">Companies</Link>
+            <Link href="/tools">Tools</Link>
           </div>
         </div>
-        <div>
-          <span className="snapshot-label">Watch areas</span>
-          <p>
-            Review liquidity, cost assumptions, data status, and holding-window behavior before
-            interpreting any output.
-          </p>
+
+        <div className="quote-panel">
+          <div className="quote-panel-header">
+            <span>Snapshot Board</span>
+            <strong>DEMO</strong>
+          </div>
+          <div className="quote-metrics">
+            <div>
+              <span>Sample allocated</span>
+              <strong>{allocated}</strong>
+            </div>
+            <div>
+              <span>Reserve cash</span>
+              <strong>{reserve}</strong>
+            </div>
+            <div>
+              <span>Held back</span>
+              <strong>{unfundedCount}</strong>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="market-content-grid">
+        <div className="market-module wide">
+          <div className="module-heading">
+            <h3>Top demo setups</h3>
+            <Link href="/portfolio">View portfolio plan</Link>
+          </div>
+          {funded.length > 0 ? <SetupRows trades={funded} /> : <DemoSetupRows />}
+        </div>
+
+        <div className="market-module">
+          <div className="module-heading">
+            <h3>Market notes</h3>
+            <Link href="/demo">Demo mode</Link>
+          </div>
+          <ul className="market-news-list">
+            <li>Latest available dataset: {latestDate}</li>
+            <li>Source: {datasetSource}</li>
+            <li>Cost assumptions and liquidity checks are active.</li>
+            <li>Official live feed requires JSE/data-rights validation.</li>
+          </ul>
         </div>
       </div>
     </section>
@@ -90,65 +183,27 @@ export async function HomeMarketSnapshot() {
   }
 
   if (unavailable || !status || !plan) {
-    return <DemoFallbackSnapshot />;
+    return (
+      <MarketFrontPage
+        latestDate={demoFallback.latestMarketDate}
+        datasetSource={demoFallback.datasetSource}
+        rowsLoaded={demoFallback.rowsLoaded}
+        allocated={demoFallback.allocated}
+        reserve={demoFallback.reserve}
+        unfundedCount={demoFallback.unfundedCount}
+      />
+    );
   }
 
-  const funded = plan.funded_trades.slice(0, 3);
-  const unfundedCount = plan.summary.unfunded_count;
-
   return (
-    <section className="market-snapshot">
-      <div className="snapshot-lead">
-        <span className="eyebrow">Demo Market Snapshot</span>
-        <h2>Latest available market view</h2>
-        <p>
-          A live-looking homepage preview using the current internal dataset. This demonstrates the
-          market-intelligence experience and is not an official live JSE feed.
-        </p>
-      </div>
-
-      <div className="snapshot-grid">
-        <div className="snapshot-card">
-          <span>Market mode</span>
-          <strong>Demo / internal</strong>
-          <p>Latest available prepared dataset.</p>
-        </div>
-        <div className="snapshot-card">
-          <span>Latest market date</span>
-          <strong>{status.latest_market_date || 'Not available'}</strong>
-          <p>{status.dataset_source}</p>
-        </div>
-        <div className="snapshot-card">
-          <span>Rows loaded</span>
-          <strong>{status.row_count.toLocaleString()}</strong>
-          <p>Used for demo analysis and routing.</p>
-        </div>
-        <div className="snapshot-card">
-          <span>Sample capital plan</span>
-          <strong>{formatJmd(plan.summary.total_allocated)}</strong>
-          <p>{formatJmd(plan.reserve_cash)} held as reserve.</p>
-        </div>
-      </div>
-
-      <div className="snapshot-strip">
-        <div>
-          <span className="snapshot-label">Top funded demo setups</span>
-          <div className="snapshot-tickers">
-            {funded.map((trade) => (
-              <Link key={trade.ticker} href={'/ticker/' + encodeURIComponent(trade.ticker)}>
-                {trade.ticker} · {trade.holding_window} · {formatPercent(trade.allocation_pct)}
-              </Link>
-            ))}
-          </div>
-        </div>
-        <div>
-          <span className="snapshot-label">Watch areas</span>
-          <p>
-            {unfundedCount} setups held back by rules. Review liquidity, cost assumptions, and data
-            status before interpreting outputs.
-          </p>
-        </div>
-      </div>
-    </section>
+    <MarketFrontPage
+      latestDate={status.latest_market_date || 'Not available'}
+      datasetSource={status.dataset_source}
+      rowsLoaded={status.row_count.toLocaleString()}
+      allocated={formatJmd(plan.summary.total_allocated)}
+      reserve={formatJmd(plan.reserve_cash)}
+      unfundedCount={plan.summary.unfunded_count}
+      plan={plan}
+    />
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -6,6 +6,10 @@ export function getApiBaseUrl(): string {
   return API_BASE_URL;
 }
 
+export function hasConfiguredApiBaseUrl(): boolean {
+  return Boolean(process.env.NEXT_PUBLIC_API_BASE_URL);
+}
+
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(API_BASE_URL + path, {
     ...init,


### PR DESCRIPTION
## Summary

Adds a homepage snapshot section so the first screen shows useful platform/data context before the user-intent cards.

## What changed

Added:

```text
frontend/components/shared/HomeMarketSnapshot.tsx
```

Updated:

```text
frontend/app/page.tsx
frontend/app/globals.css
```

## Notes

The section is clearly labeled as a demo/internal latest-available snapshot. It does not claim official live JSE data access and does not add trading, broker, account, AI, or simulation functionality.

## Test locally

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=https://jse-market-lab.onrender.com NEXT_PUBLIC_DEMO_MODE=true npm run dev
```

Open:

```text
http://localhost:3000/
```

Expected:

- homepage loads
- snapshot appears before the intent cards
- fallback appears if the API is unreachable
- existing intent cards remain visible
- mobile layout remains readable

Closes #158.