### PR TITLE
Build demo Market Pulse page

### DIFF
--- a/frontend/app/market/page.tsx
+++ b/frontend/app/market/page.tsx
@@ -1,52 +1,134 @@
 import Link from 'next/link';
-import { InfoCard } from '@/components/shared/InfoCard';
 
-const sections = [
-  {
-    title: 'Market Pulse',
-    label: 'Preview',
-    body: 'A future weekly view of broad market context, unusual movement, liquidity watch areas, and data-quality notes.',
-  },
-  {
-    title: 'Signals overview',
-    label: 'Future surface',
-    body: 'A future summary of recent signal activity by quality tier, holding window, liquidity, and risk context.',
-  },
-  {
-    title: 'Liquidity watch',
-    label: 'Future surface',
-    body: 'A future market-reality view for spotting thin trading, spread risk, and stocks that may be difficult to enter or exit.',
-  },
+const marketTape = [
+  { label: 'Market mode', value: 'Demo / internal' },
+  { label: 'Latest data', value: '2026-04-24' },
+  { label: 'Rows loaded', value: '57,656+' },
+  { label: 'Feed status', value: 'Not live JSE', tone: 'warn' },
+];
+
+const movers = [
+  { ticker: 'JPS9.5', name: 'JPS Preference', window: '5D', tier: 'A', note: 'Funded in demo plan' },
+  { ticker: 'WIPT', name: 'Wigton Windfarm', window: '30D', tier: 'A', note: 'Longer holding window' },
+  { ticker: 'TJH8.0', name: 'TransJamaican Highway', window: '5D', tier: 'A', note: 'Smaller allocation' },
+  { ticker: 'CAR', name: 'Carreras', window: '30D', tier: 'B', note: 'Held back by rules' },
+];
+
+const liquidityWatch = [
+  'Thin trading can affect entry and exit timing.',
+  'Spread widening should be reviewed before interpreting short holding windows.',
+  'Volume confirmation is a stronger signal-quality input than price movement alone.',
+];
+
+const signalClusters = [
+  { label: 'Tier A setups', value: '3 demo funded' },
+  { label: 'Tier B/C watch', value: 'Rule-dependent' },
+  { label: 'Holding windows', value: '5D / 10D / 20D / 30D' },
+  { label: 'Cost profile', value: 'Conservative estimate' },
+];
+
+const marketNotes = [
+  'This page uses demo/internal data to show the intended Market Pulse experience.',
+  'Official live market feed access requires JSE/data-rights validation.',
+  'Market context should lead users into company research, tools, and review workflows.',
 ];
 
 export default function MarketPage() {
   return (
-    <div className="page-shell">
-      <section className="hero">
-        <span className="eyebrow">Market</span>
-        <h1>See the broader market context before drilling into one ticker.</h1>
-        <p>
-          Market views will help users understand what is happening across the JSE before reviewing a
-          company, setup, or portfolio plan.
-        </p>
-      </section>
+    <div className="page-shell market-home-shell">
+      <section className="market-pulse-page">
+        <div className="market-pulse-header">
+          <span className="eyebrow">Demo Market Pulse</span>
+          <h1>JSE market context, before the ticker deep dive.</h1>
+          <p>
+            A demo-safe market intelligence view for broad conditions, setup clusters, liquidity
+            context, and data status. This is not an official live JSE feed.
+          </p>
+        </div>
 
-      <section className="grid">
-        {sections.map((section) => (
-          <InfoCard key={section.title} title={section.title} label={section.label}>
-            <p>{section.body}</p>
-          </InfoCard>
-        ))}
-      </section>
+        <div className="market-tape pulse-tape" aria-label="Demo Market Pulse status tape">
+          {marketTape.map((item) => (
+            <div key={item.label} className={'tape-item ' + (item.tone || 'neutral')}>
+              <span>{item.label}</span>
+              <strong>{item.value}</strong>
+            </div>
+          ))}
+        </div>
 
-      <div className="button-row">
-        <Link className="button" href="/ticker/JMMBGL">
-          Review sample ticker
-        </Link>
-        <Link className="button secondary" href="/platform-preview">
-          See future market modules
-        </Link>
-      </div>
+        <div className="pulse-grid">
+          <section className="pulse-module pulse-main">
+            <div className="module-heading">
+              <h2>Market movers mockup</h2>
+              <Link href="/companies">Research companies</Link>
+            </div>
+            <div className="pulse-table">
+              <div className="pulse-table-head">
+                <span>Ticker</span>
+                <span>Window</span>
+                <span>Tier</span>
+                <span>Context</span>
+              </div>
+              {movers.map((row) => (
+                <Link className="pulse-table-row" key={row.ticker} href={'/ticker/' + encodeURIComponent(row.ticker)}>
+                  <strong>{row.ticker}</strong>
+                  <span>{row.window}</span>
+                  <span>{row.tier}</span>
+                  <span>{row.note}</span>
+                </Link>
+              ))}
+            </div>
+          </section>
+
+          <section className="pulse-module">
+            <div className="module-heading">
+              <h2>Signal clusters</h2>
+              <Link href="/tools">Open tools</Link>
+            </div>
+            <div className="cluster-list">
+              {signalClusters.map((cluster) => (
+                <div key={cluster.label}>
+                  <span>{cluster.label}</span>
+                  <strong>{cluster.value}</strong>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <div className="pulse-grid lower">
+          <section className="pulse-module">
+            <div className="module-heading">
+              <h2>Liquidity watch</h2>
+              <Link href="/learn">Learn why it matters</Link>
+            </div>
+            <ul className="market-news-list">
+              {liquidityWatch.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="pulse-module pulse-main">
+            <div className="module-heading">
+              <h2>Latest market notes</h2>
+              <Link href="/demo">Demo mode</Link>
+            </div>
+            <ul className="market-news-list">
+              {marketNotes.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          </section>
+        </div>
+
+        <div className="notice warning">
+          <p>
+            Demo Market Pulse is a product mockup using sample or internally prepared data. It is for
+            education and decision-support demonstration only, not investment advice or an official
+            real-time exchange feed.
+          </p>
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/app/market/page.tsx
+++ b/frontend/app/market/page.tsx
@@ -8,10 +8,10 @@ const marketTape = [
 ];
 
 const movers = [
-  { ticker: 'JPS9.5', name: 'JPS Preference', window: '5D', tier: 'A', note: 'Funded in demo plan' },
-  { ticker: 'WIPT', name: 'Wigton Windfarm', window: '30D', tier: 'A', note: 'Longer holding window' },
-  { ticker: 'TJH8.0', name: 'TransJamaican Highway', window: '5D', tier: 'A', note: 'Smaller allocation' },
-  { ticker: 'CAR', name: 'Carreras', window: '30D', tier: 'B', note: 'Held back by rules' },
+  { ticker: 'JPS9.5', window: '5D', tier: 'A', note: 'Funded in demo plan' },
+  { ticker: 'WIPT', window: '30D', tier: 'A', note: 'Longer holding window' },
+  { ticker: 'TJH8.0', window: '5D', tier: 'A', note: 'Smaller allocation' },
+  { ticker: 'CAR', window: '30D', tier: 'B', note: 'Held back by rules' },
 ];
 
 const liquidityWatch = [
@@ -36,17 +36,8 @@ const marketNotes = [
 export default function MarketPage() {
   return (
     <div className="page-shell market-home-shell">
-      <section className="market-pulse-page">
-        <div className="market-pulse-header">
-          <span className="eyebrow">Demo Market Pulse</span>
-          <h1>JSE market context, before the ticker deep dive.</h1>
-          <p>
-            A demo-safe market intelligence view for broad conditions, setup clusters, liquidity
-            context, and data status. This is not an official live JSE feed.
-          </p>
-        </div>
-
-        <div className="market-tape pulse-tape" aria-label="Demo Market Pulse status tape">
+      <section className="market-front">
+        <div className="market-tape" aria-label="Demo Market Pulse status tape">
           {marketTape.map((item) => (
             <div key={item.label} className={'tape-item ' + (item.tone || 'neutral')}>
               <span>{item.label}</span>
@@ -55,36 +46,27 @@ export default function MarketPage() {
           ))}
         </div>
 
-        <div className="pulse-grid">
-          <section className="pulse-module pulse-main">
-            <div className="module-heading">
-              <h2>Market movers mockup</h2>
-              <Link href="/companies">Research companies</Link>
+        <div className="market-front-grid">
+          <div className="market-lede-panel">
+            <span className="eyebrow">Demo Market Pulse</span>
+            <h2>JSE market context, before the ticker deep dive.</h2>
+            <p>
+              A demo-safe market intelligence view for broad conditions, setup clusters, liquidity
+              context, and data status. This is not an official live JSE feed.
+            </p>
+            <div className="market-lede-actions">
+              <Link href="/companies">Companies</Link>
+              <Link href="/tools">Tools</Link>
+              <Link href="/demo">Demo</Link>
             </div>
-            <div className="pulse-table">
-              <div className="pulse-table-head">
-                <span>Ticker</span>
-                <span>Window</span>
-                <span>Tier</span>
-                <span>Context</span>
-              </div>
-              {movers.map((row) => (
-                <Link className="pulse-table-row" key={row.ticker} href={'/ticker/' + encodeURIComponent(row.ticker)}>
-                  <strong>{row.ticker}</strong>
-                  <span>{row.window}</span>
-                  <span>{row.tier}</span>
-                  <span>{row.note}</span>
-                </Link>
-              ))}
-            </div>
-          </section>
+          </div>
 
-          <section className="pulse-module">
-            <div className="module-heading">
-              <h2>Signal clusters</h2>
-              <Link href="/tools">Open tools</Link>
+          <div className="quote-panel">
+            <div className="quote-panel-header">
+              <span>Pulse Board</span>
+              <strong>DEMO</strong>
             </div>
-            <div className="cluster-list">
+            <div className="quote-metrics">
               {signalClusters.map((cluster) => (
                 <div key={cluster.label}>
                   <span>{cluster.label}</span>
@@ -92,14 +74,37 @@ export default function MarketPage() {
                 </div>
               ))}
             </div>
-          </section>
+          </div>
         </div>
 
-        <div className="pulse-grid lower">
-          <section className="pulse-module">
+        <div className="market-content-grid">
+          <section className="market-module wide">
             <div className="module-heading">
-              <h2>Liquidity watch</h2>
-              <Link href="/learn">Learn why it matters</Link>
+              <h3>Market movers mockup</h3>
+              <Link href="/companies">Research companies</Link>
+            </div>
+            <div className="market-table">
+              <div className="market-table-head">
+                <span>Ticker</span>
+                <span>Tier</span>
+                <span>Window</span>
+                <span>Context</span>
+              </div>
+              {movers.map((row) => (
+                <Link className="market-table-row" key={row.ticker} href={'/ticker/' + encodeURIComponent(row.ticker)}>
+                  <strong>{row.ticker}</strong>
+                  <span>{row.tier}</span>
+                  <span>{row.window}</span>
+                  <span>{row.note}</span>
+                </Link>
+              ))}
+            </div>
+          </section>
+
+          <section className="market-module">
+            <div className="module-heading">
+              <h3>Liquidity watch</h3>
+              <Link href="/learn">Learn why</Link>
             </div>
             <ul className="market-news-list">
               {liquidityWatch.map((note) => (
@@ -107,10 +112,12 @@ export default function MarketPage() {
               ))}
             </ul>
           </section>
+        </div>
 
-          <section className="pulse-module pulse-main">
+        <div className="market-content-grid">
+          <section className="market-module wide">
             <div className="module-heading">
-              <h2>Latest market notes</h2>
+              <h3>Latest market notes</h3>
               <Link href="/demo">Demo mode</Link>
             </div>
             <ul className="market-news-list">
@@ -119,16 +126,28 @@ export default function MarketPage() {
               ))}
             </ul>
           </section>
-        </div>
 
-        <div className="notice warning">
-          <p>
-            Demo Market Pulse is a product mockup using sample or internally prepared data. It is for
-            education and decision-support demonstration only, not investment advice or an official
-            real-time exchange feed.
-          </p>
+          <section className="market-module">
+            <div className="module-heading">
+              <h3>Next step</h3>
+              <Link href="/tools">Open tools</Link>
+            </div>
+            <ul className="market-news-list">
+              <li>Use Market Pulse to get context first.</li>
+              <li>Open Companies to research a specific ticker.</li>
+              <li>Use Tools for portfolio planning and decision review.</li>
+            </ul>
+          </section>
         </div>
       </section>
+
+      <div className="notice warning">
+        <p>
+          Demo Market Pulse is a product mockup using sample or internally prepared data. It is for
+          education and decision-support demonstration only, not investment advice or an official
+          real-time exchange feed.
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Turns `/market` from a placeholder into a fuller demo-safe Market Pulse page.

## What changed

Updated:

```text
frontend/app/market/page.tsx
```

## Page direction

The Market page now includes:

- demo/internal market tape
- Market Pulse lede panel
- Pulse Board with signal clusters
- market movers mockup
- liquidity watch
- latest market notes
- next-step guidance into Companies and Tools
- demo/internal data disclaimer

## Guardrails

The page is clearly positioned as a demo/internal Market Pulse mockup. It does not claim official live JSE data, give investment advice, recommend buy/sell actions, recommend a broker, or execute trades.

## Test locally

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=https://jse-market-lab.onrender.com NEXT_PUBLIC_DEMO_MODE=true npm run dev
```

Open:

```text
http://localhost:3000/market
```

Expected:

- `/market` loads
- page uses the market-front style
- demo/internal labels are clear
- links to Companies, Tools, Demo, Learn, and sample tickers work
- mobile layout remains readable

Closes #160.