### PR TITLE
Build demo Companies research entry page

### DIFF
--- a/frontend/app/companies/page.tsx
+++ b/frontend/app/companies/page.tsx
@@ -1,51 +1,204 @@
 import Link from 'next/link';
-import { InfoCard } from '@/components/shared/InfoCard';
 
-const modules = [
+const sampleCompanies = [
   {
-    title: 'Company Pages',
-    label: 'Future anchor',
-    body: 'Company pages will combine ticker analysis, company context, dividend notes, earnings context, and tradability review.',
+    ticker: 'JMMBGL',
+    name: 'JMMB Group Limited',
+    focus: 'Financial services',
+    status: 'Working ticker analysis',
+    context: 'Use this sample to review quick take, holding windows, risk context, and what to watch.',
   },
+  {
+    ticker: 'WIPT',
+    name: 'Wigton Windfarm Limited',
+    focus: 'Energy / utilities',
+    status: 'Demo company card',
+    context: 'Useful for showing how company pages can connect market movement, signals, and research context.',
+  },
+  {
+    ticker: 'CAR',
+    name: 'Carreras Limited',
+    focus: 'Consumer / income context',
+    status: 'Demo company card',
+    context: 'Useful for future dividend and income-context workflows once source data is validated.',
+  },
+  {
+    ticker: 'TJH8.0',
+    name: 'TransJamaican Highway preference',
+    focus: 'Preference / income context',
+    status: 'Demo company card',
+    context: 'Useful for showing income, holding-window, and tradability considerations in a company view.',
+  },
+];
+
+const companyModules = [
   {
     title: 'Ticker Analysis',
     label: 'Working surface',
-    body: 'Use the current ticker page to review quick take, holding windows, risk context, and what to watch.',
+    body: 'Review quick take, historical holding-window behavior, risk context, and what to watch for a single ticker.',
   },
   {
-    title: 'Earnings and tradability',
-    label: 'Future context',
-    body: 'Future company views will add earnings scorecards and float/tradability context where data is available and rights are clear.',
+    title: 'Company Profile',
+    label: 'Future anchor',
+    body: 'A future company page will combine business context, market data, signals, dividend notes, and research links.',
   },
+  {
+    title: 'Dividend Context',
+    label: 'Future income layer',
+    body: 'Future income tools will show distribution timing, history, and risk notes without treating dividends as guaranteed.',
+  },
+  {
+    title: 'Earnings Scorecard',
+    label: 'Future research layer',
+    body: 'A future scorecard will connect earnings events to company behavior, source notes, and market reaction context.',
+  },
+  {
+    title: 'Float / Tradability',
+    label: 'Future market reality layer',
+    body: 'A future layer will help users understand liquidity, float, spread risk, and entry/exit difficulty.',
+  },
+  {
+    title: 'Research Links',
+    label: 'Compliance-gated',
+    body: 'Research hosting and redistribution must remain gated until source rights and compliance rules are validated.',
+  },
+];
+
+const researchSteps = [
+  'Start with broad Market Pulse context.',
+  'Open a company or ticker page for focused review.',
+  'Check holding windows, liquidity, costs, and risk notes.',
+  'Use Tools only after reviewing context and assumptions.',
 ];
 
 export default function CompaniesPage() {
   return (
-    <div className="page-shell">
-      <section className="hero">
-        <span className="eyebrow">Companies</span>
-        <h1>Research one company at a time.</h1>
+    <div className="page-shell market-home-shell">
+      <section className="market-front">
+        <div className="market-tape" aria-label="Demo company research status tape">
+          <div className="tape-item">
+            <span>Company mode</span>
+            <strong>Demo / internal</strong>
+          </div>
+          <div className="tape-item">
+            <span>Available view</span>
+            <strong>Ticker Analysis</strong>
+          </div>
+          <div className="tape-item">
+            <span>Future modules</span>
+            <strong>Company Pages</strong>
+          </div>
+          <div className="tape-item warn">
+            <span>Status</span>
+            <strong>Not advice</strong>
+          </div>
+        </div>
+
+        <div className="market-front-grid">
+          <div className="market-lede-panel">
+            <span className="eyebrow">Demo Company Research</span>
+            <h2>Start with a ticker, then build the company picture.</h2>
+            <p>
+              Companies will become the research anchor for ticker analysis, dividend context, earnings
+              notes, tradability, and source links. Current examples are for product walkthroughs only.
+            </p>
+            <div className="market-lede-actions">
+              <Link href="/market">Market Pulse</Link>
+              <Link href="/tools">Tools</Link>
+              <Link href="/research">Research</Link>
+            </div>
+          </div>
+
+          <div className="quote-panel">
+            <div className="quote-panel-header">
+              <span>Research Board</span>
+              <strong>DEMO</strong>
+            </div>
+            <div className="quote-metrics">
+              <div>
+                <span>Working surface</span>
+                <strong>Ticker Analysis</strong>
+              </div>
+              <div>
+                <span>Next layer</span>
+                <strong>Company Pages</strong>
+              </div>
+              <div>
+                <span>Data status</span>
+                <strong>Internal/demo</strong>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="market-content-grid">
+          <section className="market-module wide">
+            <div className="module-heading">
+              <h3>Sample company cards</h3>
+              <Link href="/market">Back to Market</Link>
+            </div>
+            <div className="company-card-grid">
+              {sampleCompanies.map((company) => (
+                <Link className="company-research-card" key={company.ticker} href={'/ticker/' + encodeURIComponent(company.ticker)}>
+                  <span>{company.status}</span>
+                  <strong>{company.ticker}</strong>
+                  <h4>{company.name}</h4>
+                  <p>{company.focus}</p>
+                  <small>{company.context}</small>
+                </Link>
+              ))}
+            </div>
+          </section>
+
+          <section className="market-module">
+            <div className="module-heading">
+              <h3>Research flow</h3>
+              <Link href="/learn">Learn</Link>
+            </div>
+            <ul className="market-news-list">
+              {researchSteps.map((step) => (
+                <li key={step}>{step}</li>
+              ))}
+            </ul>
+          </section>
+        </div>
+
+        <div className="market-content-grid">
+          <section className="market-module wide">
+            <div className="module-heading">
+              <h3>Company page modules</h3>
+              <Link href="/platform-preview">Preview roadmap</Link>
+            </div>
+            <div className="company-module-grid">
+              {companyModules.map((module) => (
+                <div className="company-module-card" key={module.title}>
+                  <span>{module.label}</span>
+                  <strong>{module.title}</strong>
+                  <p>{module.body}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="market-module">
+            <div className="module-heading">
+              <h3>Next step</h3>
+              <Link href="/tools">Open tools</Link>
+            </div>
+            <ul className="market-news-list">
+              <li>Open a ticker analysis page for a focused view.</li>
+              <li>Review market context before treating a setup as useful.</li>
+              <li>Use portfolio tools only after checking liquidity, risk, and assumptions.</li>
+            </ul>
+          </section>
+        </div>
+      </section>
+
+      <div className="notice warning">
         <p>
-          Company pages will become the main place to connect market data, dashboard signals, dividend
-          context, earnings context, and research notes for a single ticker.
+          Company research examples use sample or internally prepared data for product demonstration.
+          They are not investment advice, recommendations, official research coverage, or live JSE data.
         </p>
-      </section>
-
-      <section className="grid">
-        {modules.map((module) => (
-          <InfoCard key={module.title} title={module.title} label={module.label}>
-            <p>{module.body}</p>
-          </InfoCard>
-        ))}
-      </section>
-
-      <div className="button-row">
-        <Link className="button" href="/ticker/JMMBGL">
-          Open sample ticker
-        </Link>
-        <Link className="button secondary" href="/research">
-          View research direction
-        </Link>
       </div>
     </div>
   );

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -392,6 +392,63 @@ p {
   padding-bottom: 12px;
 }
 
+.company-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.company-research-card,
+.company-module-card {
+  background: #f8fafc;
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+}
+
+.company-research-card span,
+.company-module-card span {
+  color: #0f766e;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.company-research-card strong,
+.company-module-card strong {
+  color: #08245c;
+  font-size: 24px;
+  font-weight: 900;
+}
+
+.company-research-card h4 {
+  color: #111827;
+  font-size: 16px;
+  margin: 0;
+}
+
+.company-research-card p,
+.company-module-card p {
+  margin: 0;
+}
+
+.company-research-card small {
+  color: #64748b;
+  line-height: 1.45;
+}
+
+.company-module-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.company-module-card strong {
+  font-size: 18px;
+}
+
 .pill {
   display: inline-flex;
   width: fit-content;
@@ -478,7 +535,9 @@ p {
   .home-positioning,
   .market-tape,
   .market-front-grid,
-  .market-content-grid {
+  .market-content-grid,
+  .company-card-grid,
+  .company-module-grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary

Turns `/companies` from a simple placeholder into a demo-safe company research entry page.

## What changed

Updated:

```text
frontend/app/companies/page.tsx
frontend/app/globals.css
```

## Page direction

The Companies page now includes:

- demo/internal company research status tape
- company research lede panel
- Research Board with working/future surface status
- sample company cards linking to ticker analysis
- company page module previews
- research flow guidance
- next-step guidance into Market, Tools, Research, and Learn
- demo/internal data disclaimer

## Guardrails

The page is clearly positioned as a demo/company research mockup. It does not claim official live JSE data, provide investment advice, recommend companies, guarantee outcomes, or publish official research coverage.

## Test locally

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=https://jse-market-lab.onrender.com NEXT_PUBLIC_DEMO_MODE=true npm run dev
```

Open:

```text
http://localhost:3000/companies
```

Expected:

- `/companies` loads
- sample company cards render
- ticker links open existing ticker pages
- future modules are clearly labelled
- demo/internal language is clear
- mobile layout remains readable

Closes #162.