### PR TITLE
Update demo advisor walkthrough and platform preview

### DIFF
--- a/frontend/app/demo/page.tsx
+++ b/frontend/app/demo/page.tsx
@@ -3,24 +3,93 @@ import { InfoCard } from '@/components/shared/InfoCard';
 import { DEMO_MODE_MESSAGE } from '@/lib/demoMode';
 
 const demoSurfaces = [
+  'Market-first homepage',
+  'Demo Market Pulse',
+  'Companies research entry page',
+  'Tools decision-support hub',
   'Portfolio Plan',
   'Ticker Analysis',
   'Decision Audit',
+  'AI Helper shell',
   'Platform Preview',
-  'Company Pages concept',
-  'Market Pulse concept',
-  'Research Hub concept',
-  'Setup Tester concept',
-  'AI Helper concept',
 ];
 
 const notYetLive = [
   'Official JSE API integration',
+  'Official live JSE data feed',
   'Broker referral routing',
   'Trade execution',
   'User accounts or saved portfolios',
+  'Setup Tester / Paper Portfolio persistence',
+  'Search-enabled AI research mode',
   'Paid research or sponsored placements',
-  'Public AI helper responses',
+];
+
+const walkthroughSteps = [
+  {
+    title: '1. Start with the homepage',
+    label: 'Market first',
+    body: 'Show that users see market context immediately before choosing a path.',
+    href: '/',
+  },
+  {
+    title: '2. Open Market Pulse',
+    label: 'Market context',
+    body: 'Explain demo/internal market notes, signal clusters, and liquidity watch.',
+    href: '/market',
+  },
+  {
+    title: '3. Open Companies',
+    label: 'Research entry',
+    body: 'Show how users move from broad market context into company/ticker research.',
+    href: '/companies',
+  },
+  {
+    title: '4. Open Tools',
+    label: 'Decision support',
+    body: 'Show the working tools and future simulation tools in one decision-support hub.',
+    href: '/tools',
+  },
+  {
+    title: '5. Open Portfolio Plan',
+    label: 'Decision engine',
+    body: 'Show funded setups, unfunded setups, reserve cash, and cost assumptions.',
+    href: '/portfolio',
+  },
+  {
+    title: '6. Open Ticker Analysis',
+    label: 'Single ticker',
+    body: 'Use one ticker to explain holding windows, risk context, and what to watch.',
+    href: '/ticker/JMMBGL',
+  },
+  {
+    title: '7. Open Decision Audit',
+    label: 'Trust layer',
+    body: 'Show how the platform explains the rules behind the output.',
+    href: '/review',
+  },
+  {
+    title: '8. Use Guide Me',
+    label: 'AI Helper shell',
+    body: 'Open the floating helper to show page-aware guidance and future research mode boundaries.',
+    href: '/platform-preview',
+  },
+  {
+    title: '9. End with Platform Preview',
+    label: 'Roadmap',
+    body: 'Show future modules, compliance/data gates, and what must be validated before launch.',
+    href: '/platform-preview',
+  },
+];
+
+const validationGates = [
+  'JSE data rights / API authorization',
+  'FSC/legal review for public claims and advice boundaries',
+  'Broker referral and account-opening rules',
+  'Research hosting and source-use permissions',
+  'User profile privacy and database design',
+  'AI Helper grounding, search citations, and safety evaluation',
+  'Sponsored content and monetization disclosures',
 ];
 
 export default function DemoPage() {
@@ -28,58 +97,48 @@ export default function DemoPage() {
     <div className="page-shell">
       <section className="hero">
         <span className="eyebrow">Demo Mode</span>
-        <h1>What this demo is showing.</h1>
+        <h1>Advisor walkthrough for the current platform.</h1>
         <p>{DEMO_MODE_MESSAGE}</p>
       </section>
 
       <section className="grid">
-        <InfoCard title="What is real" label="Working product">
+        <InfoCard title="What is working" label="Current product">
           <p>
-            The Vercel frontend, Render FastAPI backend, and API-backed Portfolio, Ticker Analysis,
-            and Decision Audit pages are working product surfaces.
+            The Vercel frontend, Render FastAPI backend, market-first homepage, Market Pulse,
+            Companies, Tools, Portfolio Plan, Ticker Analysis, Decision Audit, and AI Helper shell are
+            working product surfaces.
           </p>
         </InfoCard>
-        <InfoCard title="What is sample/demo" label="Data status">
+        <InfoCard title="What is demo/internal" label="Data status">
           <p>
-            The current market data should be treated as internal sample or transformed historical data
-            for demonstration until official data rights and API access are confirmed.
+            Current market views should be treated as demo/internal or transformed historical data for
+            product demonstration until official JSE data rights and API access are confirmed.
           </p>
         </InfoCard>
         <InfoCard title="What this is not" label="Boundary">
           <p>
-            This is not financial advice, not an official JSE data feed, not broker/dealer activity, and
-            not a live trading system.
+            This is not financial advice, not an official live JSE data feed, not broker/dealer
+            activity, not a broker referral engine, and not a live trading system.
           </p>
         </InfoCard>
       </section>
 
       <section className="hero compact">
         <span className="eyebrow">Advisor demo flow</span>
-        <h2>Suggested walkthrough</h2>
+        <h2>Suggested walkthrough order</h2>
         <p>
-          Use this order when showing the product to an advisor, partner, tester, or potential user.
+          Use this order when showing the product to an advisor, partner, tester, potential user,
+          school, institution, or grant/program reviewer.
         </p>
       </section>
 
       <section className="grid">
-        <InfoCard title="1. Start Here" label="Context">
-          <p>Explain the product: market intelligence and decision support for Jamaican investors.</p>
-        </InfoCard>
-        <InfoCard title="2. Portfolio Plan" label="Decision engine">
-          <p>Show how capital, funded setups, unfunded setups, and reserve cash are structured.</p>
-        </InfoCard>
-        <InfoCard title="3. Ticker Analysis" label="Single-company view">
-          <p>Open one ticker to show holding windows, risk context, and what to review.</p>
-        </InfoCard>
-        <InfoCard title="4. Decision Audit" label="Trust layer">
-          <p>Explain why the plan looks the way it does and how the rules guide discipline.</p>
-        </InfoCard>
-        <InfoCard title="5. Platform Preview" label="Expansion">
-          <p>Show Research Hub, Company Pages, Market Pulse, Setup Tester, and AI Helper concepts.</p>
-        </InfoCard>
-        <InfoCard title="6. Compliance path" label="Before launch">
-          <p>Explain that JSE/FSC/legal validation is needed before official data, referrals, or monetization.</p>
-        </InfoCard>
+        {walkthroughSteps.map((step) => (
+          <InfoCard key={step.title} title={step.title} label={step.label}>
+            <p>{step.body}</p>
+            <Link href={step.href}>Open</Link>
+          </InfoCard>
+        ))}
       </section>
 
       <section className="grid two">
@@ -99,19 +158,37 @@ export default function DemoPage() {
         </InfoCard>
       </section>
 
+      <section className="grid two">
+        <InfoCard title="Validation gates" label="Before broader launch">
+          <div className="list-stack">
+            {validationGates.map((gate) => (
+              <p key={gate}>{gate}</p>
+            ))}
+          </div>
+        </InfoCard>
+        <InfoCard title="How to describe the demo" label="Safe language">
+          <p>
+            This is a demo-safe market intelligence and decision-support platform for Jamaican,
+            Caribbean, and diaspora investors. It shows product workflow, education, research entry,
+            and planning support without giving personal investment advice or executing trades.
+          </p>
+        </InfoCard>
+      </section>
+
       <div className="notice warning">
         <p>
-          Before public launch, JSE Market Lab still needs validation around data rights, research
-          hosting, broker access flows, sponsored content, paid products, and AI-assisted explanations.
+          Before public launch or monetization, JSE Market Lab still needs validation around data
+          rights, research hosting, broker access flows, sponsored content, paid products, and
+          AI-assisted explanations.
         </p>
       </div>
 
       <div className="button-row">
-        <Link className="button" href="/portfolio">
-          View Portfolio Plan
+        <Link className="button" href="/market">
+          Start Demo Flow
         </Link>
-        <Link className="button secondary" href="/ticker/JMMBGL">
-          Open Ticker Analysis
+        <Link className="button secondary" href="/tools">
+          Open Tools Hub
         </Link>
         <Link className="button secondary" href="/platform-preview">
           Open Platform Preview

--- a/frontend/app/platform-preview/page.tsx
+++ b/frontend/app/platform-preview/page.tsx
@@ -2,35 +2,63 @@ import Link from 'next/link';
 import { InfoCard } from '@/components/shared/InfoCard';
 import { DEMO_MODE_MESSAGE } from '@/lib/demoMode';
 
-const futureModules = [
+const builtSurfaces = [
   {
-    title: 'Research Hub',
-    label: 'Future surface',
-    body: 'A structured place to discover company research, market notes, source links, and saved reports once rights and hosting rules are validated.',
-  },
-  {
-    title: 'Company Pages',
-    label: 'Future surface',
-    body: 'Ticker-centered pages that combine company context, dashboard signals, dividend profile, earnings context, and tradability notes.',
+    title: 'Market-first homepage',
+    label: 'Working surface',
+    body: 'The homepage now opens with market context before routing users into learning, research, tools, income, and demo paths.',
+    href: '/',
   },
   {
     title: 'Market Pulse',
-    label: 'Future surface',
-    body: 'A weekly market overview showing broad observations, unusual movement, liquidity warnings, and data-quality notes.',
+    label: 'Working demo surface',
+    body: 'A demo-safe market-intelligence page with market tape, movers mockup, signal clusters, liquidity watch, and market notes.',
+    href: '/market',
+  },
+  {
+    title: 'Companies',
+    label: 'Working demo surface',
+    body: 'A company research entry point with sample company cards, ticker-analysis links, and future company-page module previews.',
+    href: '/companies',
+  },
+  {
+    title: 'Tools',
+    label: 'Working surface',
+    body: 'A decision-support hub that links Portfolio Plan, Ticker Analysis, Decision Audit, and future simulation concepts.',
+    href: '/tools',
+  },
+  {
+    title: 'AI Helper shell',
+    label: 'Working shell',
+    body: 'A persistent Guide Me panel with page-aware guidance. It is rule-based for now and does not make live AI or web-search calls yet.',
+    href: '/demo',
+  },
+];
+
+const futureModules = [
+  {
+    title: 'Research Hub',
+    label: 'Future / compliance-gated',
+    body: 'A structured place to discover company research, market notes, source links, and saved reports once rights and hosting rules are validated.',
+  },
+  {
+    title: 'Full Company Pages',
+    label: 'Future expansion',
+    body: 'Ticker-centered pages that combine company context, dashboard signals, dividend profile, earnings context, and tradability notes.',
   },
   {
     title: 'Dividend View',
-    label: 'Future surface',
+    label: 'Future income layer',
     body: 'A focused view for income-oriented investors to track dividend notices, yield context, payment timing, and company patterns.',
   },
   {
     title: 'Earnings Scorecard',
-    label: 'Future surface',
+    label: 'Future research layer',
     body: 'A research layer to help users review earnings events, company performance context, and post-result market behavior.',
   },
   {
     title: 'Float / Tradability View',
-    label: 'Future surface',
+    label: 'Future market reality layer',
     body: 'A market-reality layer to help users understand whether a stock may be difficult to enter or exit because of float, volume, or liquidity.',
   },
   {
@@ -44,9 +72,14 @@ const futureModules = [
     body: 'A practice portfolio for tracking simulated positions, planned review dates, outcome review, and lessons learned.',
   },
   {
-    title: 'AI Helper',
-    label: 'Future assistant',
-    body: 'A grounded guide to help users navigate the platform, understand outputs, and review next steps without recommending trades.',
+    title: 'AI Research Mode',
+    label: 'Future assistant layer',
+    body: 'A search-enabled AI Helper mode for public-source research with citations, source dates, and clear advice boundaries.',
+  },
+  {
+    title: 'Brokerage Access Education',
+    label: 'Future / compliance-gated',
+    body: 'A neutral education flow explaining account-opening considerations, broker-fee checks, and investor responsibilities after validation.',
   },
 ];
 
@@ -55,8 +88,9 @@ const gates = [
   'Research hosting and source-use rules',
   'Broker referral and account-opening boundaries',
   'User profile privacy and database design',
-  'AI helper grounding and evaluation tests',
+  'AI Helper grounding, web-search citations, and evaluation tests',
   'Sponsored content and monetization disclosures',
+  'Public brand name and JSE attribution approach',
 ];
 
 export default function PlatformPreviewPage() {
@@ -64,16 +98,36 @@ export default function PlatformPreviewPage() {
     <div className="page-shell">
       <section className="hero">
         <span className="eyebrow">Platform Preview</span>
-        <h1>Where JSE Market Lab is going next.</h1>
+        <h1>What is built now, and what comes next.</h1>
         <p>
-          This page shows future platform modules as mockups and product direction. These surfaces are
-          not fully launched features yet.
+          This page separates working demo-safe surfaces from future platform modules. It should help
+          advisors, partners, testers, and reviewers understand the current product without confusing
+          demo/internal data for official live JSE data.
         </p>
       </section>
 
       <div className="notice warning">
         <p>{DEMO_MODE_MESSAGE}</p>
       </div>
+
+      <section className="hero compact">
+        <span className="eyebrow">Built now</span>
+        <h2>Current demo-safe platform surfaces</h2>
+      </section>
+
+      <section className="grid">
+        {builtSurfaces.map((surface) => (
+          <InfoCard key={surface.title} title={surface.title} label={surface.label}>
+            <p>{surface.body}</p>
+            <Link href={surface.href}>Open</Link>
+          </InfoCard>
+        ))}
+      </section>
+
+      <section className="hero compact">
+        <span className="eyebrow">Future modules</span>
+        <h2>Product direction after validation and data foundations</h2>
+      </section>
 
       <section className="grid">
         {futureModules.map((module) => (
@@ -87,7 +141,8 @@ export default function PlatformPreviewPage() {
         <span className="eyebrow">Before these go live</span>
         <h2>Compliance and data gates</h2>
         <p>
-          These items need validation before the preview surfaces become public product features.
+          These items need validation before future surfaces become public product features or revenue
+          channels.
         </p>
       </section>
 
@@ -101,19 +156,23 @@ export default function PlatformPreviewPage() {
         </InfoCard>
         <InfoCard title="What can be shown now" label="Demo-safe">
           <p>
-            The current demo can show the platform vision, decision-support workflow, API-backed core
-            dashboard pages, and future module concepts. It should not imply official live JSE data,
-            broker approval, or investment advice.
+            The current demo can show the market-first product experience, decision-support workflow,
+            company research entry point, Tools hub, API-backed core dashboard pages, and AI Helper
+            shell. It should not imply official live JSE data, broker approval, personal investment
+            advice, or production research coverage.
           </p>
         </InfoCard>
       </section>
 
       <div className="button-row">
         <Link className="button" href="/demo">
-          View Demo Mode Guide
+          View Demo Walkthrough
         </Link>
-        <Link className="button secondary" href="/portfolio">
-          Back to Portfolio Plan
+        <Link className="button secondary" href="/market">
+          Start at Market Pulse
+        </Link>
+        <Link className="button secondary" href="/tools">
+          Open Tools Hub
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Updates the existing `/demo` and `/platform-preview` pages for the current platform state instead of creating new demo docs/pages.

## What changed

Updated:

```text
frontend/app/demo/page.tsx
frontend/app/platform-preview/page.tsx
```

## Demo page updates

The `/demo` page now reflects the current walkthrough flow:

```text
Homepage
→ Market Pulse
→ Companies
→ Tools
→ Portfolio Plan
→ Ticker Analysis
→ Decision Audit
→ Guide Me / AI Helper shell
→ Platform Preview
```

It also updates:

- demo surfaces list
- not-yet-live/gated items
- validation gates
- safe language for advisors/partners/testers
- CTAs into Market, Tools, and Platform Preview

## Platform Preview updates

The `/platform-preview` page now separates:

```text
Built now / working demo-safe surfaces
Future modules / compliance-gated surfaces
Validation gates
```

This avoids describing already-built surfaces like Market Pulse, Companies, Tools, and AI Helper shell as purely future work.

## Guardrails

The pages continue to make clear that the product is:

- demo/internal data only where applicable
- not an official live JSE data feed
- not investment advice
- not broker/dealer activity
- not trade execution
- not broker referral routing

## Test locally

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=https://jse-market-lab.onrender.com NEXT_PUBLIC_DEMO_MODE=true npm run dev
```

Open:

```text
http://localhost:3000/demo
http://localhost:3000/platform-preview
```

Expected:

- both pages load
- demo walkthrough reflects current platform flow
- Platform Preview separates built-now vs future modules
- links to homepage, Market, Companies, Tools, Portfolio, Ticker, Review, and Platform Preview work
- demo/internal and compliance-gated language remains clear

Related to #149.